### PR TITLE
Adding POP and IMAP values for x-ms-client-application

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/AD-FS-Claims-Types.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/AD-FS-Claims-Types.md
@@ -60,6 +60,8 @@ This AD FS claim represents the protocol used by the end client, which correspon
 	- Microsoft.Exchange.Powershell
 	- Microsoft.Exchange.SMTP
 	- Microsoft.Exchange.PopImap
+	- Microsoft.Exchange.Pop
+	- Microsoft.Exchange.Imap
 
 ## X-MS-Client-User-Agent
 


### PR DESCRIPTION
Per https://support.microsoft.com/en-us/help/3107357/pop-imap-client-authenticate-fails-if-x-ms-client-application-in-the-ad-fs-claim-rule-is-set-to-microsoft.exchange.popimap