### PR TITLE
Modified guest OS support statement

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/Supported-Windows-guest-operating-systems-for-Hyper-V-on-Windows.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-Windows-guest-operating-systems-for-Hyper-V-on-Windows.md
@@ -30,8 +30,6 @@ Following are the versions of Windows Server that are supported as guest operati
 |Windows Server 2012 R2 |64|Built-in||  
 |Windows Server 2012 |64|Built-in||  
 |Windows Server 2008 R2 with Service Pack 1 (SP 1)|64|Install all critical Windows updates after you set up the guest operating system.|Datacenter, Enterprise, Standard and Web editions.|  
-|Windows Server 2008 with Service Pack 2 (SP 2)|8|Install all critical Windows updates after you set up the operating system in the virtual machine.|Datacenter, Enterprise, Standard and Web editions (32-bit and 64-bit).|  
-|Windows Small Business Server 2011|Essentials edition 2<br /><br />Standard edition 4|Install all critical Windows updates after you set up the operating system in the virtual machine.|Essentials and Standard editions.|   
   
 ## Supported Windows client guest operating systems  
 
@@ -42,7 +40,6 @@ Following are the versions of Windows that are supported as guest operating syst
 |Windows 10|32|Built-in||  
 |Windows 8.1|32|Built-in||  
 |Windows 7 with Service Pack 1 (SP 1)|4|Upgrade the integration services after you set up the guest operating system.|Ultimate, Enterprise, and Professional editions (32-bit and 64-bit).|  
-|Windows Vista with Service Pack 2 (SP2)|2|Install the integration services after you set up the guest operating system.|Business, Enterprise, and Ultimate, including N and KN editions.|  
   
 ## Guest operating system support on other versions of Windows  
 


### PR DESCRIPTION
Hyper-V's guest support statement is the same as Microsoft's when server 16 shipped.  I believe Vista wasn't supported and Server 2008/Windows 7 had just stopped being supported but it may take some forensics.

https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet

https://support.microsoft.com/en-us/lifecycle/search for server OSes