### PR TITLE
Fix GPOs & OUs in privileged-access-workstations.md

### DIFF
--- a/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
+++ b/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
@@ -485,7 +485,7 @@ Phase 1 includes the following steps:
             |-----|---------|
             |PAW Configuration|Admin\Tier 0\Devices|
 
-6.  **Create "PAW Configuration - User" group policy object (GPO) and link to the Tier 0 Users OU ("Users" under Tier 0\Admin)**.  In this section, you will create a new "PAW Configuration - User" GPO which provide specific protections for these PAWs.
+6.  **Create "PAW Configuration - User" group policy object (GPO) and link to the Tier 0 Accounts OU ("Accounts" under Tier 0\Admin)**.  In this section, you will create a new "PAW Configuration - User" GPO which provide specific protections for these PAWs.
 
     > [!NOTE]
     > Do not add these settings to the Default Domain Policy
@@ -531,7 +531,7 @@ Phase 1 includes the following steps:
 
         2.  Go to User Configuration\Preferences\Windows Settings\Registry, click New **Registry Item** and configure the following settings:
 
-            -   Action:  Create
+            -   Action:  Replace
 
             -   Hive: HKEY_CURRENT_USER
 
@@ -566,7 +566,7 @@ Phase 1 includes the following steps:
 
         3.  Click **OK** to complete the ProxyServer group policy setting,
 
-    2.  Go to Configuration\Administrative Templates\Windows Components\Internet Explorer\ and enable the options below. These settings will prevent the administrators from manually overriding the proxy settings.
+    2.  Go to User Configuration\Administrative Templates\Windows Components\Internet Explorer\ and enable the options below. These settings will prevent the administrators from manually overriding the proxy settings.
 
         1.  Enable the **Disable changing Automatic Configuration** settings.
 


### PR DESCRIPTION
6. "PAW Configuration - User"
- Corrected references of "Tier 0 Users OU" to "**Tier 0 Accounts OU**" to match OU structure created by TechNet Gallery script.

6. a. (ii)
- Changed Action: Create to **Action: Replace** (Create is changed to Replace during step when selecting Remove this item when it is no longer applied.)

6. b.
- Corrected GPO path to include "User" at beginning: "**User** Configuration\Administrative Templates\Windows Components\Internet Explorer\..."