### PR TITLE
Storage Spaces UI shows NVDIMM-N bus type as unknown

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/Storage-class-memory-health.md
+++ b/WindowsServerDocs/storage/storage-spaces/Storage-class-memory-health.md
@@ -25,7 +25,7 @@ All conditions listed here are expected to be very rare occurrences, but depend 
 
 The various cases below may refer to Storage Spaces configurations. The particular configuration of interest is one where two NVDIMM-N devices are utilized as a mirrored write-back cache in a storage space. To set up such a configuration, see [Configuring Storage Spaces with a NVDIMM-N write-back cache](http://msdn.microsoft.com/library/mt650885.aspx).
 
-In Windows Server 2016, the Storage Spaces GUI shows NVDIMM-N bus type as UNKNOWN. It doesn't have any fuctionality loss or inability to  in creation of Pool, Storage VD. You can verify the bus type by running the following command:
+In Windows Server 2016, the Storage Spaces GUI shows NVDIMM-N bus type as UNKNOWN. It doesn't have any fuctionality loss or inability in creation of Pool, Storage VD. You can verify the bus type by running the following command:
 
 ```powershell
 PS C:\>Get-PhysicalDisk | fl

--- a/WindowsServerDocs/storage/storage-spaces/Storage-class-memory-health.md
+++ b/WindowsServerDocs/storage/storage-spaces/Storage-class-memory-health.md
@@ -25,6 +25,13 @@ All conditions listed here are expected to be very rare occurrences, but depend 
 
 The various cases below may refer to Storage Spaces configurations. The particular configuration of interest is one where two NVDIMM-N devices are utilized as a mirrored write-back cache in a storage space. To set up such a configuration, see [Configuring Storage Spaces with a NVDIMM-N write-back cache](http://msdn.microsoft.com/library/mt650885.aspx).
 
+In Windows Server 2016, the Storage Spaces GUI shows NVDIMM-N bus type as UNKNOWN. It doesn't have any fuctionality loss or inability to  in creation of Pool, Storage VD. You can verify the bus type by running the following command:
+
+```powershell
+PS C:\>Get-PhysicalDisk | fl
+```
+The parameter BusType in output of cmdlet will correctly show bus type as "SCM"
+
 ## Checking the health of storage-class memory
 To query the health of storage-class memory, use the following commands in a Windows PowerShell session.
 


### PR DESCRIPTION
1. The "unknown" classification in UI causes confusion that NVDIMM-N storage may be a problem and hence using the content guidance, customers will be able to validate the bus type before calling Microsoft or OEMs.
2. This was reported by DellEMC during their testing of NVDIMM hardware with Windows Server 2016 storage spaces.