### PR TITLE
Update Deploy-Nano-Server.md

### DIFF
--- a/WindowsServerDocs/get-started/Deploy-Nano-Server.md
+++ b/WindowsServerDocs/get-started/Deploy-Nano-Server.md
@@ -190,7 +190,7 @@ Exit**
    
 Apply the Nano Server image (adjust the path of the .wim file):  
   
-**Dism.exe /apply-imagmediafile:.\NanoServer.wim /index:1 /applydir:n:\   
+**Dism.exe /apply-image /imagefile:.\NanoServer.wim /index:1 /applydir:n:\   
 Bcdboot.exe n:\Windows /s s:**  
    
 Remove the DVD media or USB drive and reboot your system with **Wpeutil.exe reboot**  


### PR DESCRIPTION
In the "Installing a Nano Server WIM" section, the page displays:

Apply the Nano Server image (adjust the path of the .wim file):  
  Dism.exe /apply-imagmediafile:.\NanoServer.wim /index:1 /applydir:n:\
   
which is wrong, and does not work. The correct dism command is:

Dism.exe /apply-image /imagefile:.\NanoServer.wim /index:1 /applydir:n:\