### PR TITLE
replace "one" with "a" for clarity

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/Storage-Spaces-Fault-Tolerance.md
+++ b/WindowsServerDocs/storage/storage-spaces/Storage-Spaces-Fault-Tolerance.md
@@ -82,7 +82,7 @@ We recommend this in-depth yet eminently readable walkthrough of [how local reco
 
 ## Mirror-accelerated parity
 
-Beginning in Windows Server 2016, one Storage Spaces Direct volume can be part mirror and part parity. Writes land first in the mirrored portion and are gradually moved into the parity portion later. Effectively, this is [using mirroring to accelerate erasure coding](https://blogs.technet.microsoft.com/filecab/2016/09/06/volume-resiliency-and-efficiency-in-storage-spaces-direct/).
+Beginning in Windows Server 2016, a Storage Spaces Direct volume can be part mirror and part parity. Writes land first in the mirrored portion and are gradually moved into the parity portion later. Effectively, this is [using mirroring to accelerate erasure coding](https://blogs.technet.microsoft.com/filecab/2016/09/06/volume-resiliency-and-efficiency-in-storage-spaces-direct/).
 
 To mix three-way mirror and dual parity, you need at least four fault domains, meaning four servers.
 


### PR DESCRIPTION
replace "one" with "a" for clarity