### PR TITLE
Use actual wording shown in UI

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/deploy/Demoting-Domain-Controllers-and-Domains--Level-200-.md
+++ b/WindowsServerDocs/identity/ad-ds/deploy/Demoting-Domain-Controllers-and-Domains--Level-200-.md
@@ -103,7 +103,7 @@ Uninstall-windowsfeature
   
 You configure demotion options on the **Credentials** page. Provide the credentials necessary to perform the demotion from the following list:  
   
--   Demoting an additional domain controller requires Domain Admin credentials. Selecting **Force removal of the domain controller** demotes the domain controller without removing the domain controller object's metadata from Active Directory.  
+-   Demoting an additional domain controller requires Domain Admin credentials. Selecting **Force the removal of this domain controller** demotes the domain controller without removing the domain controller object's metadata from Active Directory.  
   
     > [!WARNING]  
     > Do not select this option unless the domain controller cannot contact other domain controllers and there is *no reasonable way* to resolve that network issue. Forced demotion leaves orphaned metadata in Active Directory on the remaining domain controllers in the forest. In addition, all un-replicated changes on that domain controller, such as passwords or new user accounts, are lost forever. Orphaned metadata is the root cause in a significant percentage of Microsoft Customer Support cases for AD DS, Exchange, SQL, and other software.  


### PR DESCRIPTION
The correct wording is used in other parts of the document but not here.