### PR TITLE
Dynamic routes for subnets on Internal network

### DIFF
--- a/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-client-vpn-connections.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-client-vpn-connections.md
@@ -244,6 +244,8 @@ is also used as the primary connection specific DNS suffix for the VPN Interface
 
 **$TrustedNetwork**. Comma separated string to identify the trusted network. VPN will not connect automatically when the user is on their corporate wireless network where protected resources are directly accessible to the device.
 
+**$IpRanges**. List of comma separated IP address ranges (in CIDR notation) on the Internal network. If the DNS Server IP addresses above are not in the DMZ, their subnet(s) need routes to be dynamically created when the VPN is connected.
+
 Following are example values for parameters used in the commands below. Ensure that you change these values for your environment.
 
     $TemplateName = 'Template'
@@ -253,6 +255,7 @@ Following are example values for parameters used in the commands below. Ensure t
     $DomainName = '.corp.contoso.com'
     $DNSServers = '10.10.0.2,10.10.0.3'
     $TrustedNetwork = 'corp.contoso.com'
+    $IpRanges = '10.10.0.0/16'
 
 ### Prepare and create the profile XML
 
@@ -397,6 +400,10 @@ You can use this script on the Windows 10 desktop or in System Center Configurat
     	$newInstance.CimInstanceProperties.Add($property)
     	$session.CreateInstance($namespaceName, $newInstance, $options)
     	$Message = "Created $ProfileName profile."
+	$IpRanges.Split(",") | % 
+	{
+		Add-VpnConnectionRoute -ConnectionName $ProfileNameEscaped -DestinationPrefix $_
+	}
     	Write-Host "$Message"
     }
     catch [Exception]
@@ -434,6 +441,7 @@ The following example script includes all of the code examples from previous sec
     $DomainName = '.corp.contoso.com'
     $DNSServers = '10.10.0.2,10.10.0.3'
     $TrustedNetwork = 'corp.contoso.com'
+    $IpRanges = '10.10.0.0/16'
     
     $Connection = Get-VpnConnection -Name $TemplateName
     if(!$Connection)
@@ -540,6 +548,10 @@ The following example script includes all of the code examples from previous sec
     	$newInstance.CimInstanceProperties.Add($property)
     	$session.CreateInstance($namespaceName, $newInstance, $options)
     	$Message = "Created $ProfileName profile."
+	$IpRanges.Split(",") | % 
+	{
+		Add-VpnConnectionRoute -ConnectionName $ProfileNameEscaped -DestinationPrefix $_
+	}
     	Write-Host "$Message"
     }
     catch [Exception]
@@ -564,7 +576,7 @@ To configure the VPNv2 CSP on a Windows 10 client computer, run the VPN_Profile.
 
 After running VPN_Profile.ps1 to configure the VPN profile, you can verify at any time that it was successful by running the following command in the Windows PowerShell ISE:
 
-    Get-WmiObject -Namespace root\\cimv2\\mdm\\dmmap -Class MDM_VPNv2_01
+    Get-WmiObject -Namespace root\cimv2\mdm\dmmap -Class MDM_VPNv2_01
 
 Successful results look similar to Listing 2.
 


### PR DESCRIPTION
Added $IpRanges variable to automatically add MDM_VPNv2_RouteList02_01 objects via Add-VpnConnectionRoute (this allows routing to resources on the Internal network, not just stuff in the DMZ). I'm not sure how to implement this in InTune though...

Fixed double-escaping typo in Get-WmiObject -Namespace root\cimv2\mdm\dmmap -Class MDM_VPNv2_01.

I've also got code to automate the "### Configure the VPN client by using Windows PowerShell" section by creating a personalised Scheduled Task that runs VPN_Profile.ps1 with admin privileges. I thought it might be beyond the scope of what you're aiming at here though?

These guides are **beautiful** :)

This is my first edit, so apologies if I've not got the protocol correct.