### PR TITLE
Fix bash scripts for Supported-FreeBSD-virtual-machines-on-Hyper-V.md

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
@@ -10,7 +10,7 @@ ms.topic: article
 ms.assetid: 930e758f-bd50-46b4-a3a4-9857110f17b4
 author: shirgall
 ms.author: kathydav
-ms.date: 01/09/2017
+ms.date: 08/14/2017
 ---
 # Supported FreeBSD virtual machines on Hyper-V
 
@@ -26,44 +26,44 @@ The following feature distribution map indicates the features in each version. T
 
 * (*blank*) - Feature not available
 
-|**Feature**|**Windows Server operating system version**|**11**|**10.3**|**10.2**|**10 - 10.1**|**9.1 - 9.3**|**8.4**|
+|**Feature**|**Windows Server operating system version**|**11.1**|**11**|**10.3**|**10.2**|**10 - 10.1**|**9.1 - 9.3**|**8.4**|
 |-|-|-|-|-|-|-|-|
-|**Availability**||Built in|Built in|Built in|Built in|[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |
-|**[Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_core)**|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004; |&#10004; |
-|Windows Server 2016 Accurate Time|2016|||||||
+|**Availability**||Built in|Built in|Built in|Built in|Built in|[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |
+|**[Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_core)**|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004; |&#10004; |
+|Windows Server 2016 Accurate Time|2016||||||||
 |**[Networking](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Networking)**||||||||
-|Jumbo frames|2016, 2012 R2, 2012, 2008 R2|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|
-|VLAN tagging and trunking|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
-|Live migration|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
-|Static IP Injection|2016, 2012 R2, 2012|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004;|&#10004;|
-|vRSS|2016, 2012 R2|&#10004;|||||||
-|TCP Segmentation and Checksum Offloads|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;||||
-|Large Receive Offload (LRO)|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|||||
-|SR-IOV|2016|||||||
+|Jumbo frames|2016, 2012 R2, 2012, 2008 R2|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|
+|VLAN tagging and trunking|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
+|Live migration|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
+|Static IP Injection|2016, 2012 R2, 2012|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004;|&#10004;|
+|vRSS|2016, 2012 R2|&#10004;|&#10004;||||||||
+|TCP Segmentation and Checksum Offloads|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;||||
+|Large Receive Offload (LRO)|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|||||
+|SR-IOV|2016||||||||
 |**[Storage](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Storage)**|Note 1|Note 1|Note 1|Note 1|Note 1,2|Note 1,2|Note 1,2|
-|VHDX resize|2016, 2012 R2|&#10004; Note 7||||||
-|Virtual Fibre Channel|2016, 2012 R2|||||||
-|Live virtual machine backup|2016, 2012 R2|||||||
-|TRIM support|2016, 2012 R2|||||||
-|SCSI WWN|2016, 2012 R2|||||||
-|**[Memory](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Memory)**||||||||
-|PAE Kernel Support|2016, 2012 R2, 2012, 2008 R2|||||||
-|Configuration of MMIO gap|2016, 2012 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
-|Dynamic Memory - Hot-Add|2016, 2012 R2, 2012|||||||
-|Dynamic Memory - Ballooning|2016, 2012 R2, 2012|||||||
-|Runtime Memory Resize|2016|||||||
-|**[Video](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Video)**||||||||
-|Hyper-V specific video device|2016, 2012 R2, 2012, 2008 R2|||||||
-|**[Miscellaneous](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Misc)**||||||||
-|Key/value pair|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004; Note 6|&#10004; Note 5, 6|&#10004; Note 6|&#10004; Note 6|
-|Non-Maskable Interrupt|2016, 2012 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
-|File copy from host to guest|2016, 2012 R2|||||||
-|lsvmbus command|2016, 2012 R2, 2012, 2008 R2|||||||
-|Hyper-V Sockets|2016|||||||
-|PCI Passthrough/DDA|2016|||||||
+|VHDX resize|2016, 2012 R2|&#10004; Note 7|&#10004; Note 7||||||
+|Virtual Fibre Channel|2016, 2012 R2||||||||
+|Live virtual machine backup|2016, 2012 R2|&#10004;|||||||
+|TRIM support|2016, 2012 R2|&#10004;|||||||
+|SCSI WWN|2016, 2012 R2||||||||
+|**[Memory](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Memory)**|||||||||
+|PAE Kernel Support|2016, 2012 R2, 2012, 2008 R2||||||||
+|Configuration of MMIO gap|2016, 2012 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
+|Dynamic Memory - Hot-Add|2016, 2012 R2, 2012||||||||
+|Dynamic Memory - Ballooning|2016, 2012 R2, 2012||||||||
+|Runtime Memory Resize|2016||||||||
+|**[Video](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Video)**|||||||||
+|Hyper-V specific video device|2016, 2012 R2, 2012, 2008 R2||||||||
+|**[Miscellaneous](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Misc)**|||||||||
+|Key/value pair|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004; Note 6|&#10004; Note 5, 6|&#10004; Note 6|&#10004; Note 6|
+|Non-Maskable Interrupt|2016, 2012 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
+|File copy from host to guest|2016, 2012 R2||||||||
+|lsvmbus command|2016, 2012 R2, 2012, 2008 R2||||||||
+|Hyper-V Sockets|2016||||||||
+|PCI Passthrough/DDA|2016|&#10004;|||||||
 |**[Generation 2 virtual machines](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_gen2)**||||||||
-|Boot using UEFI|2016, 2012 R2|||||||
-|Secure boot|2016||||||||
+|Boot using UEFI|2016, 2012 R2||||||||
+|Secure boot|2016|||||||||
 
 ## <a name="BKMK_notes"></a>Notes
 

--- a/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
@@ -36,7 +36,7 @@ The following feature distribution map indicates the features in each version. T
 |VLAN tagging and trunking|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
 |Live migration|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
 |Static IP Injection|2016, 2012 R2, 2012|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004;|
-|vRSS|2016, 2012 R2|&#10004;|&#10004;|||||||
+|vRSS|2016, 2012 R2|&#10004;|&#10004;|||||
 |TCP Segmentation and Checksum Offloads|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|||
 |Large Receive Offload (LRO)|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;||||
 |SR-IOV|2016|||||||
@@ -63,7 +63,7 @@ The following feature distribution map indicates the features in each version. T
 |PCI Passthrough/DDA|2016|&#10004;||||||
 |**[Generation 2 virtual machines](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_gen2)**||||||||
 |Boot using UEFI|2016, 2012 R2|||||||
-|Secure boot|2016||||||||
+|Secure boot|2016|||||||
 
 ## <a name="BKMK_notes"></a>Notes
 
@@ -88,7 +88,7 @@ The following feature distribution map indicates the features in each version. T
     # set hw.ata.disk_enable=1
     # boot
     ```
-Additional Notes: The feature matrix of 10 stable and 11 stable is same with FreeBSD 11.1 release. In addition, FreeBSD 10.2 and previous versions (10.1, 10, 9.x, 8.x) are end of life. 
+**Additional Notes**: The feature matrix of 10 stable and 11 stable is same with FreeBSD 11.1 release. In addition, FreeBSD 10.2 and previous versions (10.1, 10, 9.x, 8.x) are end of life. Please refer [here](https://security.freebsd.org/) for an up-to-date list of supported releases and the latest security advisories.
 
 See Also
 

--- a/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
@@ -30,7 +30,7 @@ The following feature distribution map indicates the features in each version. T
 |-|-|-|-|-|-|-|-|
 |**Availability**||Built in|Built in|Built in|Built in|Built in|[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |
 |**[Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_core)**|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004; |
-|Windows Server 2016 Accurate Time|2016|||||||
+|Windows Server 2016 Accurate Time|2016|&#10004;||||||
 |**[Networking](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Networking)**||||||||
 |Jumbo frames|2016, 2012 R2, 2012, 2008 R2|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|
 |VLAN tagging and trunking|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
@@ -62,7 +62,7 @@ The following feature distribution map indicates the features in each version. T
 |Hyper-V Sockets|2016|||||||
 |PCI Passthrough/DDA|2016|&#10004;||||||
 |**[Generation 2 virtual machines](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_gen2)**||||||||
-|Boot using UEFI|2016, 2012 R2|||||||
+|Boot using UEFI|2016, 2012 R2|&#10004;||||||
 |Secure boot|2016|||||||
 
 ## <a name="BKMK_notes"></a>Notes
@@ -90,7 +90,7 @@ The following feature distribution map indicates the features in each version. T
     ```
 **Additional Notes**: The feature matrix of 10 stable and 11 stable is same with FreeBSD 11.1 release. In addition, FreeBSD 10.2 and previous versions (10.1, 10, 9.x, 8.x) are end of life. Please refer [here](https://security.freebsd.org/) for an up-to-date list of supported releases and the latest security advisories.
 
-See Also
+## See Also
 
 * [Feature Descriptions for Linux and FreeBSD virtual machines on Hyper-V](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md)
 * [Best practices for running FreeBSD on Hyper-V](Best-practices-for-running-FreeBSD-on-Hyper-V.md)

--- a/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
@@ -31,7 +31,7 @@ The following feature distribution map indicates the features in each version. T
 |**Availability**||Built in|Built in|Built in|Built in|Built in|[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |
 |**[Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_core)**|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004; |&#10004; |
 |Windows Server 2016 Accurate Time|2016||||||||
-|**[Networking](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Networking)**||||||||
+|**[Networking](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Networking)**|||||||||
 |Jumbo frames|2016, 2012 R2, 2012, 2008 R2|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|
 |VLAN tagging and trunking|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
 |Live migration|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
@@ -40,7 +40,7 @@ The following feature distribution map indicates the features in each version. T
 |TCP Segmentation and Checksum Offloads|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;||||
 |Large Receive Offload (LRO)|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|||||
 |SR-IOV|2016||||||||
-|**[Storage](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Storage)**|Note 1|Note 1|Note 1|Note 1|Note 1,2|Note 1,2|Note 1,2|
+|**[Storage](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Storage)**||Note 1|Note 1|Note 1|Note 1|Note 1,2|Note 1,2|Note 1,2|
 |VHDX resize|2016, 2012 R2|&#10004; Note 7|&#10004; Note 7||||||
 |Virtual Fibre Channel|2016, 2012 R2||||||||
 |Live virtual machine backup|2016, 2012 R2|&#10004;|||||||
@@ -61,7 +61,7 @@ The following feature distribution map indicates the features in each version. T
 |lsvmbus command|2016, 2012 R2, 2012, 2008 R2||||||||
 |Hyper-V Sockets|2016||||||||
 |PCI Passthrough/DDA|2016|&#10004;|||||||
-|**[Generation 2 virtual machines](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_gen2)**||||||||
+|**[Generation 2 virtual machines](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_gen2)**|||||||||
 |Boot using UEFI|2016, 2012 R2||||||||
 |Secure boot|2016|||||||||
 

--- a/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
@@ -26,9 +26,9 @@ The following feature distribution map indicates the features in each version. T
 
 * (*blank*) - Feature not available
 
-|**Feature**|**Windows Server operating system version**|**11.1**|**11**|**10.3**|**10.2**|**10 - 10.1**|**9.1 - 9.3, 8.4**|
+|**Feature**|**Windows Server operating system version**|**11.1**|**11.0**|**10.3**|**10.2**|**10.0 - 10.1**|**9.1 - 9.3, 8.4**|
 |-|-|-|-|-|-|-|-|
-|**Availability**||Built in|Built in|Built in|Built in|Built in|[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |
+|**Availability**||Built in|Built in|Built in|Built in|Built in|[Ports](https://svnweb.freebsd.org/ports/branches/2015Q1/emulators/hyperv-is/) |
 |**[Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_core)**|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004; |
 |Windows Server 2016 Accurate Time|2016|&#10004;||||||
 |**[Networking](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Networking)**||||||||
@@ -70,25 +70,26 @@ The following feature distribution map indicates the features in each version. T
 1. Suggest to [Label Disk Devices]( https://www.freebsd.org/doc/handbook/geom-glabel.html) to avoid ROOT MOUNT ERROR during startup.
 
 2. The virtual DVD drive may not be recognized when BIS drivers are loaded on FreeBSD 8.x and 9.x unless you enable the legacy ATA driver through the following command.
-    ```bash
-    # dd if=/dev/da1 of=/dev/da1 count=0
-    # gpart recover da1
+    ```sh
+    # echo ‘hw.ata.disk_enable=1’ >> /boot/loader.conf
+    # shutdown -r now
     ```
 
 3. 9126 is the maximum supported MTU size.
 
 4. In a failover scenario, you cannot set a static IPv6 address in the replica server. Use an IPv4 address instead.
 
-5. KVP is provided by ports on FreeBSD 10. See the [FreeBSD 10 ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) on FreeBSD.org for more information.
+5. KVP is provided by ports on FreeBSD 10.0. See the [FreeBSD 10.0 ports](https://svnweb.freebsd.org/ports/branches/2015Q1/emulators/hyperv-is/) on FreeBSD.org for more information.
 
 6. KVP may not work on Windows Server 2008 R2.
 
-7. To make VHDX online resizing work properly in FreeBSD 11, a special manual step is required to work around a GEOM bug which is fixed in 11+, after the host resizes the VHDX disk - open the disk for write, and run “gpart recover” as the following.
-    ```bash
-    # set hw.ata.disk_enable=1
-    # boot
+7. To make VHDX online resizing work properly in FreeBSD 11.0, a special manual step is required to work around a GEOM bug which is fixed in 11.0+, after the host resizes the VHDX disk - open the disk for write, and run “gpart recover” as the following.
+    ```sh
+    # dd if=/dev/da1 of=/dev/da1 count=0
+    # gpart recover da1
     ```
-**Additional Notes**: The feature matrix of 10 stable and 11 stable is same with FreeBSD 11.1 release. In addition, FreeBSD 10.2 and previous versions (10.1, 10, 9.x, 8.x) are end of life. Please refer [here](https://security.freebsd.org/) for an up-to-date list of supported releases and the latest security advisories.
+
+**Additional Notes**: The feature matrix of 10 stable and 11 stable is same with FreeBSD 11.1 release. In addition, FreeBSD 10.2 and previous versions (10.1, 10.0, 9.x, 8.x) are end of life. Please refer [here](https://security.freebsd.org/) for an up-to-date list of supported releases and the latest security advisories.
 
 ## See Also
 

--- a/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-FreeBSD-virtual-machines-on-Hyper-V.md
@@ -20,50 +20,50 @@ The following feature distribution map indicates the features in each version. T
 
 ## Table legend
 
-* **Built in** - BIS are included as part of this FreeBSD release.
+* **Built in** - BIS (FreeBSD Integration Service) are included as part of this FreeBSD release.
 
 * &#10004; - Feature available
 
 * (*blank*) - Feature not available
 
-|**Feature**|**Windows Server operating system version**|**11.1**|**11**|**10.3**|**10.2**|**10 - 10.1**|**9.1 - 9.3**|**8.4**|
+|**Feature**|**Windows Server operating system version**|**11.1**|**11**|**10.3**|**10.2**|**10 - 10.1**|**9.1 - 9.3, 8.4**|
 |-|-|-|-|-|-|-|-|
-|**Availability**||Built in|Built in|Built in|Built in|Built in|[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |
-|**[Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_core)**|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004; |&#10004; |
-|Windows Server 2016 Accurate Time|2016||||||||
-|**[Networking](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Networking)**|||||||||
-|Jumbo frames|2016, 2012 R2, 2012, 2008 R2|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|
-|VLAN tagging and trunking|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
-|Live migration|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
-|Static IP Injection|2016, 2012 R2, 2012|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004;|&#10004;|
-|vRSS|2016, 2012 R2|&#10004;|&#10004;||||||||
-|TCP Segmentation and Checksum Offloads|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;||||
-|Large Receive Offload (LRO)|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|||||
-|SR-IOV|2016||||||||
-|**[Storage](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Storage)**||Note 1|Note 1|Note 1|Note 1|Note 1,2|Note 1,2|Note 1,2|
-|VHDX resize|2016, 2012 R2|&#10004; Note 7|&#10004; Note 7||||||
-|Virtual Fibre Channel|2016, 2012 R2||||||||
-|Live virtual machine backup|2016, 2012 R2|&#10004;|||||||
-|TRIM support|2016, 2012 R2|&#10004;|||||||
-|SCSI WWN|2016, 2012 R2||||||||
-|**[Memory](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Memory)**|||||||||
-|PAE Kernel Support|2016, 2012 R2, 2012, 2008 R2||||||||
-|Configuration of MMIO gap|2016, 2012 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
-|Dynamic Memory - Hot-Add|2016, 2012 R2, 2012||||||||
-|Dynamic Memory - Ballooning|2016, 2012 R2, 2012||||||||
-|Runtime Memory Resize|2016||||||||
-|**[Video](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Video)**|||||||||
-|Hyper-V specific video device|2016, 2012 R2, 2012, 2008 R2||||||||
-|**[Miscellaneous](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Misc)**|||||||||
-|Key/value pair|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004; Note 6|&#10004; Note 5, 6|&#10004; Note 6|&#10004; Note 6|
-|Non-Maskable Interrupt|2016, 2012 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
-|File copy from host to guest|2016, 2012 R2||||||||
-|lsvmbus command|2016, 2012 R2, 2012, 2008 R2||||||||
-|Hyper-V Sockets|2016||||||||
-|PCI Passthrough/DDA|2016|&#10004;|||||||
-|**[Generation 2 virtual machines](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_gen2)**|||||||||
-|Boot using UEFI|2016, 2012 R2||||||||
-|Secure boot|2016|||||||||
+|**Availability**||Built in|Built in|Built in|Built in|Built in|[Ports](http://svnweb.freebsd.org/ports/head/emulators/hyperv-is/) |
+|**[Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_core)**|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004; |
+|Windows Server 2016 Accurate Time|2016|||||||
+|**[Networking](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Networking)**||||||||
+|Jumbo frames|2016, 2012 R2, 2012, 2008 R2|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|&#10004; Note 3|
+|VLAN tagging and trunking|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
+|Live migration|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
+|Static IP Injection|2016, 2012 R2, 2012|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004; Note 4|&#10004;|
+|vRSS|2016, 2012 R2|&#10004;|&#10004;|||||||
+|TCP Segmentation and Checksum Offloads|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004;|||
+|Large Receive Offload (LRO)|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;||||
+|SR-IOV|2016|||||||
+|**[Storage](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Storage)**||Note 1|Note 1|Note 1|Note 1|Note 1,2|Note 1,2|
+|VHDX resize|2016, 2012 R2|&#10004; Note 7|&#10004; Note 7|||||
+|Virtual Fibre Channel|2016, 2012 R2|||||||
+|Live virtual machine backup|2016, 2012 R2|&#10004;||||||
+|TRIM support|2016, 2012 R2|&#10004;||||||
+|SCSI WWN|2016, 2012 R2|||||||
+|**[Memory](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Memory)**||||||||
+|PAE Kernel Support|2016, 2012 R2, 2012, 2008 R2|||||||
+|Configuration of MMIO gap|2016, 2012 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
+|Dynamic Memory - Hot-Add|2016, 2012 R2, 2012|||||||
+|Dynamic Memory - Ballooning|2016, 2012 R2, 2012|||||||
+|Runtime Memory Resize|2016|||||||
+|**[Video](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Video)**||||||||
+|Hyper-V specific video device|2016, 2012 R2, 2012, 2008 R2|||||||
+|**[Miscellaneous](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_Misc)**||||||||
+|Key/value pair|2016, 2012 R2, 2012, 2008 R2|&#10004;|&#10004;|&#10004;|&#10004; Note 6|&#10004; Note 5, 6|&#10004; Note 6|
+|Non-Maskable Interrupt|2016, 2012 R2|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|
+|File copy from host to guest|2016, 2012 R2|||||||
+|lsvmbus command|2016, 2012 R2, 2012, 2008 R2|||||||
+|Hyper-V Sockets|2016|||||||
+|PCI Passthrough/DDA|2016|&#10004;||||||
+|**[Generation 2 virtual machines](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#BKMK_gen2)**||||||||
+|Boot using UEFI|2016, 2012 R2|||||||
+|Secure boot|2016||||||||
 
 ## <a name="BKMK_notes"></a>Notes
 
@@ -88,6 +88,7 @@ The following feature distribution map indicates the features in each version. T
     # set hw.ata.disk_enable=1
     # boot
     ```
+Additional Notes: The feature matrix of 10 stable and 11 stable is same with FreeBSD 11.1 release. In addition, FreeBSD 10.2 and previous versions (10.1, 10, 9.x, 8.x) are end of life. 
 
 See Also
 


### PR DESCRIPTION
1) fix sh scripts. Two scripts are swapped. On FreeBSD use ‘sh’. 
-	Scripts for the 2nd item:
sh
------
echo ‘hw.ata.disk_enable=1’ >> /boot/loader.conf
shutdown -r now

2) mark 10/11 release as 10.0 and 11.0 to avoid confusion. 
