### PR TITLE
PowerShell/Docker updates to Nano Server changes

### DIFF
--- a/WindowsServerDocs/get-started/nano-in-semi-annual-channel.md
+++ b/WindowsServerDocs/get-started/nano-in-semi-annual-channel.md
@@ -15,7 +15,6 @@ ms.assetid: a270334d-42a7-46ff-8eed-d8656a276544
 
 >Applies To: Windows Server, Semi-annual Channel
 
-
 As described in [Window Server Semi-annual Channel Overview](semi-annual-channel-overview.md), the next release of Windows Server is offering a new option: the Semi-annual Channel.
 
 If you're already running Nano Server, this servicing model will be familiar, since it is already serviced by the Current Branch for Business (CBB) model. Windows Server's new Semi-annual Channel is just a new name for the same model. In this model, feature update releases of Nano Server are expected two to three times per year.
@@ -24,20 +23,10 @@ However, **starting with the new feature release of Windows Server, version 1709
 
 - Nano Server has been optimized for .NET Core applications.
 - Nano Server is even smaller than the Windows Server 2016 version.
-- Windows PowerShell, .NET Core, and WMI are no longer included by default, but you can include PowerShell and .NET Core container packages when building your container.
+- PowerShell Core, .NET Core, and WMI are no longer included by default, but you can include [PowerShell Core](https://hub.docker.com/r/microsoft/powershell/) and [.NET Core](https://hub.docker.com/r/microsoft/dotnet/) container packages when building your container.
 - There is no longer a servicing stack included in Nano Server. Microsoft publishes an updated Nano container to Docker Hub that you redeploy.
 - You troubleshoot the new Nano Container by using Docker.
 - You can now run Nano containers on IoT Core.
 
-
-
 ## Related topics
 When the Insider Program starts, find more information in the [Windows Container Documentation](http://aka.ms/windowscontainers).
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Updated to use the term "PowerShell Core" (CoreCLR-based, as shipped on Nano Server) instead of Windows PowerShell (NetFx-based and never shipped on Nano Server).

Also added links to the PowerShell Core and .NET Core Docker Hub containers.

Oh, additionally, I removed a bunch of extraneous whitespace. Looked at other files in the same folder, none seemed to be formatted w/ extra whitespace. If I broke a style guide, I can add it back. :) 