### PR TITLE
Updating WSUS Database requirements

### DIFF
--- a/WindowsServerDocs/administration/windows-server-update-services/plan/plan-your-wsus-deployment.md
+++ b/WindowsServerDocs/administration/windows-server-update-services/plan/plan-your-wsus-deployment.md
@@ -99,13 +99,13 @@ WSUS requires one of the following databases:
 
 -   Windows Internal Database (WID)
 
--   Microsoft SQL Server 2012 with SP1
+-   Microsoft SQL Server 2016
+
+-   Microsoft SQL Server 2014
 
 -   Microsoft SQL Server 2012
 
--   Microsoft SQL Server 2008 R2 SP2
-
--   Microsoft SQL Server 2008 R2 SP1
+-   Microsoft SQL Server 2008 R2
 
 The following editions of SQL Server are supported by WSUS:
 


### PR DESCRIPTION
When the documentation was migrated to docs.microsoft.com, some updated information was lost:
https://technet.microsoft.com/en-us/library/hh852344.aspx 

On the older doc we support the following:
WSUS database requirements
--------------------------------------------------------------------------------
Regardless of service packs associated with each version of Microsoft SQL Server, WSUS requires one of the following databases:
•Windows Internal Database (WID)
•Microsoft SQL Server 2016
•Microsoft SQL Server 2014
•Microsoft SQL Server 2012
•Microsoft SQL Server 2008 R2

This was added about 1 year ago, after a discussion with the at the moment WSUS PM Steve Henry.
CI Bug: https://vstf-us-wa-28.partners.extranet.microsoft.com:8443/tfs/ContentIdea/ContentIdea/_workitems?_a=edit&id=51927