### PR TITLE
Update deployment-guide.md

### DIFF
--- a/WindowsServerDocs/manage/honolulu/deployment-guide.md
+++ b/WindowsServerDocs/manage/honolulu/deployment-guide.md
@@ -70,11 +70,11 @@ On Windows Server Core and Windows Server 2016 Core, Project Honolulu can instal
 
    To install Project Honolulu and automatically generate a self-signed certificate:
    
-        msiexec /i ServerManagementGateway.msi /qn /L*v log.txt SME_PORT=<port> SSL_CERTIFICATE_OPTION=generate
+        msiexec /i <HonoluluInstallerName>.msi /qn /L*v log.txt SME_PORT=<port> SSL_CERTIFICATE_OPTION=generate
    
    To install Project Honolulu with an existing certificate:
 
-        msiexec /i ServerManagementGateway.msi /qn /L*v log.txt SME_PORT=<port> SME_THUMBPRINT=<thumbprint> SSL_CERTIFICATE_OPTION=installed
+        msiexec /i <HonoluluInstallerName>.msi /qn /L*v log.txt SME_PORT=<port> SME_THUMBPRINT=<thumbprint> SSL_CERTIFICATE_OPTION=installed
         
 > [!WARNING] 
 > Invoking `msiexec` from PowerShell using dot-slash relative path notation (e.g. `.\ServerManagementGateway.msi`) is not supported


### PR DESCRIPTION
Replaced 'ServerManagementGateway.msi' with '<HonoluluInstallerName>.msi'
The name of the installer is no longer ServerManagementGateway, and may vary with each release.