### PR TITLE
Correcting errors

### DIFF
--- a/WindowsServerDocs/remote/remote-access/web-application-proxy/Publishing-Applications-with-SharePoint,-Exchange-and-RDG.md
+++ b/WindowsServerDocs/remote/remote-access/web-application-proxy/Publishing-Applications-with-SharePoint,-Exchange-and-RDG.md
@@ -40,7 +40,7 @@ The following table describes the Exchange services that you can publish through
 |Outlook Web App|-   AD FS using non-claims-based authentication<br />-   Pass-through<br />-   AD FS using claims-based authentication for on-premises Exchange 2013 Service Pak 1 (SP1)|For more information see: [Using AD FS claims-based authentication with Outlook Web App and EAC](http://go.microsoft.com/fwlink/?LinkId=393723)|  
 |Exchange Control Panel|Pass-through||  
 |Outlook Anywhere|Pass-through|You must publish three URLs for Outlook Anywhere to work correctly:<br /><br />-   The autodiscover URL.<br />-   The external host name of the Exchange Server; that is, the URL that is configured for clients to connect to.<br />-   The internal FQDN of the Exchange Server.|  
-|Exchange ActiveSync|Pass-through||  
+|Exchange ActiveSync|Pass-through<br/> AD FS using HTTP Basic authorization protocol|| For more information see: https://docs.microsoft.com/en-us/windows-server/remote/remote-access/web-application-proxy/publishing-applications-using-ad-fs-preauthentication 
   
 To publish Outlook Web App using Integrated Windows authentication, you must use the Add Non-Claims-Based Relying Party Trust Wizard to configure the relying party trust for the application.  
   
@@ -63,10 +63,10 @@ If you want to restrict access to your Remote Access Gateway and add pre-authent
   
 3.  If the RD Web Access and the RD Gateway are hosted on separate RDG servers, you have to publish the two virtual directories individually. You can use the same or different external FQDN's e.g. https://rdweb.contoso.com/rdweb/ and https://gateway.contoso.com/rpc/.  
   
-4.  If the External and Internal FQDN's are different you should disable request header translation on the RDWeb publishing rule. This can be done by running the following PowerShell script on the Web Application Proxy server  
+4.  If the External and Internal FQDN's are different you should not disable request header translation on the RDWeb publishing rule. This can be done by running the following PowerShell script on the Web Application Proxy server but it should be enabled by default.
   
     ```  
-    Get-WebApplicationProxyApplication applicationname | Set-WebApplicationProxyApplication -DisableTranslateUrlInRequestHeaders:$true  
+    Get-WebApplicationProxyApplication applicationname | Set-WebApplicationProxyApplication -DisableTranslateUrlInRequestHeaders:$false  
     ```  
   
     > [!NOTE]  
@@ -101,10 +101,10 @@ If you want to restrict access to your Remote Access Gateway and add pre-authent
   
     It is possible to publish /rdweb and /rpc as separate applications and even to use different published servers. You just need to ensure that you publish both using the same Relying Party Trust as the Web Application Proxy token is issued for the Relying Party Trust and is therefore valid across applications published with the same Relying Party Trust.  
   
-5.  If the External and Internal FQDN's are different you should disable request header translation on the RDWeb publishing rule. This can be done by running the following PowerShell script on the Web Application Proxy server:  
+5.  If the External and Internal FQDN's are different you should not disable request header translation on the RDWeb publishing rule. This can be done by running the following PowerShell script on the Web Application Proxy server but it should be enabled by default:
   
     ```  
-    Get-WebApplicationProxyApplication applicationname | Set-WebApplicationProxyApplication -DisableTranslateUrlInRequestHeaders:$true  
+    Get-WebApplicationProxyApplication applicationname | Set-WebApplicationProxyApplication -DisableTranslateUrlInRequestHeaders:$false 
     ```  
   
 6.  Disable the HttpOnly cookie property in Web Application Proxy on the RDG published application. To allow the RDG ActiveX control access to the Web Application Proxy authentication cookie, you have to disable the HttpOnly property on the Web Application Proxy cookie.  


### PR DESCRIPTION
Line 43 about Exchange ActiveSync pre-authentication, corrected information

Line 66-69, this looks incorrect. Fixed as it should be enabled if URLs are different. Refer to: https://technet.microsoft.com/en-us/library/dn383995(v=ws.11).aspx

Lines 104-107, same as 66-69.