### PR TITLE
Update System-Requirements.md

### DIFF
--- a/WindowsServerDocs/get-started/System-Requirements.md
+++ b/WindowsServerDocs/get-started/System-Requirements.md
@@ -87,7 +87,6 @@ Network adapters used with this release should include these features:
 **Minimum**:  
 - An Ethernet adapter capable of at least gigabit throughput  
 - Compliant with the PCI Express architecture specification.  
-- Supports Pre-boot Execution Environment (PXE).  
 
 A network adapter that supports network debugging (KDNet) is useful, but not a minimum requirement.   
 


### PR DESCRIPTION
The PXE requirement is flat out wrong. AFAIK, there's no requirements in the Windows Server 2016 logo program that requires systems or NICs to support PXE for all network adapters across the system, which is what the bullet point implies.