### PR TITLE
Not applicable for Windows Server 2012

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Configuring-Alternate-Login-ID.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Configuring-Alternate-Login-ID.md
@@ -13,7 +13,7 @@ ms.technology: identity-adfs
 ---
 # Configuring Alternate Login ID
 
->Applies To: Windows Server 2016, Windows Server 2012 R2, Windows Server 2012
+>Applies To: Windows Server 2016, Windows Server 2012 R2
 
 Users can sign in to Active Directory Federation Services (AD FS) enabled applications using any form of user identifier that is accepted by Active Directory Domain Services (AD DS). These include User Principal Names (UPNs) (johndoe@contoso.com) or domain qualified sam-account names (contoso\johndoe or contoso.com\johndoe).
 


### PR DESCRIPTION
Update KB2919355 is required and according to the documentation can only be installed on Windows Server 2012 R2.
https://support.microsoft.com/en-us/help/2919355/windows-rt-8-1--windows-8-1--and-windows-server-2012-r2-update-april-2