### PR TITLE
Fix image references

### DIFF
--- a/WindowsServerDocs/storage/refs/integrity-streams.md
+++ b/WindowsServerDocs/storage/refs/integrity-streams.md
@@ -22,7 +22,7 @@ Integrity streams can be enabled for individual files, directories, or the entir
 
 Once integrity streams is enabled, ReFS will create and maintain a checksum for the specified file(s) in that file's metadata. This checksum allows ReFS to validate the integrity of the data before accessing it. Before returning any data that has integrity streams enabled, ReFS will first calculate its checksum:
 
-<img src=media/compute-checksum.gif alt="Compute checksum for file data"/>
+![Compute checksum for file data](media/compute-checksum.gif)
 
 Then, this checksum is compared to the checksum contained in the file metadata. If the checksums match, then the data is marked as valid and returned to the user. If the checksums don't match, then the data is corrupt. The resiliency of the volume determines how ReFS responds to corruptions:
 
@@ -33,7 +33,7 @@ Then, this checksum is compared to the checksum contained in the file metadata. 
 
 ReFS will record all corruptions in the System Event Log, and the log will reflect whether the corruptions were fixed. 
 
-<img src=media/corrective-write.gif alt="Corrective write restores data integrity."/>
+![Corrective write restores data integrity](media/corrective-write.gif)
 
 ## Performance 
 


### PR DESCRIPTION
Converted image references from img tags to markdown syntax. Previous version looks fine on GitHub but isn't rendered on docs.microsoft.com - just shows escaped HTML.