### PR TITLE
Add Distributed COM Users to Tier0 Equivelancy

### DIFF
--- a/WindowsServerDocs/identity/securing-privileged-access/securing-privileged-access-reference-material.md
+++ b/WindowsServerDocs/identity/securing-privileged-access/securing-privileged-access-reference-material.md
@@ -650,6 +650,8 @@ Organizations should control and monitor membership in all of the Tier 0 groups 
 
 -   Cryptographic Operators
 
+-   Distributed COM Users
+
 -   Other Delegated Groups
 
     > [!NOTE]


### PR DESCRIPTION
Default permissions for the "Distributed COM Users" group make it Tier 0 equivalent. 

-Josh M. Bryant
Cybersecurity Architect
Microsoft
