### PR TITLE
Remove Workplace-Joined Device Requirement

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Update-password-customization.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Update-password-customization.md
@@ -18,11 +18,8 @@ ms.technology: identity-adfs
 
 In some instances, users might not be able to connect to the corporate network to change their account password. This factor can be problematic especially for remote employees who might live far from the nearest corporate office. For these specific cases, the update password page can be used by only connecting to the Internet.  
   
-You can customize the update password page by providing your own description for the page. This feature is only available for a workplace\-joined device.  
+You can customize the update password page by providing your own description for the page.  
   
-> [!WARNING]  
-> The update password page is only available for Workplace Joined devices and is disabled by default. For more information about Workplace Join and configuring a federation server with Device Registration Service, see [Overview: Join to Workplace from Any Device for SSO and Seamless Second Factor Authentication Across Company Applications](https://technet.microsoft.com/library/dn280945.aspx).  
->   
 > To enable the password update page, go to AD FS Management under Endpoints. The endpoint for update password is located at the bottom under Other - /adfs/portal/updatepassword/. Once you have enabled the endpoint, you must restart the AD FS service. This must be done manually. You can then navigate to https://<fqdn>/adfs/portal/updatepassword/ on a workplace joined device and you should see the update password page.  
   
 ![update](media/AD-FS-user-sign-in-customization/ADFS_Blue_Custom5.png)  


### PR DESCRIPTION
Now that Hotfix 3035025 [ https://support.microsoft.com/en-us/help/3035025/hotfix-for-update-password-feature-so-that-users-are-not-required-to-u ] has been released, it is no longer required that devices be registered to the workplace in order to use the password reset page.