### PR TITLE
Removed "Applied to : Windows Server Essentials 2016"

### DIFF
--- a/EssentialsDocs/manage/Manage-Digital-Media-in-Windows-Server-Essentials.md
+++ b/EssentialsDocs/manage/Manage-Digital-Media-in-Windows-Server-Essentials.md
@@ -16,7 +16,7 @@ manager: dongill
 
 # Manage Digital Media in Windows Server Essentials
 
->Applies To: Windows Server 2016 Essentials, Windows Server 2012 R2 Essentials, Windows Server 2012 Essentials
+>Applies To: Windows Server 2012 R2 Essentials, Windows Server 2012 Essentials
 
 The following topics discuss the media streaming features of your server, and explain how to set up and use media streaming on your network.  
   


### PR DESCRIPTION
The Essential Media Pack software is not compatible with 2016 version of Windows Server Essentials. When we try to install, it throw an error : "The Windows Server Essentials Media Pack cannot be installed on this version of the operating system".