### PR TITLE
Update storage-spaces-direct-in-vm.md

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/storage-spaces-direct-in-vm.md
+++ b/WindowsServerDocs/storage/storage-spaces/storage-spaces-direct-in-vm.md
@@ -66,9 +66,9 @@ The following considerations apply when deploying Storage Spaces Direct in a vir
 
     `HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\spaceport\\Parameters\\HwTimeout`
 
-    `dword: 00002710`
+    `dword: 00007530`
 
-    The decimal equivalent is 30000, which is 30 seconds. Note that the default value is 1770 Hexadecimal, or 6000 Decimal, which is 6 seconds.
+    The decimal equivalent of Hexadecimal 7530 is 30000, which is 30 seconds. Note that the default value is 1770 Hexadecimal, or 6000 Decimal, which is 6 seconds.
 
 ## See also
 


### PR DESCRIPTION
Customer made us aware that Hex 2710 = 10,000, not 30,000. I checked with the Storage Spaces Direct dev lead, Vinod Shankar, and he stated that the correct value is 30 seconds, or 30,000 or Hex 7530.