### PR TITLE
Fix typo.

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/overview/AD-FS-FAQ.md
+++ b/WindowsServerDocs/identity/ad-fs/overview/AD-FS-FAQ.md
@@ -134,7 +134,7 @@ The default lifetimes of the various cookies and tokens are listed below (as wel
 
 HTTP Strict Transport Security (HSTS) is a web security policy mechanism which helps mitigate protocol downgrade attacks and cookie hijacking for services that have both HTTP and HTTPS endpoints. It allows web servers to declare that web browsers (or other complying user agents) should only interact with it using HTTPS and never via the HTTP protocol.
 
-All AD FS endpoints for web authentication traffic are opened exclusively over HTTPS.  As a result, AD FS effectively mitigates the threats that HTTP String Transport Security policy mechanism provides (by design there is no downgrade to HTTP since there are no listeners in HTTP). In addition, AD FS prevents the cookies from being sent to another server with HTTP protocol endpoints by marking all cookies with the secure flag.
+All AD FS endpoints for web authentication traffic are opened exclusively over HTTPS.  As a result, AD FS effectively mitigates the threats that HTTP Strict Transport Security policy mechanism provides (by design there is no downgrade to HTTP since there are no listeners in HTTP). In addition, AD FS prevents the cookies from being sent to another server with HTTP protocol endpoints by marking all cookies with the secure flag.
 
 Therefore, implementing HSTS on an AD FS server is not required because it can never be downgraded.  For compliance purposes, AD FS servers meet these requirements because they can never use HTTP and all cookies are marked secure.
 


### PR DESCRIPTION
Fix typo mentioned in #300 (but not the actual focus of that issue), "HTTP String Transport Security" -> "HTTP Strict Transport Security"