### PR TITLE
Adding missing description for -d and -i switches

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/ftp.md
+++ b/WindowsServerDocs/administration/windows-commands/ftp.md
@@ -27,6 +27,8 @@ ftp [-v] [-d] [-i] [-n] [-g] [-s:<FileName>] [-a] [-A] [-x:<SendBuffer>] [-r:<Re
 |Parameter|Description|
 |-------|--------|
 |-v|Suppresses display of remote server responses.|
+|-d|Enables debugging, displaying all commands passed between the FTP client and FTP server.|
+|-i|Disables interactive prompting during multiple file transfers.|
 |-n|Suppresses auto-login upon initial connection.|
 |-g|Disables file name globbing.  **Glob** permits the use of the asterisk (*) and question mark (?) as wildcard characters in local file and path names. For more information, see [additional references](ftp.md#BKMK_additionalRef).|
 |-s:<FileName>|Specifies a text file that contains **ftp** commands. These commands run automatically after **ftp** starts. This parameter allows no spaces. Use this parameter instead of redirection (**<**). **Note:** In Windows 8 and  Windows Server 2012  or later operating systems, the text file must be written in UTF-8.|


### PR DESCRIPTION
Description copied from https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490910(v=technet.10)