### PR TITLE
escape vertical bar so markdown table parses

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/command-line-syntax-key.md
+++ b/WindowsServerDocs/administration/windows-commands/command-line-syntax-key.md
@@ -27,5 +27,5 @@ The following table describes the notation used to indicate command-line syntax.
 |\<Text inside angle brackets>|Placeholder for which you must supply a value|
 |[Text inside square brackets]|Optional items|
 |{Text inside braces}|Set of required items; choose one|
-|Vertical bar (|)|Separator for mutually exclusive items; choose one|
+|Vertical bar (\|)|Separator for mutually exclusive items; choose one|
 |Ellipsis (…)|Items that can be repeated|


### PR DESCRIPTION
Currently, the markdown table parses like so:

![image](https://user-images.githubusercontent.com/2986349/37166705-d54d4662-22cd-11e8-86ef-363c0ad2107f.png)
