### PR TITLE
Update AD-Forest-Recovery-Single-Domain-in-Multidomain-Recovery.md

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/manage/AD-Forest-Recovery-Single-Domain-in-Multidomain-Recovery.md
+++ b/WindowsServerDocs/identity/ad-ds/manage/AD-Forest-Recovery-Single-Domain-in-Multidomain-Recovery.md
@@ -21,17 +21,18 @@ There can be times when it is necessary to recover only a single domain within a
   
  A single domain recovery presents a unique challenge for rebuilding global catalog (GC) servers. For example, if the first domain controller (DC) for the domain is restored from a backup that was created one week earlier, then all other GCs in the forest will have more up-to-date data for that domain than the restored DC. To re-establish GC data consistency, there are a couple options:  
   
--   Unhost and then rehost all GCs in the forest, except those in the recovered domain, at the same time.  
+-   Unhost and then rehost the recovered domains partition from all GCs in the forest, except those in the recovered domain, at the same time.  
   
 -   Follow the forest recovery process to recover the domain, and then remove lingering objects from GCs in other domains.  
   
  The following sections provide general considerations for each option. The complete set of steps that need to be done for the recovery will vary for different Active Directory environments.  
   
 ## Rehost all GCs  
- Rehosting all GCs can be done using repadmin /unhost and repadmin /rehost commands (part of repadmin /experthelp). You would run the repadmin commands on every GC in each domain that is not recovered.  
-  
+
 > [!WARNING]
->  The password of the built-in Administrator account for all domains must be ready for use in case a problem prevents access to a GC for logon.  
+>  The password of the Domain Administrator account for all domains must be ready for use in case a problem prevents access to a GC for logon.  
+
+ Rehosting all GCs can be done using repadmin /unhost and repadmin /rehost commands (part of repadmin /experthelp). You would run the repadmin commands on every GC in each domain that is not recovered. It needs to be ensured, that all GCs do not hold a copy of the recovered domain anymore. To achieve this, unhost the domain partition first from all domain controllers across all none-recovered domains of the forest first. After all GCs do not contain the partition anymore, you can rehost it. When rehosting, consider the site- and replication-structure of your forest, for example, finish the rehost of one DC per site prior to rehosting the other DCs of that site.  
   
  This option can be advantageous for a small organization that has only a few domain controllers for each domain. All of the GCs could be rebuilt on a Friday night and, if necessary, complete replication for all read-only domain partitions before Monday morning. But if you need to recover a large domain that covers sites across the globe, rehosting the read-only domain partition on all GCs for other domains can significantly impact operations and potentially require down time.  
   
@@ -47,7 +48,7 @@ There can be times when it is necessary to recover only a single domain within a
 ## Next Steps
 -   [AD Forest Recovery - Prerequisites](AD-Forest-Recovery-Prerequisties.md)  
 -   [AD Forest Recovery - Devising a custom forest recovery plan](AD-Forest-Recovery-Devising-a-Plan.md)  
-- [AD Forest Recovery - Identify the problem](AD-Forest-Recovery-Identify-the-Problem.md)
+-   [AD Forest Recovery - Identify the problem](AD-Forest-Recovery-Identify-the-Problem.md)
 -   [AD Forest Recovery - Determine how to recover](AD-Forest-Recovery-Determine-how-to-Recover.md)
 -   [AD Forest Recovery - Perform initial recovery](AD-Forest-Recovery-Perform-initial-recovery.md)  
 -   [AD Forest Recovery - Procedures](AD-Forest-Recovery-Procedures.md)  


### PR DESCRIPTION
As part of the #MVPHackaDoc, I found some (hopefully) valuable remarks to clarify timing of unhost/rehost, also ensure that the administrator account is at the beginning and the built-in admin wouldn't help since he cannot logon to a domain controller with ADDS running. The Domain Administrator is needed. In further edits, examples for unhost and rehost might be valuable, since you need to sprecify the partition which need to be unhosted.