### PR TITLE
Adding support statement for dynamic disk

### DIFF
--- a/EssentialsDocs/get-started/system-requirements.md
+++ b/EssentialsDocs/get-started/system-requirements.md
@@ -46,7 +46,10 @@ manager: dongill
  For more information about the hardware requirements, see the [Windows Server Catalog](http://www.windowsservercatalog.com/).  
   
  All server hardware should meet the requirements established for the  Windows Server 2012 R2 Logo Program for Systems. For more information, see [Windows Logo Program](https://msdn.microsoft.com/windows/hardware/gg487403.aspx).  
-  
+
+> [!IMPORTANT]
+> Dynamic disks are not supported on system drive while configuring Server Essentials.
+
 ## See also  
  
 -   [Install Windows Server Essentials](../install/Install-Windows-Server-Essentials.md)  

--- a/EssentialsDocs/get-started/system-requirements.md
+++ b/EssentialsDocs/get-started/system-requirements.md
@@ -48,7 +48,7 @@ manager: dongill
  All server hardware should meet the requirements established for the  Windows Server 2012 R2 Logo Program for Systems. For more information, see [Windows Logo Program](https://msdn.microsoft.com/windows/hardware/gg487403.aspx).  
 
 > [!IMPORTANT]
-> Dynamic disks are not supported on system drive while configuring Server Essentials.
+> Dynamic disks are not supported on Windows Server Essentials.
 
 ## See also  
  


### PR DESCRIPTION
 Dynamic disks are not supported on system drive while configuring Server Essentials.