### PR TITLE
Split port config for PPTP and IKEv2

### DIFF
--- a/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-ras.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-ras.md
@@ -196,15 +196,17 @@ In this section, you can configure Remote Access VPN to allow IKEv2 VPN connecti
 
     2.  Click **OK**.
 
-6.  Click **WAN Miniport (PPTP)** and click **Configure**. The Configure Device - WAN Miniport (IKEv2) dialog box opens.
+6.  Click **WAN Miniport (PPTP)** and click **Configure**. The Configure Device - WAN Miniport (PPTP) dialog box opens.
 
     1.  In **Maximum ports**, type the number of ports to match the maximum number of simultaneous VPN connections that you want to support.
 
     2.  Click **OK**.
+    
+7. Click **WAN Miniport (IKEv2)** and click **Configure**. The Configure Device - WAN Miniport (IKEv2) dialog box opens.
 
-    3.  In **Maximum ports**, type the number of ports to match the maximum number of simultaneous VPN connections that you want to support.
+    1.  In **Maximum ports**, type the number of ports to match the maximum number of simultaneous VPN connections that you want to support.
 
-    4.  Click **OK**.
+    2.  Click **OK**.
 
 7.  If prompted, click **Yes** to confirm restarting the server and click **Close** to restart the server.
 


### PR DESCRIPTION
Steps for configuring the Maximum Ports for WAN Miniport (PPTP) and WAN Miniport (IKEv2) look like they got combined by mistake.  Split these into separate steps and sub-steps.