### PR TITLE
Change WSUS using URLs list

### DIFF
--- a/WindowsServerDocs/administration/windows-server-update-services/deploy/2-configure-wsus.md
+++ b/WindowsServerDocs/administration/windows-server-update-services/deploy/2-configure-wsus.md
@@ -52,11 +52,11 @@ if there is a corporate firewall between WSUS and the Internet, you might have t
 
 -   https://windowsupdate.microsoft.com
 
--   https://*.windowsupdate.microsoft.com
+-   http://*.windowsupdate.microsoft.com
 
 -   https://*.windowsupdate.microsoft.com
 
--   https://*.update.microsoft.com
+-   http://*.update.microsoft.com
 
 -   https://*.update.microsoft.com
 
@@ -70,9 +70,9 @@ if there is a corporate firewall between WSUS and the Internet, you might have t
 
 -   http://wustat.windows.com
 
--   https://ntservicepack.microsoft.com
+-   http://ntservicepack.microsoft.com
 
--   https://go.microsoft.com
+-   http://go.microsoft.com
 
 > [!IMPORTANT]
 > For a scenario in which WSUS is failing to obtain updates due firewall configurations, see [article 885819](https://support.microsoft.com/kb/885819) in the Microsoft Knowledge Base.


### PR DESCRIPTION
The following information appears to be correct.
I think that HTTP and HTTPs are changed in some URLs unexpectedly.

https://web.archive.org/web/20170710190910/https://technet.microsoft.com/en-us/library/hh852346.aspx

•	http://windowsupdate.microsoft.com
•	http://*.windowsupdate.microsoft.com
•	https://*.windowsupdate.microsoft.com
•	http://*.update.microsoft.com
•	https://*.update.microsoft.com
•	http://*.windowsupdate.com
•	http://download.windowsupdate.com
•	http://download.microsoft.com
•	http://*.download.windowsupdate.com
•	http://wustat.windows.com
•	http://ntservicepack.microsoft.com
•	http://go.microsoft.com