### PR TITLE
Fix the MinRoot link

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/manage/manage-hyper-v-cpugroups.md
+++ b/WindowsServerDocs/virtualization/hyper-v/manage/manage-hyper-v-cpugroups.md
@@ -109,7 +109,7 @@ This can be accomplished using a combination of the “minroot” configuration,
 The virtualization host can be configured to use only a subset of the system LPs for the root, with one or more CPU groups affinitized to the remaining LPs. 
 In this manner, the root and guest partitions can run on dedicated CPU resources, and completely isolated, with no CPU sharing.
 
-For more information about the "minroot" configuration, see [Hyper-V Host CPU Resource Management](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/hyper-v-requirements).
+For more information about the "minroot" configuration, see [Hyper-V Host CPU Resource Management](https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/manage/manage-hyper-v-minroot-2016).
 
 ## Using the CpuGroups Tool
 


### PR DESCRIPTION
Fix the link to MinRoot, it's going to the wrong page.  (It's going to the general requirements page, https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/hyper-v-requirements, which says nothing about min root, it should be going to https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/manage/manage-hyper-v-minroot-2016, like it says in the link).