### PR TITLE
Removed "2016" from WSLab scripts

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/deploy-storage-spaces-direct.md
+++ b/WindowsServerDocs/storage/storage-spaces/deploy-storage-spaces-direct.md
@@ -21,7 +21,7 @@ This topic provides step-by-step instructions to deploy [Storage Spaces Direct](
 > Looking to acquire Hyper-Converged Infrastructure? Microsoft recommends these [Windows Server Software-Defined](https://microsoft.com/wssd) solutions from our partners. They are designed, assembled, and validated against our reference architecture to ensure compatibility and reliability, so you get up and running quickly.
 
 > [!Tip]
-> You can use Hyper-V virtual machines, including in Microsoft Azure, to [evaluate Storage Spaces Direct without hardware](storage-spaces-direct-in-vm.md). You may also want to review the handy [Windows Server 2016 rapid lab deployment scripts](https://aka.ms/ws2016lab), which we use for training purposes.
+> You can use Hyper-V virtual machines, including in Microsoft Azure, to [evaluate Storage Spaces Direct without hardware](storage-spaces-direct-in-vm.md). You may also want to review the handy [Windows Server rapid lab deployment scripts](https://aka.ms/wslab), which we use for training purposes.
 
 ## Before you start
 


### PR DESCRIPTION
WS2016lab renamed to just WSLab since it can deploy 2008R2, 2012, 2012R2, 2016 and 2019 servers.