### PR TITLE
Update the-server-cleanup-wizard.md

### DIFF
--- a/WindowsServerDocs/administration/windows-server-update-services/manage/the-server-cleanup-wizard.md
+++ b/WindowsServerDocs/administration/windows-server-update-services/manage/the-server-cleanup-wizard.md
@@ -39,7 +39,11 @@ The Server cleanup Wizard is integrated into the user interface and can be used 
 
     -   The superseding update must be approved for install to a computer group
 
-It is important to mention that if you choose to remove unneeded content with the Server cleanup Wizard, all the private update files that you have downloaded from the Catalog Site will be removed as well. You will need to re-import these files after running the Server cleanup Wizard.
+    >  [!WARNING]  
+    >  In a WSUS hierarchy, it is strongly recommended that you run the cleanup process on the lower-most, downstream/replica WSUS server first, and then move up the hierarchy. Incorrectly running cleanup on any upstream server prior to running cleanup on every downstream server can cause a mismatch between the data that is present in upstream databases and downstream databases. The data mismatch can lead to synchronization failures between the upstream and downstream servers. 
+
+ >  [!IMPORTANT]  
+    >  If you remove unnecessary content by using the Server Cleanup Wizard, all the private update files that you have downloaded from the Microsoft Update Catalog site are also removed. You must reimport these files after you run the Server Cleanup Wizard. 
 
 If updates are approved using an auto-approval rule, they might still be in the "Approved" state, and will not be removed by The Server cleanup Wizard. To remove auto-approved updates that are in an "approved" state , the WSUS Admin must - at minimum - manually set the approval status of superseded updates to "Not Approved" so they will be eligible for declination by the Server cleanup Wizard. The Server cleanup Wizard will ensure a newer update is approved and that no client system is still reporting that update as needed before marking the update as "Declined."
 


### PR DESCRIPTION
I've added the warning regarding the cleanup wizard order from the WSUS 3.0 SP2 documentation (https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd939856(v=ws.10)) since I feel it's a very important call-out for large organizations.  If the product was changed so that this guidance no longer holds true and the wizard should be ran top-down then please let me know.