### PR TITLE
updating the incorrect URI for the claim type

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Configure-AD-FS-to-Send-Password-Expiry-Claims.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Configure-AD-FS-to-Send-Password-Expiry-Claims.md
@@ -20,8 +20,9 @@ You can configure Active Directory Federation Services (AD FS) to send password 
 To configure AD FS to send password expiry claims to a relying party trust, you must add the following claim rules to this relying party trust:
 
 ```
-c1:[Type == "https://schemas.microsoft.com/ws/2012/01/passwordexpirationtime"]
-=> issue(store = "_PasswordExpiryStore", types = ("https://schemas.microsoft.com/ws/2012/01/passwordexpirationtime", "https://schemas.microsoft.com/ws/2012/01/passwordexpirationdays", "https://schemas.microsoft.com/ws/2012/01/passwordchangeurl"), query = "{0};", param = c1.Value);
+@RuleName = "Issue Password Expiry Claims"
+c1:[Type == "http://schemas.microsoft.com/ws/2012/01/passwordexpirationtime"]
+ => issue(store = "_PasswordExpiryStore", types = ("http://schemas.microsoft.com/ws/2012/01/passwordexpirationtime", "http://schemas.microsoft.com/ws/2012/01/passwordexpirationdays", "http://schemas.microsoft.com/ws/2012/01/passwordchangeurl"), query = "{0};", param = c1.Value);
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The URI for password expiration claims are http. Not https. See https://adfshelp.microsoft.com/AadTrustClaims/GenerateClaims for sample claims rules.