### PR TITLE
"Size" parameter fix

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/wevtutil.md
+++ b/WindowsServerDocs/administration/windows-commands/wevtutil.md
@@ -25,7 +25,7 @@ Enables you to retrieve information about event logs and publishers. You can als
 
 ```
 wevtutil [{el | enum-logs}] [{gl | get-log} <Logname> [/f:<Format>]]
-[{sl | set-log} <Logname> [/e:<Enabled>] [/i:<Isolation>] [/lfn:<Logpath>] [/rt:<Retention>] [/ab:<Auto>] [/ms:<Size>] [/l:<Level>] [/k:<Keywords>] [/ca:<Channel>] [/c:<Config>]] 
+[{sl | set-log} <Logname> [/e:<Enabled>] [/i:<Isolation>] [/lfn:<Logpath>] [/rt:<Retention>] [/ab:<Auto>] [/ms:<MaxSize>] [/l:<Level>] [/k:<Keywords>] [/ca:<Channel>] [/c:<Config>]] 
 [{ep | enum-publishers}] 
 [{gp | get-publisher} <Publishername> [/ge:<Metadata>] [/gm:<Message>] [/f:<Format>]] [{im | install-manifest} <Manifest>] 
 [{um | uninstall-manifest} <Manifest>] [{qe | query-events} <Path> [/lf:<Logfile>] [/sq:<Structquery>] [/q:<Query>] [/bm:<Bookmark>] [/sbm:<Savebm>] [/rd:<Direction>] [/f:<Format>] [/l:<Locale>] [/c:<Count>] [/e:<Element>]] 
@@ -41,7 +41,7 @@ wevtutil [{el | enum-logs}] [{gl | get-log} <Logname> [/f:<Format>]]
 |---------|-----------|
 |{el \| enum-logs}|Displays the names of all logs.|
 |{gl \| get-log} \<Logname> [/f:\<Format>]|Displays configuration information for the specified log, which includes whether the log is enabled or not, the current maximum size limit of the log, and the path to the file where the log is stored.|
-|{sl \| set-log} \<Logname> [/e:\<Enabled>] [/i:\<Isolation>] [/lfn:\<Logpath>] [/rt:\<Retention>] [/ab:\<Auto>] [/ms:\<Size>] [/l:\<Level>] [/k:\<Keywords>] [/ca:\<Channel>] [/c:\<Config>]|Modifies the configuration of the specified log.|
+|{sl \| set-log} \<Logname> [/e:\<Enabled>] [/i:\<Isolation>] [/lfn:\<Logpath>] [/rt:\<Retention>] [/ab:\<Auto>] [/ms:\<MaxSize>] [/l:\<Level>] [/k:\<Keywords>] [/ca:\<Channel>] [/c:\<Config>]|Modifies the configuration of the specified log.|
 |{ep \| enum-publishers}|Displays the event publishers on the local computer.|
 |{gp \| get-publisher} \<Publishername> [/ge:\<Metadata>] [/gm:\<Message>] [/f:\<Format>]]|Displays the configuration information for the specified event publisher.|
 |{im \| install-manifest} \<Manifest>|Installs event publishers and logs from a manifest. For more information about event manifests and using this parameter, see the Windows Event Log SDK at the Microsoft Developers Network (MSDN) Web site (https://msdn.microsoft.com).|
@@ -62,7 +62,7 @@ wevtutil [{el | enum-logs}] [{gl | get-log} <Logname> [/f:<Format>]]
 |/lfn:\<Logpath>|Defines the log file name. \<Logpath> is a full path to the file where the Event Log service stores events for this log.|
 |/rt:\<Retention>|Sets the log retention mode. \<Retention> can be true or false. The log retention mode determines the behavior of the Event Log service when a log reaches its maximum size. If an event log reaches its maximum size and the log retention mode is true, existing events are retained and incoming events are discarded. If the log retention mode is false, incoming events overwrite the oldest events in the log.|
 |/ab:\<Auto>|Specifies the log auto-backup policy. \<Auto> can be true or false. If this value is true, the log will be backed up automatically when it reaches the maximum size. If this value is true, the retention (specified with the **/rt** option) must also be set to true.|
-|/ms:\<Size>|Sets the maximum size of the log in bytes. The minimum log size is 1048576 bytes (1024KB) and log files are always multiples of 64KB, so the value you enter will be rounded off accordingly.|
+|/ms:\<MaxSize>|Sets the maximum size of the log in bytes. The minimum log size is 1048576 bytes (1024KB) and log files are always multiples of 64KB, so the value you enter will be rounded off accordingly.|
 |/l:\<Level>|Defines the level filter of the log. \<Level> can be any valid level value. This option is only applicable to logs with a dedicated session. You can remove a level filter by setting <Level> to 0.|
 |/k:\<Keywords>|Specifies the keywords filter of the log. \<Keywords> can be any valid 64 bit keyword mask. This option is only applicable to logs with a dedicated session.|
 |/ca:\<Channel>|Sets the access permission for an event log. \<Channel> is a security descriptor that uses the Security Descriptor Definition Language (SDDL). For more information about SDDL format, see the Microsoft Developers Network (MSDN) Web site (https://msdn.microsoft.com).|


### PR DESCRIPTION
The following invokation:
wentutil.exe /size:10485760
is invalid: "wevtutil.exe : Invalid option size. Option is not supported. The parameter is incorrect."

Should be:
wentutil.exe /maxsize:10485760

Please correct the documentation