### PR TITLE
Update DNS-Policies-Overview.md

### DIFF
--- a/WindowsServerDocs/networking/dns/deploy/DNS-Policies-Overview.md
+++ b/WindowsServerDocs/networking/dns/deploy/DNS-Policies-Overview.md
@@ -60,7 +60,7 @@ The DNS policy criteria field is composed of two elements:
 
 |Name|Description|Sample values|
 |--------|---------------|-----------------|
-|**Client Subnet**|Transport protocol used in the query. Possible entries are **UDP** and **TCP**|-   **EQ,Spain,France** - resolves to true if the subnet is identified as either Spain or France<br />-   **NE,Canada,Mexico** - resolves to true if the client subnet is any subnet other than Canada and Mexico|  
+|**Client Subnet**|Name of a predefined client subnet. Used to verify the subnet from which the query was sent.|-   **EQ,Spain,France** - resolves to true if the subnet is identified as either Spain or France<br />-   **NE,Canada,Mexico** - resolves to true if the client subnet is any subnet other than Canada and Mexico|  
 |**Transport Protocol**|Transport protocol used in the query. Possible entries are **UDP** and **TCP**|-   **EQ,TCP**<br />-   **EQ,UDP**|  
 |**Internet Protocol**|Network protocol used in the query. Possible entries are **IPv4** and **IPv6**|-   **EQ,IPv4**<br />-   **EQ,IPv6**|  
 |**Server Interface IP address**|IP address for the incoming DNS server network interface|-   **EQ,10.0.0.1**<br />-   **EQ,192.168.1.1**|  


### PR DESCRIPTION
***Client Subnet*** Description text is a duplicate of Description for the next field ***Transport Protocol***.  Description for ***Client Subnet*** should be ***Name of a predefined client subnet. Used to verify the subnet from which the query was sent.*** which is exact wording on other official doc pages i.e., https://docs.microsoft.com/en-us/windows-server/networking/dns/deploy/apply-filters-on-dns-queries