### PR TITLE
Adds section "Using DNS Policy on Read-Only Domain Controllers"

### DIFF
--- a/WindowsServerDocs/networking/dns/deploy/DNS-Policies-Overview.md
+++ b/WindowsServerDocs/networking/dns/deploy/DNS-Policies-Overview.md
@@ -190,4 +190,6 @@ For information on how to use DNS policy for specific scenarios, see the followi
 - [Use DNS Policy for Application Load Balancing](app-lb.md)
 - [Use DNS Policy for Application Load Balancing With Geo-Location Awareness](app-lb-geo.md)
 
+## Using DNS Policy on Read-Only Domain Controllers
 
+DNS Policy is compatible with Read-Only Domain Controllers. Do note that a restart of the DNS Server service is required for new DNS Policies to be loaded on Read-Only Domain Controllers. This is not necessary on writable domain controllers.


### PR DESCRIPTION
Based on findings in support case 11808071873578, it is necessary to restart the DNS Server service for new DNS Policies to be loaded on Read-Only Domain Controllers. Adding information about this to the documentation would be good for other DNS Policy users to not spend as much time troubleshooting why DNS Policies is not being loaded on Read-Only Domain Controllers.