### PR TITLE
Updated AAD PSv2 URL to point to correct page

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/configure-ad-fs-and-azure-mfa.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/configure-ad-fs-and-azure-mfa.md
@@ -71,7 +71,7 @@ The following pre-requisites are required when using Azure MFA for authenticatio
       - https://adnotifications.windowsazure.com
       - https://login.microsoftonline.com
 - Your on-premises environment is [federated with Azure AD.](https://azure.microsoft.com/documentation/articles/active-directory-aadconnect-get-started-custom/#configuring-federation-with-ad-fs)  
-- [Windows Azure Active Directory Module for Windows PowerShell](https://go.microsoft.com/fwlink/p/?linkid=236297).  
+- [Windows Azure Active Directory Module for Windows PowerShell](https://docs.microsoft.com/en-us/powershell/module/Azuread/?view=azureadps-2.0).  
 - Global administrator permissions on your instance of Azure AD to configure it using Azure AD PowerShell.  
 - Enterprise administrator credentials to configure the AD FS farm for Azure MFA.  
   


### PR DESCRIPTION
URL was pointing to defunct Connect beta portal that no longer exists.  Replaced URL with URL pointing to current AAD PSv2 landing site.