### PR TITLE
NFS 4.1 allowing the illegal characters in the file name

### DIFF
--- a/WindowsServerDocs/storage/nfs/deploy-nfs.md
+++ b/WindowsServerDocs/storage/nfs/deploy-nfs.md
@@ -124,3 +124,6 @@ The following Windows PowerShell cmdlet can also create an NFS file share (where
 ```PowerShell
 New-NfsShare -name nfs1 -Path C:\shares\nfsfolder
 ```
+
+### Known issue
+NFS version 4.1 allows the file names to be created or copied using illegal characters. If you attempt to open the files with vi editor, it shows as being corrupt. You cannot save the file from vi, rename, move it or change permissions. Avoid using illigal characters.


### PR DESCRIPTION
Adding known issue for NFS 4.1 allowing the illegal characters in the file name.