### PR TITLE
Update TargetFirmware BinaryPath in XML example

### DIFF
--- a/WindowsServerDocs/failover-clustering/health-service-overview.md
+++ b/WindowsServerDocs/failover-clustering/health-service-overview.md
@@ -115,7 +115,7 @@ If the `Cache` section is provided, only the drives listed (as `CacheDisk`) are 
       </AllowedFirmware>
       <TargetFirmware>
         <Version>2.1</Version>
-        <BinaryPath>\\path\to\image.bin</BinaryPath>
+        <BinaryPath>C:\ClusterStorage\path\to\image.bin</BinaryPath>
       </TargetFirmware>
     </Disk>
     <Disk>


### PR DESCRIPTION
TargetFirmware BinaryPath in supported components XML doesn't actually support network paths; the example looks like a network path and might hint to users otherwise.