### PR TITLE
fix: Remove space in markdown links

### DIFF
--- a/WindowsServerDocs/get-started-19/sys-reqs-19.md
+++ b/WindowsServerDocs/get-started-19/sys-reqs-19.md
@@ -39,7 +39,7 @@ Processor performance depends not only on the clock frequency of the processor, 
 - Supports CMPXCHG16b, LAHF/SAHF, and PrefetchW  
 - Supports Second Level Address Translation (EPT or NPT)  
 
-[Coreinfo] (https://technet.microsoft.com/sysinternals/cc835722.aspx) is a tool you can use to confirm which of these capabilities your CPU has.
+[Coreinfo](https://technet.microsoft.com/sysinternals/cc835722.aspx) is a tool you can use to confirm which of these capabilities your CPU has.
 
 ## RAM  
 The following are the estimated RAM requirements for this product:  

--- a/WindowsServerDocs/get-started/System-Requirements.md
+++ b/WindowsServerDocs/get-started/System-Requirements.md
@@ -49,7 +49,7 @@ Processor performance depends not only on the clock frequency of the processor, 
 - Supports CMPXCHG16b, LAHF/SAHF, and PrefetchW  
 - Supports Second Level Address Translation (EPT or NPT)  
 
-[Coreinfo] (https://technet.microsoft.com/sysinternals/cc835722.aspx) is a tool you can use to confirm which of these capabilities your CPU has.
+[Coreinfo](https://technet.microsoft.com/sysinternals/cc835722.aspx) is a tool you can use to confirm which of these capabilities your CPU has.
 
 ## RAM  
 The following are the estimated RAM requirements for this product:  

--- a/WindowsServerDocs/identity/ad-ds/active-directory-functional-levels.md
+++ b/WindowsServerDocs/identity/ad-ds/active-directory-functional-levels.md
@@ -36,7 +36,7 @@ Supported Domain Controller Operating System:
 ### Windows Server 2016 forest functional level features
 
 * All of the features that are available at the Windows Server 2012R2 forest functional level, and the following features, are available:
-   * [Privileged access management (PAM) using Microsoft Identity Manager (MIM)] (https://docs.microsoft.com/windows-server/identity/whats-new-active-directory-domain-services#a-namebkmkpamaprivileged-access-management)
+   * [Privileged access management (PAM) using Microsoft Identity Manager (MIM)](https://docs.microsoft.com/windows-server/identity/whats-new-active-directory-domain-services#a-namebkmkpamaprivileged-access-management)
 
 ### Windows Server 2016 domain functional level features
 

--- a/WindowsServerDocs/manage/windows-admin-center/extend/publish-extensions.md
+++ b/WindowsServerDocs/manage/windows-admin-center/extend/publish-extensions.md
@@ -68,7 +68,7 @@ Using your Build infrastructure (this could be as simple as opening Visual Studi
 
 To create the NuGet package, you need to first create a .nuspec file. A .nuspec file is an XML manifest that contains NuGet package metadata. This manifest is used both to build the package and to provide information to consumers.  Place this file at the root of the "NuGet Package" folder.
 
-Here's an example .nuspec file and the list of required or recommended properties. For the full schema, see the [.nuspec reference] (https://docs.microsoft.com/nuget/reference/nuspec). Save the .nuspec file to your project's root folder with a file name of your choice.
+Here's an example .nuspec file and the list of required or recommended properties. For the full schema, see the [.nuspec reference](https://docs.microsoft.com/nuget/reference/nuspec). Save the .nuspec file to your project's root folder with a file name of your choice.
 
 > [!IMPORTANT]
 > The ```<id>``` value in the .nuspec file needs to match the ```"name"``` value in your project's ```manifest.json``` file, or else your published extension won't load successfully in Windows Admin Center.


### PR DESCRIPTION
The space renders these as text instead of links