### PR TITLE
1387770: Fixed an internal URL link with an unnecesary ".md".

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/deployment/how-to-connect-fed-azure-adfs.md
+++ b/WindowsServerDocs/identity/ad-fs/deployment/how-to-connect-fed-azure-adfs.md
@@ -369,6 +369,5 @@ You can use an existing virtual network or create a new VNET while deploying thi
 
 ## Next steps
 * [Integrating your on-premises identities with Azure Active Directory](https://docs.microsoft.com/azure/active-directory/hybrid/whatis-hybrid-identity)
-* [Configuring and managing your AD FS using Azure AD Connect](https://docs.microsoft.com/azure/active-directory/hybrid/how-to-connect-fed-whatis.md)
+* [Configuring and managing your AD FS using Azure AD Connect](/azure/active-directory/hybrid/how-to-connect-fed-whatis)
 * [High availability cross-geographic AD FS deployment in Azure with Azure Traffic Manager](active-directory-adfs-in-azure-with-azure-traffic-manager.md)
-


### PR DESCRIPTION
For [Task 1387770: Assist w/ fixing broken links in Azure-docs-pr](https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1387770).

Our broken link list in Azure included https://docs.microsoft.com/en-us/azure/active-directory/connect/active-directory-aadconnect-azure-adfs, but this URL redirected to https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/how-to-connect-fed-azure-adfs, which is maintained in this repo.