### PR TITLE
Clarify Desktop Experience text

### DIFF
--- a/WindowsServerDocs/get-started-19/whats-new-19.md
+++ b/WindowsServerDocs/get-started-19/whats-new-19.md
@@ -17,7 +17,7 @@ This topic describes some of the new features in Windows Server 2019. Windows Se
 
 ### Desktop experience
 
-Because Windows Server 2019 is a Long-Term Servicing Channel (LTSC) release, it includes the <b>Desktop Experience</b>. (It's not included in Windows Server, version 1709, Windows Server, version 1803, or Windows Server, version 1809, because Semi-Annual Channel \[SAC\] releases don't including the Desktop Experience by design; they are strictly Server Core and Nano Server container image releases.)
+Because Windows Server 2019 is a Long-Term Servicing Channel (LTSC) release, it includes the <b>Desktop Experience</b>. (It's not included in Windows Server, version 1709, Windows Server, version 1803, or Windows Server, version 1809, because Semi-Annual Channel \(SAC\) releases don't include the Desktop Experience by design; they are strictly Server Core and Nano Server container image releases.)
 As with Windows Server 2016, during setup of the operating system you can choose between Server Core installations or Server with Desktop Experience installations.
 
 ### System Insights

--- a/WindowsServerDocs/get-started-19/whats-new-19.md
+++ b/WindowsServerDocs/get-started-19/whats-new-19.md
@@ -17,7 +17,7 @@ This topic describes some of the new features in Windows Server 2019. Windows Se
 
 ### Desktop experience
 
-The <b>Desktop Experience</b> is back in Windows Server 2019!  It is not included in Windows Server, version 1709, Windows Server, version 1803, or Windows Server, version 1809.  
+Because Windows Server 2019 is an Long-Term Servicing Channel (LTSC) release, it includes the <b>Desktop Experience</b>.  (It is not included in Windows Server, version 1709, Windows Server, version 1803, or Windows Server, version 1809, because Semi-Annual Channel \[SAC\] releases don't including the Desktop Experience.)
 As with Windows Server 2016, during setup of the operating system it is possible to choose between Server Core installations or Server with Desktop Experience installations.
 
 ### System Insights

--- a/WindowsServerDocs/get-started-19/whats-new-19.md
+++ b/WindowsServerDocs/get-started-19/whats-new-19.md
@@ -17,7 +17,7 @@ This topic describes some of the new features in Windows Server 2019. Windows Se
 
 ### Desktop experience
 
-Because Windows Server 2019 is an Long-Term Servicing Channel (LTSC) release, it includes the <b>Desktop Experience</b>.  (It is not included in Windows Server, version 1709, Windows Server, version 1803, or Windows Server, version 1809, because Semi-Annual Channel \[SAC\] releases don't including the Desktop Experience.)
+Because Windows Server 2019 is an Long-Term Servicing Channel (LTSC) release, it includes the <b>Desktop Experience</b>.  (It is not included in Windows Server, version 1709, Windows Server, version 1803, or Windows Server, version 1809, because Semi-Annual Channel \[SAC\] releases don't including the Desktop Experience by design; they are strictly Server Core and Nano Server container image releases by design.)
 As with Windows Server 2016, during setup of the operating system it is possible to choose between Server Core installations or Server with Desktop Experience installations.
 
 ### System Insights

--- a/WindowsServerDocs/get-started-19/whats-new-19.md
+++ b/WindowsServerDocs/get-started-19/whats-new-19.md
@@ -17,8 +17,8 @@ This topic describes some of the new features in Windows Server 2019. Windows Se
 
 ### Desktop experience
 
-Because Windows Server 2019 is an Long-Term Servicing Channel (LTSC) release, it includes the <b>Desktop Experience</b>.  (It is not included in Windows Server, version 1709, Windows Server, version 1803, or Windows Server, version 1809, because Semi-Annual Channel \[SAC\] releases don't including the Desktop Experience by design; they are strictly Server Core and Nano Server container image releases by design.)
-As with Windows Server 2016, during setup of the operating system it is possible to choose between Server Core installations or Server with Desktop Experience installations.
+Because Windows Server 2019 is a Long-Term Servicing Channel (LTSC) release, it includes the <b>Desktop Experience</b>. (It's not included in Windows Server, version 1709, Windows Server, version 1803, or Windows Server, version 1809, because Semi-Annual Channel \[SAC\] releases don't including the Desktop Experience by design; they are strictly Server Core and Nano Server container image releases.)
+As with Windows Server 2016, during setup of the operating system you can choose between Server Core installations or Server with Desktop Experience installations.
 
 ### System Insights
 


### PR DESCRIPTION
The original text ignores the reason for why the named releases don't include the Desktop Experience, and implies that somehow it's broken that that's the case.  It's by design, and considering 1809 and 2019 are being released at the same time, it's important to be clear on the reasoning.