### PR TITLE
Fixed #2129 reference to key mode on WS2016

### DIFF
--- a/WindowsServerDocs/security/guarded-fabric-shielded-vm/guarded-fabric-deployment-overview.md
+++ b/WindowsServerDocs/security/guarded-fabric-shielded-vm/guarded-fabric-deployment-overview.md
@@ -8,7 +8,7 @@ manager: dongill
 author: justinha
 ms.author: justinha
 ms.technology: security-guarded-fabric
-ms.date: 09/17/2018
+ms.date: 12/31/2018
 ---
 
 # Quick start for guarded fabric deployment
@@ -58,7 +58,7 @@ When you initialize HGS, you need to choose the mode:
 - Host key attestation, or key mode, is less secure but easier to adopt  
 - TPM-based attestation, or TPM mode, is more secure but requires more configuration and specific hardware
 
-If necessary, you can deploy in key mode using existing Hyper-V hosts that have been upgraded to Windows Server 2016 Datacenter edition, and then convert to the more secure TPM mode when supporting server hardware (including TPM 2.0) is available. 
+If necessary, you can deploy in key mode using existing Hyper-V hosts that have been upgraded to Windows Server 2019 Datacenter edition, and then convert to the more secure TPM mode when supporting server hardware (including TPM 2.0) is available. 
 
 Now that you know what the pieces are, let’s walk through an example of the deployment model.
 
@@ -70,7 +70,7 @@ Let's imagine this scenario—you have an existing Hyper-V fabric, like Contoso.
 
 ## Step 1: Deploy the Hyper-V hosts running Windows Server 2016 
 
-The Hyper-V hosts need to run Windows Server 2016 Datacenter edition. If you are upgrading hosts, you can [upgrade](https://technet.microsoft.com/windowsserver/dn527667.aspx) from Standard edition to Datacenter edition.
+The Hyper-V hosts need to run Windows Server 2016 Datacenter edition or later. If you are upgrading hosts, you can [upgrade](https://technet.microsoft.com/windowsserver/dn527667.aspx) from Standard edition to Datacenter edition.
 
 ![Upgrade Hyper-V hosts](../../security/media/Guarded-Fabric-Shielded-VM/guarded-fabric-deployment-step-one-upgrade-hyper-v.png)
 


### PR DESCRIPTION
Host key mode is only supported on WS2019, but the docs incorrectly stated that it worked on WS2016.