### PR TITLE
Update Supported-Windows-guest-operating-systems-for-Hyper-V-on-Windo…

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/Supported-Windows-guest-operating-systems-for-Hyper-V-on-Windows.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-Windows-guest-operating-systems-for-Hyper-V-on-Windows.md
@@ -26,7 +26,7 @@ Following are the versions of Windows Server that are supported as guest operati
   
 |Guest operating system (server)|Maximum number of virtual processors|Integration Services|Notes|  
 |-------------------------------------|----------------------------------------|------------------------|---------|  
-|Windows Server 2019 |240 for generation 2;<br>64 for generation 1|Built-in|Not supported on Windows Server 2016 hosts| 
+|Windows Server 2019 |240 for generation 2;<br>64 for generation 1|Built-in|| 
 |Windows Server 2016 |240 for generation 2;<br>64 for generation 1|Built-in|| 
 |Windows Server 2012 R2 |64|Built-in||  
 |Windows Server 2012 |64|Built-in||  


### PR DESCRIPTION
…ws.md

In the Notes column for Windows Server 2019, there is the note that it is not supported on Windows 2016 host.  THIS IS INCORRECT!!!  The PFE who put in the change was thinking something else.  This needs to be removed ASAP as customers see this and are not installing Windows 2019.