### PR TITLE
Remove CU Specific Details in maintain-servers.md

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/maintain-servers.md
+++ b/WindowsServerDocs/storage/storage-spaces/maintain-servers.md
@@ -169,7 +169,7 @@ Use the following steps to path your Storage Spaces Direct system quickly. It in
 2. Take the virtual disks offline.
 3. Stop the cluster to take the storage pool offline. Run the  **Stop-Cluster** cmdlet or use Failover Cluster Manager to stop the cluster.
 4. Set the cluster service to **Disabled** in Services.msc on each node. This prevents the cluster service from starting up while being patched.
-5. Apply the Dec 2017 Cumulative Update (KB 4053579) to all nodes. (You can update all nodes at the same time, no need to wait since the cluster is down).  
+5. Apply the Windows Server Cumulative Update and any required Servicing Stack Updates to all nodes. (You can update all nodes at the same time, no need to wait since the cluster is down).  
 6. Restart the nodes, and ensure everything looks good.
 7. Set the cluster service back to **Automatic** on each node.
 8. Start the cluster. Run the **Start-Cluster** cmdlet or use Failover Cluster Manager. 


### PR DESCRIPTION
Current instructions for updating Storage Spaces Direct offline specifically reference the December 2017 CU, this should be removed and replaced with a generic `Windows Server CU and any required SSUs`
https://docs.microsoft.com/en-us/windows-server/storage/storage-spaces/maintain-servers#how-to-update-storage-spaces-direct-nodes-offline