### PR TITLE
Fix command

### DIFF
--- a/WindowsServerDocs/security/guarded-fabric-shielded-vm/guarded-fabric-manage-branch-office.md
+++ b/WindowsServerDocs/security/guarded-fabric-shielded-vm/guarded-fabric-manage-branch-office.md
@@ -52,7 +52,7 @@ It is controlled by a policy on HGS, which is disabled by default.
 To enable support for offline mode, run the following command on an HGS node:
 
 ```powershell
-Set-HgsKeyProtectionConfiguration -AllowKeyMaterialCaching
+Set-HgsKeyProtectionConfiguration -AllowKeyMaterialCaching:$true
 ```
 
 Since the cacheable key protectors are unique to each shielded VM, you will need to fully shut down (not restart) and start up your shielded VMs to obtain a cacheable key protector after this setting is enabled on HGS.


### PR DESCRIPTION
Fixing it so it doesn't throw this error

Set-HgsKeyProtectionConfiguration : Missing an argument for parameter 'AllowKeyMaterialCaching'. Specify a parameter
of type 'System.Nullable`1[System.Boolean]' and try again.
At line:1 char:35
+ Set-HgsKeyProtectionConfiguration -AllowKeyMaterialCaching
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-HgsKeyProtectionConfiguration], ParameterBindingException
    + FullyQualifiedErrorId : MissingArgument,Microsoft.Windows.KpsServer.Administration.SetHgsKeyProtectionConfigurat
   ionCommand