### PR TITLE
Added warning about Azure limitations to Hyper-V documentation.

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/plan/Should-I-create-a-generation-1-or-2-virtual-machine-in-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/plan/Should-I-create-a-generation-1-or-2-virtual-machine-in-Hyper-V.md
@@ -16,6 +16,9 @@ ms.date: 12/05/2016
 
 >Applies To: Windows 10, Windows Server 2016, Microsoft Hyper-V Server 2016, Windows Server 2019, Microsoft Hyper-V Server 2019
 
+> [!WARNING]
+> If you plan to ever upload a Windows virtual machines (VM) from on-premises to Microsoft Azure, **only generation 1 VMs** that are in the VHD file format and have a fixed sized disk are supported. For more information on uploading a Windows VHD or VHDX, see [Prepare a Windows VHD or VHDX to upload to Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/prepare-for-upload-vhd-image).
+
 Your choice to create a generation 1 or generation 2 virtual machine depends on which guest operating system you want to install and the boot method you want to use to deploy the virtual machine. We recommend that you create a generation 2 virtual machine to take advantage of features like Secure Boot unless one of the following statements is true:  
 
 - The VHD you want to boot from is not [UEFI-compatible](https://technet.microsoft.com/library/hh824898.aspx).  


### PR DESCRIPTION
Added a warning near the top of the page to link to [Prepare a Windows VHD or VHDX to upload to Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/prepare-for-upload-vhd-image) because I think it is pretty important to know right away if that is a possible use case you have but have not considered. As far as I can tell, this is not warned of in the gen1 vs gen2 document.