### PR TITLE
SPN to Service Principal

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/configure-ad-fs-and-azure-mfa.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/configure-ad-fs-and-azure-mfa.md
@@ -92,9 +92,9 @@ Note that TenantID is the name of your directory in Azure AD.  Use the following
 
 ![AD FS and MFA](media/Configure-AD-FS-2016-and-Azure-MFA/ADFS_AzureMFA1.PNG)  
   
-### Step 2: Add the new credentials to Azure Multi-Factor Auth Client SPN
+### Step 2: Add the new credentials to the Azure Multi-Factor Auth Client Service Principal
 
-In order to enable the AD FS servers to communicate with the Azure Multi-Factor Auth Client, you need to add the credentials to the SPN for the Azure Multi-Factor Auth Client. The certificates generated using the `New-AdfsAzureMFaTenantCertificate` cmdlet will serve as these credentials. Do the following using PowerShell to add the new credentials to the Azure Multi-Factor Auth Client SPN.  
+In order to enable the AD FS servers to communicate with the Azure Multi-Factor Auth Client, you need to add the credentials to the Service Principal for the Azure Multi-Factor Auth Client. The certificates generated using the `New-AdfsAzureMFaTenantCertificate` cmdlet will serve as these credentials. Do the following using PowerShell to add the new credentials to the Azure Multi-Factor Auth Client Service Principal.  
 
 > [!NOTE]
 > In order to complete this step you need to connect to your instance of Azure AD with PowerShell using Connect-MsolService.  These steps assume you have already connected via PowerShell.  For information see [Connect-MsolService.](https://msdn.microsoft.com/library/dn194123.aspx)  


### PR DESCRIPTION
Changed references to SPN (Service Principal Name, an Active Directory/Kerberos concept) to Service Principal (an Azure AD object that represents an app on a particular tenant).