### PR TITLE
Added suggestion for Phase 1 Admin workstation

### DIFF
--- a/WindowsServerDocs/identity/securing-privileged-access/securing-privileged-access.md
+++ b/WindowsServerDocs/identity/securing-privileged-access/securing-privileged-access.md
@@ -92,7 +92,7 @@ Additional guidance for operating an environment with LAPS and PAWs can be found
 
 ### 3. Administrative workstations
 
-As an initial security measure for those users with Azure Active Directory and traditional on-premises Active Directory administrative privileges, ensure they are using Windows 10 devices configured with the [Standards for a highly secure Windows 10 device](/windows-hardware/design/device-experiences/oem-highly-secure). 
+As an initial security measure for those users with Azure Active Directory and traditional on-premises Active Directory administrative privileges, ensure they are using Windows 10 devices configured with the [Standards for a highly secure Windows 10 device](/windows-hardware/design/device-experiences/oem-highly-secure). Privileged administrator accounts should not be a members of the local administrator group of the administrative workstations.  Privilege elevation via User Access Control (UAC) can be utilized when configuration changes to the workstations is required.  Additionally, the Windows 10 Security Baseline should be applied to the workstations to further harden the device.
 
 ### 4. Identity attack detection
 


### PR DESCRIPTION
Based on my DSE and POP-SLAM engagements with customers, I believe "Administrative Workstation Phase 1" is best positioned as a "**remediation**" of their current workstations.  I explain it to customers as a way to "get better than you are today" rather than put off improvements until a true PAW solution can be deployed.  In my experience Tier 0 administrators are always members of administrators of their own workstations.  The risks of email and Internet access can be greatly diminished if they would just not operate their workstations as a full administrator.  My other suggestions to them includes:  remove non-essential software and agents, remove Tier1 and Tier 2 accounts from local admin of their admin workstations and if possible just rebuilt with known good media to remove any exposure from the "standard image".  Assuming they have a limited number of on-prem Domain Admins, this will impact a very small number of devices so some manually remediation is very manageable. 

Thanks
jdevore@microsoft.com