### PR TITLE
Inserted commas between the hostnames for set-ADServiceAccount

### DIFF
--- a/WindowsServerDocs/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts.md
+++ b/WindowsServerDocs/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts.md
@@ -262,7 +262,7 @@ Get-ADServiceAccount [-Name] ITFarm1 -PrincipalsAllowedToRetrieveManagedPassword
 ```
 
 ```
-Set-ADServiceAccount [-Name] ITFarm1-PrincipalsAllowedToRetrieveManagedPassword Host1 Host2 Host3
+Set-ADServiceAccount [-Name] ITFarm1-PrincipalsAllowedToRetrieveManagedPassword Host1,Host2,Host3
 
 ```
 
@@ -322,7 +322,7 @@ Get-ADServiceAccount [-Name] ITFarm1 -PrincipalsAllowedToRetrieveManagedPassword
 ```
 
 ```
-Set-ADServiceAccount [-Name] ITFarm1 -PrincipalsAllowedToRetrieveManagedPassword Host1 Host3
+Set-ADServiceAccount [-Name] ITFarm1 -PrincipalsAllowedToRetrieveManagedPassword Host1,Host3
 
 ```
 


### PR DESCRIPTION
Corrected a minor typo in a couple of the examples for the 'set-ADServiceAccount' command. 

Multiple hosts need to be separated with commas rather than just spaces