### PR TITLE
Code formats, typo fix

### DIFF
--- a/WindowsServerDocs/administration/server-performance-advisor/microsoft-server-performance-advisor.md
+++ b/WindowsServerDocs/administration/server-performance-advisor/microsoft-server-performance-advisor.md
@@ -67,16 +67,14 @@ Use the following links to download Server Performance Advisor for Windows Serve
 
 You can extract the files in the CAB file by using the following commands:
 
--   for the x86 version: **extrac32.exe /e /a /l  d:\\SPA   d:\\SPA\\SPAPlus\_x86.cab **
+-   for the x86 version: `extrac32.exe /e /a /l  d:\SPA   d:\SPA\SPAPlus\_x86.cab`
 
--   for the x64 version: **extrac32.exe /e /a /l  d:\\SPA   d:\\SPA\\SPAPlus\_amd64.cab **
+-   for the x64 version: `extrac32.exe /e /a /l  d:\SPA   d:\SPA\SPAPlus\_amd64.cab`
 
 **Caution**
 When you extract the .cab file, SPA must preserve the hierarchical directory structure to function correctly. Depending on the CAB tools that are installed on your server, extraction may result in a non-operational directory structure. To retain the hierarchical directory structure, you can use a CAB extraction utility tool that extracts a file directory structure.
 
- 
-
-if the CAB extraction tool properly extracted the files, subfolders will automatically appear in the extraction target folder.
+If the CAB extraction tool properly extracted the files, subfolders will automatically appear in the extraction target folder.
 
 ### SPA prerequisites
 


### PR DESCRIPTION
1. Existing: Adds code block formatting for 'extrac32' code block.
2. Existing: Capitalizes 'If' and removes extra line (79) for "If the CAB extraction tool properly..."