### PR TITLE
Fix broken internal title links.

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/learn-more/Use-local-resources-on-Hyper-V-virtual-machine-with-VMConnect.md
+++ b/WindowsServerDocs/virtualization/hyper-v/learn-more/Use-local-resources-on-Hyper-V-virtual-machine-with-VMConnect.md
@@ -18,7 +18,7 @@ ms.date: 12/06/2016
 
 Virtual Machine Connection (VMConnect) lets you use a computer's local resources in a virtual machine, like a removable USB flash drive or a printer. Enhanced session mode also lets you resize the VMConnect window. This article shows you how configure the host and then give the virtual machine access to a local resource.
 
-Enhanced session mode and Type clipboard text are available only for virtual machines that run recent Windows operating systems. \(See [Requirements for using local resources](#a-namebkmknewarequirements-for-using-local-resources), below.\) 
+Enhanced session mode and Type clipboard text are available only for virtual machines that run recent Windows operating systems. \(See [Requirements for using local resources](#BKMK_NEW), below.\) 
 
 For virtual machines that run Ubuntu, see [Changing Ubuntu Screen Resolution in a Hyper-V VM](https://blogs.msdn.microsoft.com/virtual_pc_guy/2014/09/19/changing-ubuntu-screen-resolution-in-a-hyper-v-vm/). 
   
@@ -55,7 +55,7 @@ Turn on enhanced session mode:
   
 ## Choose a local resource
 
-Local resources include printers, the clipboard, and a local drive on the computer where you're running VMConnect. For more details, see [Requirements for using local resources](#a-namebkmknewarequirements-for-using-local-resources), below.  
+Local resources include printers, the clipboard, and a local drive on the computer where you're running VMConnect. For more details, see [Requirements for using local resources](#BKMK_NEW), below.  
   
 To choose a local resource:
   


### PR DESCRIPTION
Looks like the links within this document weren't updated when a [manual title link was added](https://github.com/MicrosoftDocs/windowsserverdocs/blame/d385a6d84d7148c70fd198cab8645ea43c2d6bb0/WindowsServerDocs/virtualization/hyper-v/learn-more/Use-local-resources-on-Hyper-V-virtual-machine-with-VMConnect.md#L122).