### PR TITLE
Win Srv 2019 DC min requirement 2008R2 -> 2008

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/active-directory-functional-levels.md
+++ b/WindowsServerDocs/identity/ad-ds/active-directory-functional-levels.md
@@ -29,7 +29,7 @@ At the Windows Server 2008 and higher domain functional levels, Distributed File
 
 There are no new forest or domain functional levels added in this release.
 
-The minimum requirement to add a Windows Server 2019 Domain Controller is a Windows Server 2008R2 functional level.
+The minimum requirement to add a Windows Server 2019 Domain Controller is a Windows Server 2008 functional level.
 
 ## Windows Server 2016
 


### PR DESCRIPTION
Changed Windows Server 2019 minimum functional level from 2008R2 to 2008, since it is possible to add a 2019 DC to a 2008 functional level (as long as DFS is used). No idea if it was a typo or on purpose 2008R2.