### PR TITLE
Storage Replica is available in Std

### DIFF
--- a/WindowsServerDocs/get-started-19/editions-comparison-19.md
+++ b/WindowsServerDocs/get-started-19/editions-comparison-19.md
@@ -119,7 +119,7 @@ ms.localizationpriority: medium
 |SMTP Server|Yes|Yes|
 |SNMP Service|Yes|Yes|
 |Software Load Balancer|Yes|Yes|
-|Storage Replica|No|Yes|
+|Storage Replica|Yes|Yes|
 |Telnet Client|Yes|Yes|
 |TFTP Client|Yes, when installed as Server with Desktop Experience|Yes, when installed as Server with Desktop Experience|
 |VM Shielding Tools for Fabric Management|Yes|Yes|


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows-server/storage/whats-new-in-storage

"Storage Replica in Windows Server, Standard Edition

You can now use Storage Replica with Windows Server, Standard Edition in addition to Datacenter Edition. Storage Replica running on Windows Server, Standard Edition, has the following limitations:

    Storage Replica replicates a single volume instead of an unlimited number of volumes.
    Volumes can have a size of up to 2 TB instead of an unlimited size."