### PR TITLE
Update robocopy.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/robocopy.md
+++ b/WindowsServerDocs/administration/windows-commands/robocopy.md
@@ -69,7 +69,7 @@ robocopy <Source> <Destination> [<File>[ ...]] [<Options>]
 |/rh:hhmm-hhmm|Specifies run times when new copies may be started.|
 |/pf|Checks run times on a per-file (not per-pass) basis.|
 |/ipg:n|Specifies the inter-packet gap to free bandwidth on slow lines.|
-|/sl|Follows the symbolic link and copies the target.|
+|/sl|Don't follow symbolic links and instead create a copy of the link.|
 
 > [!IMPORTANT]
 > When using the **/SECFIX** copy option, specify the type of security information you want to copy by also using one of these additional copy options:</br>> -   **/COPYALL**</br>> -   **/COPY:O**</br>> -   **/COPY:S**</br>> -   **/COPY:U**</br>> -   **/SEC**


### PR DESCRIPTION
Based on the description [here](https://ss64.com/nt/robocopy.html) and anecdotal evidence, robocopy appears to follow links by default. The `/sl` flag appears to instead create copies of the links, and works with both file and directories unlike the description in the above link.