### PR TITLE
Fixed excessive single quotes in MakeProfile.ps1

### DIFF
--- a/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-client-vpn-connections.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-client-vpn-connections.md
@@ -482,10 +482,10 @@ The following example script includes all of the code examples from previous sec
     
     $ProfileXML | Out-File -FilePath ($env:USERPROFILE + '\desktop\VPN_Profile.xml')
     
-    $Script = '$ProfileName = ''' + $ProfileName + '''
+    $Script = '$ProfileName = ' + $ProfileName + ''
     $ProfileNameEscaped = $ProfileName -replace ' ', '%20'
     
-    $ProfileXML = ''' + $ProfileXML + '''
+    $ProfileXML = '' + $ProfileXML + ''
     
     $ProfileXML = $ProfileXML -replace '<', '&lt;'
     $ProfileXML = $ProfileXML -replace '>', '&gt;'
@@ -562,7 +562,7 @@ The following example script includes all of the code examples from previous sec
     }
     
     $Message = "Script Complete"
-    Write-Host "$Message"'
+    Write-Host "$Message"
     
     $Script | Out-File -FilePath ($env:USERPROFILE + '\desktop\VPN_Profile.ps1')
     


### PR DESCRIPTION
Some extra single quotes had been added to MAkeProfile.ps1 example, making the script unusable.