### PR TITLE
Admin Center - Quotas are found under Storage not Files

### DIFF
--- a/WindowsServerDocs/manage/windows-admin-center/use/manage-servers.md
+++ b/WindowsServerDocs/manage/windows-admin-center/use/manage-servers.md
@@ -228,7 +228,6 @@ The following features are supported in Files:
 - Rename a file or folder
 - Extract a zip file
 - View file or folder properties
-- Manage File Server Resource Manager [quotas](https://docs.microsoft.com/windows-server/storage/fsrm/quota-management)
 - Add, edit, or remove file shares
 - Modify user and group permissions on file shares
 
@@ -429,6 +428,7 @@ The following features are supported in Storage:
 - Edit volume properties
 - Delete a volume
 - Install Quota Management
+- Manage File Server Resource Manager Quotas [Storage->Create/Update Quota](https://docs.microsoft.com/windows-server/storage/fsrm/quota-management)
 
 [**View feedback and proposed features for Storage**](https://windowsserver.uservoice.com/forums/295071/filters/top?category_id=319162&query=%5BStorage%5D)
 


### PR DESCRIPTION
To edit or update a quota, one needs to open the Storage node - not the Files node.

In addition, it is misleading to suggest that all FSRM options are available. Setting quota management, denying disk space to users, and limiting disk usage is all that is available. 

Modifying FSRM e-mail templates, SMTP settings, or any other additional FSRM feature has not been added to Admin Center yet.