### PR TITLE
Recommendation for adding Chrome to WIASupportedUserAgents is too broad

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Configure-intranet-forms-based-authentication-for-devices-that-do-not-support-WIA.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Configure-intranet-forms-based-authentication-for-devices-that-do-not-support-WIA.md
@@ -54,14 +54,19 @@ Also ensure that the forms based authentication is enabled for intranet.
 ## Configuring WIA for Chrome
 You can add Chrome or other user agents to the AD FS configuration that supports WIA. This enables seamless logon to applications without having to manually enter credentials when you access resources protected by AD FS. Follow the steps below to enable WIA on Chrome:
 
-Add a user agent string for Chrome in AD FS configuration
+In AD FS configuration, add a user agent string for Chrome on Windows-based platforms:
 
-    Set-AdfsProperties -WIASupportedUserAgents ((Get-ADFSProperties | Select -ExpandProperty WIASupportedUserAgents) + “Chrome”)
-    
-Confirm that the user agent string for Chrome is now set in the AD FS properties
+    Set-AdfsProperties -WIASupportedUserAgents ((Get-ADFSProperties | Select -ExpandProperty WIASupportedUserAgents) + "Mozilla/5.0 (Windows NT")
+
+And similarly for Chrome on Apple macOS, add the following user agent string to the AD FS configuration:
+
+    Set-AdfsProperties -WIASupportedUserAgents ((Get-ADFSProperties | Select -ExpandProperty WIASupportedUserAgents) + "Mozilla/5.0 (Macintosh; Intel Mac OS X")
+
+Confirm that the user agent string for Chrome is now set in the AD FS properties:
 
     Get-AdfsProperties | Select -ExpandProperty WIASupportedUserAgents
 
+(You would need a new screen shot here)
 ![configure auth](media/Configure-intranet-forms-based-authentication-for-devices-that-do-not-support-WIA/chrome1.png) 
 
 >[!NOTE]   


### PR DESCRIPTION
The current recommendation seems to suggest adding the “Chrome” string to WIASupportedUserAgents, but I think that is too broadly defined and could lead to a match when it probably should not because all Chrome user agent strings start with “Mozilla/5.0” followed by the platform. Adding "Chrome" by itself would lead to scenarios where WIA could incorrectly be attempted for devices such as Chrome for Android, which has a user agent string such as:

Mozilla/5.0 (Linux; <Android Version>; <Build Tag etc.>) AppleWebKit/<WebKit Rev> (KHTML, like Gecko) Chrome/<Chrome Rev> Mobile Safari/<WebKit Rev>