### PR TITLE
Add missing argument to command

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/configure-ad-fs-and-azure-mfa.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/configure-ad-fs-and-azure-mfa.md
@@ -231,10 +231,10 @@ Here is a simple example, you may want to extend:
     ``` PowerShell
         New-AdfsWebTheme –Name ProofUp –SourceName default
     ``` 
-2. Next, export the default AD FS Web Theme:
+2. Next, create the folder and export the default AD FS Web Theme:
 
     ``` PowerShell
-       Export-AdfsWebTheme –Name default –DirectoryPath c:\Theme
+       New-Item -Path 'c:\Theme' -ItemType Directory;Export-AdfsWebTheme –Name default –DirectoryPath c:\Theme
     ```
 3. Open the C:\Theme\script\onload.js file in a text editor
 4. Append the following code to the end of the onload.js file

--- a/WindowsServerDocs/identity/ad-fs/operations/configure-ad-fs-and-azure-mfa.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/configure-ad-fs-and-azure-mfa.md
@@ -285,7 +285,7 @@ Here is a simple example, you may want to extend:
 7. Finally, apply the custom AD FS Web Theme by typing the following Windows PowerShell command:
     
     ``` PowerShell
-    Set-AdfsWebConfig -ActiveThemeName
+    Set-AdfsWebConfig -ActiveThemeName "ProofUp"
     ```
 
 ## Next steps


### PR DESCRIPTION
To apply the custom theme, the theme name is required in the Set-AdfsWebConfig command.  Without it specified, the following error is generated:  Set-AdfsWebConfig : Missing an argument for parameter 'ActiveThemeName'. Specify a parameter of type 'System.String'
and try again.