### PR TITLE
The "Thumbprint" parameter is required for Set-WebApplicationProxySsl…

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/manage-ssl-certificates-ad-fs-wap.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/manage-ssl-certificates-ad-fs-wap.md
@@ -105,7 +105,7 @@ For configuring both the default certificate authentication binding or alternate
 To replace the Web Application Proxy SSL certificate, on **each** Web Application Proxy server use the following cmdlet to install the new SSL certificate:
 
 ```powershell
-Set-WebApplicationProxySslCertificate '<thumbprint of new cert>'
+Set-WebApplicationProxySslCertificate -Thumbprint '<thumbprint of new cert>'
 ```
 
 If the above cmdlet fails because the old certificate has already expired, reconfigure the proxy using the following cmdlets:


### PR DESCRIPTION
…Certificate

As seen in the PowerShell doc for this here:
https://docs.microsoft.com/en-us/powershell/module/webapplicationproxy/set-webapplicationproxysslcertificate?view=win10-ps#required-parameters