### PR TITLE
License conversion additional info provided for Install | Upgrade | Migrate to Windows Server 2019

### DIFF
--- a/WindowsServerDocs/get-started-19/install-upgrade-migrate-19.md
+++ b/WindowsServerDocs/get-started-19/install-upgrade-migrate-19.md
@@ -43,7 +43,7 @@ Cluster OS Rolling Upgrade enables an administrator to upgrade the operating sys
 Windows Server migration is when you move one role or feature at a time from a source computer that is running Windows Server to another destination computer that is running Windows Server, either the same or a newer version. For these purposes, migration is defined as moving one role or feature and its data to a different computer, not upgrading the feature on the same computer. 
 
 ## License Conversion
-In some operating system releases, you can convert a particular edition of the release to another edition of the same release in a single step with a simple command and the appropriate license key. This is called **license conversion**. For example, if your server is running Windows Server 2016 Standard, you can convert it to Windows Server 2016 Datacenter. In some releases of Windows Server, you can also freely convert among OEM, volume-licensed, and retail versions with the same command and the appropriate key.
+In some operating system releases, you can convert a particular edition of the release to another edition of the same release in a single step with a simple command and the appropriate license key. This is called **license conversion**. For example, if your server is running Windows Server 2016 Standard, you can convert it to Windows Server 2016 Datacenter. Keep in mind that while you can move up from Server 2016 Standard to Server 2016 Datacenter, you are unable to reverse the process and go from Datacenter to Standard. In some releases of Windows Server, you can also freely convert among OEM, volume-licensed, and retail versions with the same command and the appropriate key.
 
 
  


### PR DESCRIPTION
Added additional info at License Conversion to note that while doing a license conversion from Standard to Datacenter is supported and doable, Datacenter and Standard is not.

#sign-off