### PR TITLE
Update Configure-the-CDP-and-AIA-Extensions-on-CA1.md

### DIFF
--- a/WindowsServerDocs/networking/core-network-guide/cncg/server-certs/Configure-the-CDP-and-AIA-Extensions-on-CA1.md
+++ b/WindowsServerDocs/networking/core-network-guide/cncg/server-certs/Configure-the-CDP-and-AIA-Extensions-on-CA1.md
@@ -31,13 +31,13 @@ To perform this procedure, you must be a member of Domain Admins.
   
     1.  Select the entry `file://\\<ServerDNSName>\CertEnroll\<CaName><CRLNameSuffix><DeltaCRLAllowed>.crl`, and then click **Remove**. In **Confirm removal**, click **Yes**.  
   
-    2.  Select the entry `https://<ServerDNSName>/CertEnroll/<CaName><CRLNameSuffix><DeltaCRLAllowed>.crl`, and then click **Remove**. In **Confirm removal**, click **Yes**.  
+    2.  Select the entry `http://<ServerDNSName>/CertEnroll/<CaName><CRLNameSuffix><DeltaCRLAllowed>.crl`, and then click **Remove**. In **Confirm removal**, click **Yes**.  
   
     3.  Select the entry that starts with the path `ldap:///CN=<CATruncatedName><CRLNameSuffix>,CN=<ServerShortName>`, and then click **Remove**. In **Confirm removal**, click **Yes**.  
   
 4.  In **Specify locations from which users can obtain a certificate revocation list (CRL)**, click **Add**. The **Add Location** dialog box opens.  
   
-5.  In **Add Location**, in **Location**, type `https://pki.corp.contoso.com/pki/<CaName><CRLNameSuffix><DeltaCRLAllowed>.crl`, and then click **OK**. This returns you to the CA properties dialog box.  
+5.  In **Add Location**, in **Location**, type `http://pki.corp.contoso.com/pki/<CaName><CRLNameSuffix><DeltaCRLAllowed>.crl`, and then click **OK**. This returns you to the CA properties dialog box.  
   
 6.  On the **Extensions** tab, select the following check boxes:  
   
@@ -59,13 +59,13 @@ To perform this procedure, you must be a member of Domain Admins.
   
     1.  Select the entry that starts with the path `ldap:///CN=<CATruncatedName>,CN=AIA,CN=Public Key Services`, and then click **Remove**. In **Confirm removal**, click **Yes**.  
   
-    2.  Select the entry `https://<ServerDNSName>/CertEnroll/<ServerDNSName>_<CaName><CertificateName>.crt`, and then click **Remove**. In **Confirm removal**, click **Yes**.  
+    2.  Select the entry `http://<ServerDNSName>/CertEnroll/<ServerDNSName>_<CaName><CertificateName>.crt`, and then click **Remove**. In **Confirm removal**, click **Yes**.  
   
     3.  Select the entry `file://\\<ServerDNSName>\CertEnroll\<ServerDNSName><CaName><CertificateName>.crt`, and then click **Remove**. In **Confirm removal**, click **Yes**.  
   
 11. In **Specify locations from which users can obtain the certificate for this CA**, click **Add**. The **Add Location** dialog box opens.  
   
-12. In **Add Location**, in **Location**, type `https://pki.corp.contoso.com/pki/<ServerDNSName>_<CaName><CertificateName>.crt`, and then click **OK**. This returns you to the CA properties dialog box.  
+12. In **Add Location**, in **Location**, type `http://pki.corp.contoso.com/pki/<ServerDNSName>_<CaName><CertificateName>.crt`, and then click **OK**. This returns you to the CA properties dialog box.  
   
 13. On the **Extensions** tab, select **Include in the AIA of issued certificates**.  
   


### PR DESCRIPTION
Change https:// references to http:// on lines 34, 40, 62, and 68. The change reflects the true out-of-box state for lines 34 and 62 as well as the correct value for lines 40 and 68 since https:// is not valid for CDP and AIA references.