### PR TITLE
Update links to trusted TPM roots certificate package

### DIFF
--- a/WindowsServerDocs/security/device-health-attestation.md
+++ b/WindowsServerDocs/security/device-health-attestation.md
@@ -92,7 +92,7 @@ When DHA is running in EKCert validation mode, it relies on an enterprise manage
 
 Microsoft publishes aggregated packages of trusted Roots and intermediate CA's for approved TPM manufacturers (as they become available) in a publicly accessible archive in .cab archive. You need to download the feed, validate its integrity, and install it on the server running Device Health Attestation.
 
-An example archive is [https://tpmsec.microsoft.com/OnPremisesDHA/TrustedTPM.cab](https://tpmsec.microsoft.com/OnPremisesDHA/TrustedTPM.cab).
+An example archive is [https://go.microsoft.com/fwlink/?linkid=2097925](https://go.microsoft.com/fwlink/?linkid=2097925).
 
 #### AIKCert validation mode
 
@@ -160,7 +160,7 @@ To install the trusted TPM roots certificate package, you must extract it, remov
 #### Download the trusted TPM roots certificate package
 
 Before you install the certificate package, you can download the latest list of trusted TPM roots from
-[https://tpmsec.microsoft.com/OnPremisesDHA/TrustedTPM.cab](https://tpmsec.microsoft.com/OnPremisesDHA/TrustedTPM.cab).
+[https://go.microsoft.com/fwlink/?linkid=2097925](https://go.microsoft.com/fwlink/?linkid=2097925).
 
 > **Important:** Before installing the package, verify that it is digitally signed by Microsoft.
 


### PR DESCRIPTION
The links to download the latest trusted TPM roots certificate package are outdated. The correct link was obtained from https://docs.microsoft.com/en-us/windows-server/security/guarded-fabric-shielded-vm/guarded-fabric-install-trusted-tpm-root-certificates.