### PR TITLE
Clarify PowerShell example

### DIFF
--- a/WindowsServerDocs/storage/storage-replica/storage-replica-frequently-asked-questions.md
+++ b/WindowsServerDocs/storage/storage-replica/storage-replica-frequently-asked-questions.md
@@ -71,7 +71,7 @@ Update-SmbMultichannelConnection
 
 For configuring network constraints on a stretch cluster:  
 
-    Set-SRNetworkConstraint -SourceComputerName sr-srv01 -SourceRGName group1 -SourceNWInterface "Cluster Network 1","Cluster Network 2" -DestinationComputerName sr-srv03 -DestinationRGName group2 -DestinationNWInterface "Cluster Network 1","Cluster Network 2"  
+    Set-SRNetworkConstraint -SourceComputerName sr-cluster01 -SourceRGName group1 -SourceNWInterface "Cluster Network 1","Cluster Network 2" -DestinationComputerName sr-cluster02 -DestinationRGName group2 -DestinationNWInterface "Cluster Network 1","Cluster Network 2"
 
 ## <a name="FAQ4"></a> Can I configure one-to-many replication or transitive (A to B to C) replication?  
 No, Storage Replica supports only one to one replication of a server, cluster, or stretch cluster node. This may change in a later release. You can of course configure replication between various servers of a specific volume pair, in either direction. For instance, Server 1 can replicate its D volume to server 2, and its E volume from Server 3.


### PR DESCRIPTION
Modified PowerShell example code to clarify that specifying a cluster name for source and destination is supported. When a server name was specified for the cluster example, this could lead users to believe the command had to be run for each node in the cluster who are replicating data.