### PR TITLE
typo fix

### DIFF
--- a/WindowsServerDocs/remote/multipoint-services/Configure-group-policies-for-a-domain-deployment.md
+++ b/WindowsServerDocs/remote/multipoint-services/Configure-group-policies-for-a-domain-deployment.md
@@ -21,7 +21,7 @@ To ensure that your domain deployment of MultiPoint Services works properly, app
 > Some group policy settings can prevent required configuration settings from being applied to MultiPoint Services. Be sure that you understand and define your group policy settings so that they work correctly on MultiPoint Services. For example, a Group Policy setting that prevents Autologon could present problems with MultiPoint Services logon behavior.  
   
 ## Update group policies for the WMSshell user account 
-The WMSshell user account is a system account which MultiPoint services uses to sign-in into the console where the actuall stations are created. This account is not ment be managed by MultiPoint Manager.
+The WMSshell user account is a system account which MultiPoint services uses to sign-in into the console, where the actual stations are created. This account is not meant to be managed by MultiPoint Manager.
   
 > [!NOTE]  
 > To find out how to update group policies, see [Local Group Policy Editor](https://technet.microsoft.com/library/dn265982.aspx).  


### PR DESCRIPTION
There were some spelling and grammar mistakes in line 24.

Original:
> The WMSshell user account is a system account which MultiPoint services uses to sign-in into the console where the actuall stations are created. This account is not ment be managed by MultiPoint Manager.

Updated:
> The WMSshell user account is a system account which MultiPoint services uses to sign-in into the console, where the actual stations are created. This account is not meant to be managed by MultiPoint Manager.