### PR TITLE
Resolve #859 - SLB not supported on Standard

### DIFF
--- a/WindowsServerDocs/get-started/2016-Edition-Comparison.md
+++ b/WindowsServerDocs/get-started/2016-Edition-Comparison.md
@@ -117,7 +117,7 @@ ms.localizationpriority: medium
 |SMB Bandwidth Limit|Yes|Yes|
 |SMTP Server|Yes|Yes|
 |SNMP Service|Yes|Yes|
-|Software Load Balancer|Yes|Yes|
+|Software Load Balancer|No|Yes|
 |Storage Replica|No|Yes|
 |Telnet Client|Yes|Yes|
 |TFTP Client|Yes, when installed as Server with Desktop Experience|Yes, when installed as Server with Desktop Experience|


### PR DESCRIPTION
Per #859, software load balancer is only supported on the Datacenter edition of Windows Server 2016.