### PR TITLE
Remove backticks from Powershell commands

### DIFF
--- a/WindowsServerDocs/get-started/Deprecated-Features.md
+++ b/WindowsServerDocs/get-started/Deprecated-Features.md
@@ -50,8 +50,8 @@ The **wuauclt.exe /detectnow** command has been removed and is no longer support
 
 - Run these PowerShell commands:
     ````powershell
-    $AutoUpdates = New-Object -ComObject "Microsoft.Update.AutoUpdate"`
-    $AutoUpdates.DetectNow()` 
+    $AutoUpdates = New-Object -ComObject "Microsoft.Update.AutoUpdate"
+    $AutoUpdates.DetectNow()
     ````
 
 - Alternately, use this VBScript:


### PR DESCRIPTION
The backticks escape the newlines in these commands, which produce unexpected results - when testing, this causes PowerShell to tell the user "you cannot call a method on a null-valued expression." Removing the backtick from each line resolves the issue.