### PR TITLE
Fix inverted logic in example section

### DIFF
--- a/WindowsServerDocs/networking/dns/deploy/DNS-Policies-Overview.md
+++ b/WindowsServerDocs/networking/dns/deploy/DNS-Policies-Overview.md
@@ -174,7 +174,7 @@ The first line in the script creates a subnet object named *AllowedSubnet* with 
 You can also create zone level zone transfer policies. The example below ignores any request for a zone transfer for contoso.com coming in from a server interface that has an IP address of 10.0.0.33:  
 
 ```  
-Add-DnsServerZoneTransferPolicy -Name "InternalTransfers" -Action IGNORE -ServerInterfaceIP "ne,10.0.0.33" -PassThru -ZoneName "contoso.com"  
+Add-DnsServerZoneTransferPolicy -Name "InternalTransfers" -Action IGNORE -ServerInterfaceIP "eq,10.0.0.33" -PassThru -ZoneName "contoso.com"  
 ```  
 
 ## DNS Policy Scenarios


### PR DESCRIPTION
In the "Create a zone level zone transfer policy," the description does not appear to match the command. The description indicates that the command will IGNORE any zone transfers from the given server interface IP. However, since the command used "ne," the inverse was true - the DNS server would ignore all zone transfer requests from all interface IPs except the specified one.

To correct this, I've inverted ne to eq. In my lab, this appears to be the correct command.