### PR TITLE
Update prompt.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/prompt.md
+++ b/WindowsServerDocs/administration/windows-commands/prompt.md
@@ -53,7 +53,7 @@ The following table lists the character combinations that you can include instea
 |    $n     |                                Current drive                                |
 |    $g     |                            > (greater than sign)                            |
 |    $l     |                             < (less than sign)                              |
-|    $b     |                                                                             |
+|    $b     |                              \| (pipe symbol)                               |
 |    $_     |                               ENTER-LINEFEED                                |
 |    $e     |                         ANSI escape code (code 27)                          |
 |    $h     | Backspace (to delete a character that has been written to the command line) |


### PR DESCRIPTION
The pipe symbol/vertical bar was previously left out, presumably due to markdown table parsing. I've added an escaped bar.