### PR TITLE
Procedure not effective

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/delegate-ad-fs-pshell-access.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/delegate-ad-fs-pshell-access.md
@@ -60,7 +60,7 @@ If the farm is not using delegated administration, grant the gMSA account admin 
  
 ### Create the JEA Role File 
  
-Create the JEA role in a notepad file. Instructions to create the role is provided on [JEA role capabilities](https://docs.microsoft.com/powershell/jea/role-capabilities). 
+On the AD FS server, create the JEA role in a notepad file. Instructions to create the role is provided on [JEA role capabilities](https://docs.microsoft.com/powershell/jea/role-capabilities). 
  
 The commandlets delegated in this example are `Reset-AdfsAccountLockout, Get-ADFSAccountActivity, and Set-ADFSAccountActivity`. 
 
@@ -113,4 +113,6 @@ To use the delegated commands:
 ```powershell
 Enter-pssession -ComputerName server01.contoso.com -ConfigurationName "AccountActivityAdministration" -Credential <User Using JEA> 
 Get-AdfsAccountActivity <User> 
+
+
 ```


### PR DESCRIPTION
Customers are reporting some problem with this approach.
Better approach would be, instead of loading the JEA role file directly:
RoleDefinitions = @{ JEAcontoso = @{ RoleCapabilityFiles = 'C:\Program Files\WindowsPowershell\Modules\AccountActivityJEA\RoleCapabilities\JEAAccountActivityResetRole.psrc' } }
}
Create powershell module with the "RoleCapabilities" set and Role definitions just define the module. See this working example:

$modulePath = Join-Path $env:ProgramFiles "WindowsPowerShell\Modules\ADFSActivity"

New-Item -ItemType Directory -Path $modulePath

New-Item -ItemType File -Path (Join-Path $modulePath "ADFSActivityFunctions.psm1")

​New-ModuleManifest -Path (Join-Path $modulePath "ADFSActivity.psd1") -RootModule "ADFSActivityFunctions.psm1"

$rcFolder = Join-Path $modulePath "RoleCapabilities"

New-Item -ItemType Directory $rcFolder
​
Create the PowerShell Roll Configuration File and place it into the $rcFolder path above on the AD FS server:

@{
GUID = '752d9f89-5dc8-4720-9baf-a9ea2749ab5b'
ModulesToImport = 'ADFS'
VisibleCmdlets = 'Reset-AdfsAccountLockout', 'Get-ADFSAccountActivity', 'Set-ADFSAccountActivity'
}​

ADFSActivity.psrc
C:\Program Files\WindowsPowerShell\Modules\ADFSActivity\RoleCapabilities


Create the PowerShell Session File with the following content:

@{
SchemaVersion = '2.0.0.0'
GUID = 'ffb4c0b2-f161-4ddc-a769-d2419b489170'
SessionType = 'RestrictedRemoteServer'
ModulesToImport = 'ADFSActivity'
GroupManagedServiceAccount = 'INTERNAL\msvc_ADFSMgmt'
RoleDefinitions = @{ 'INTERNAL\ADFSAccountActivity' = @{ RoleCapabilities = 'ADFSActivity' } }
}

Save the file as: ADFSActivity.pssc

On the AD FS server register the session configuration:
Register-PSSessionConfiguration -Name 'ADFSActivity' -Path .\ADFSActivity.pssc -Force


From the client computer, you can connect using the following cmdlet:
​​Enter-PSSession -ComputerName ADFSServer -ConfigurationName ADFSActivity -credential username