### PR TITLE
NPS password support statement

### DIFF
--- a/WindowsServerDocs/networking/technologies/nps/nps-best-practices.md
+++ b/WindowsServerDocs/networking/technologies/nps/nps-best-practices.md
@@ -53,6 +53,9 @@ Following are the best practices for authentication.
 - Use certificate-based authentication methods such as Protected Extensible Authentication Protocol \(PEAP\) and Extensible Authentication Protocol \(EAP\) for strong authentication. Do not use password-only authentication methods because they are vulnerable to a variety of attacks and are not secure. For secure wireless authentication, using PEAP\-MS\-CHAP v2 is recommended, because the NPS proves its identity to wireless clients by using a server certificate, while users prove their identity with their user name and password.  For more information about using NPS in your wireless deployment, see [Deploy Password-Based 802.1X Authenticated Wireless Access](https://technet.microsoft.com/windows-server-docs/networking/core-network-guide/cncg/wireless/a-deploy-8021x-wireless-access).
 - Deploy your own certification authority \(CA\) with Active Directory&reg; Certificate Services \(AD CS\) when you use strong certificate-based authentication methods, such as PEAP and EAP, that require the use of a server certificate on NPSs. You can also use your CA to enroll computer certificates and user certificates. For more information on deploying server certificates to NPS and Remote Access servers, see [Deploy Server Certificates for 802.1X Wired and Wireless Deployments](https://technet.microsoft.com/windows-server-docs/networking/core-network-guide/cncg/server-certs/deploy-server-certificates-for-802.1x-wired-and-wireless-deployments).
 
+> [!IMPORTANT]
+> Network Policy Server (NPS) does not support the use of the Extended ASCII characters within passwords.
+
 ## Client computer configuration
 
 Following are the best practices for client computer configuration.


### PR DESCRIPTION
NPS fails logon when password with extended character set.