### PR TITLE
Add SAC channels to supported guest OSes

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/Supported-Windows-guest-operating-systems-for-Hyper-V-on-Windows.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-Windows-guest-operating-systems-for-Hyper-V-on-Windows.md
@@ -26,7 +26,10 @@ Following are the versions of Windows Server that are supported as guest operati
   
 |Guest operating system (server)|Maximum number of virtual processors|Integration Services|Notes|  
 |-------------------------------------|----------------------------------------|------------------------|---------|  
-|Windows Server 2019 |240 for generation 2;<br>64 for generation 1|Built-in|| 
+|Windows Server, version 1903 |240 for generation 2;<br>64 for generation 1|Built-in||
+|Windows Server, version 1809 |240 for generation 2;<br>64 for generation 1|Built-in|| 
+|Windows Server 2019 |240 for generation 2;<br>64 for generation 1|Built-in||
+|Windows Server, version 1803 |240 for generation 2;<br>64 for generation 1|Built-in|| 
 |Windows Server 2016 |240 for generation 2;<br>64 for generation 1|Built-in|| 
 |Windows Server 2012 R2 |64|Built-in||  
 |Windows Server 2012 |64|Built-in||  


### PR DESCRIPTION
We support SAC channels of Windows Server as a guest operating system assuming they're within their 18-month lifetime window. I think this should get called out in the table (given customer comments on the article stating this is not clear)