### PR TITLE
Remove url region info

### DIFF
--- a/WindowsServerDocs/manage/windows-admin-center/extend/case-studies/purestorage.md
+++ b/WindowsServerDocs/manage/windows-admin-center/extend/case-studies/purestorage.md
@@ -47,4 +47,4 @@ Since releasing our Technical Preview, the customer feedback collected so far ha
 
 Additional resources:
 - [Pure Storage extension announcement blog post](https://blog.purestorage.com/tech-preview-of-the-pure-storage-extension-for-windows-admin-center/)
-- [PureReport](https://itunes.apple.com/us/podcast/windows-admin-center-extension-from-pure-storage/id1392639991?i=1000424316130&mt=2) podcast
+- [PureReport](https://itunes.apple.com/podcast/windows-admin-center-extension-from-pure-storage/id1392639991?i=1000424316130&mt=2) podcast

--- a/WindowsServerDocs/remote/remote-desktop-services/Tenant-on-premises-components.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/Tenant-on-premises-components.md
@@ -29,8 +29,8 @@ Additional information:
 [Microsoft Remote Desktop Clients](https://technet.microsoft.com/library/dn473009.aspx)  
 [Remote Desktop app for Windows in Microsoft Store](https://apps.microsoft.com/windows/app/remote-desktop/051f560e-5e9b-4dad-8b2e-fa5e0b05a480)  
 [Microsoft Remote Desktop - Android Apps on Google Play](https://play.google.com/store/apps/details?id=com.microsoft.rdc.android)  
-[Mac App Store - Microsoft Remote Desktop](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417?mt=12)  
-[Microsoft Remote Desktop in the App Store](https://itunes.apple.com/us/app/microsoft-remote-desktop/id714464092?mt=8)  
+[Mac App Store - Microsoft Remote Desktop](https://itunes.apple.com/app/microsoft-remote-desktop/id715768417?mt=12)  
+[Microsoft Remote Desktop in the App Store](https://itunes.apple.com/app/microsoft-remote-desktop/id714464092?mt=8)  
   
 ##  Active Directory Domain Services  
 Some larger and more sophisticated tenants may choose to host an Active Directory Domain Services (AD DS) server on their premises. In this case, the AD DS server in the tenant's environment will typically be a replica of AD DS server that is on the tenant's premises. This is supported by creating a virtual network in the tenant's environment and using the Azure VPN to create a site-to-site connection from the tenant's on-premises network to the tenant's virtual network in the Azure data center.  

--- a/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-clients.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-clients.md
@@ -29,8 +29,8 @@ The following client apps are available:
 |----------|-----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------|
 | Windows  | [Windows 10 client in the Microsoft Store](https://go.microsoft.com/fwlink/?LinkID=616709)                      | [Getting started with Remote Desktop client on Windows](windows.md)                |
 | Android  | [Android client in Google Play](https://play.google.com/store/apps/details?id=com.microsoft.rdc.android)        | [Getting started with Remote Desktop client on Android](remote-desktop-android.md) |
-| iOS      | [iOS client in the iTunes store](https://itunes.apple.com/us/app/microsoft-remote-desktop/id714464092?mt=8)     | [Getting started with Remote Desktop client on iOS](remote-desktop-ios.md)         |
-| macOS    | [macOS client in the iTunes store](https://itunes.apple.com/us/app/microsoft-remote-desktop/id1295203466?mt=12) | [Getting started with Remote Desktop client on Mac](remote-desktop-mac.md)         |
+| iOS      | [iOS client in the iTunes store](https://itunes.apple.com/app/microsoft-remote-desktop/id714464092?mt=8)     | [Getting started with Remote Desktop client on iOS](remote-desktop-ios.md)         |
+| macOS    | [macOS client in the iTunes store](https://itunes.apple.com/app/microsoft-remote-desktop/id1295203466?mt=12) | [Getting started with Remote Desktop client on Mac](remote-desktop-mac.md)         |
 
 ## Configuring the remote PC
 

--- a/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-ios.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-ios.md
@@ -32,7 +32,7 @@ Use the following information to get started. Be sure to check out the [FAQ](rem
 ### Download the Remote Desktop client from the iOS store
 Follow these steps to get started with Remote Desktop on your iOS device:
 
-1. Download the Microsoft Remote Desktop client from [iTunes](https://itunes.apple.com/us/app/microsoft-remote-desktop/id714464092?mt=8).
+1. Download the Microsoft Remote Desktop client from [iTunes](https://itunes.apple.com/app/microsoft-remote-desktop/id714464092?mt=8).
 2. [Set up your PC to accept remote connections](remote-desktop-client-faq.md#how-do-i-set-up-a-pc-for-remote-desktop).
 3. Add a [Remote Desktop connection](#add-a-remote-desktop-connection) or a [remote resource](#add-a-remote-resource). You use a connection to connect to a directly to a Windows PC and a remote resource to use a RemoteApp program, session-based desktop, or a virtual desktop published on-premises using RemoteApp and Desktop Connections. This feature is typically available in corporate environments.
 

--- a/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-mac.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-mac.md
@@ -29,7 +29,7 @@ You can use the Remote Desktop client for Mac to work with Windows apps, resourc
 ## Get the Remote Desktop client
 Follow these steps to get started with Remote Desktop on your Mac:
 
-1. Download the Microsoft Remote Desktop client from the [Mac App Store](https://itunes.apple.com/us/app/microsoft-remote-desktop/id1295203466?mt=12).
+1. Download the Microsoft Remote Desktop client from the [Mac App Store](https://itunes.apple.com/app/microsoft-remote-desktop/id1295203466?mt=12).
 2. [Set up your PC to accept remote connections](remote-desktop-client-faq.md#how-do-i-set-up-a-pc-for-remote-desktop). (If you skip this step, you can't connect to your PC.)
 3. Add a Remote Desktop connection or a remote resource. You use a connection to connect directly to a Windows PC and a remote resource to use a RemoteApp program, session-based desktop, or a virtual desktop published on-premises using RemoteApp and Desktop Connections. This feature is typically available in corporate environments.
 


### PR DESCRIPTION
From https://github.com/MicrosoftDocs/windowsserverdocs.zh-cn/issues/1

I don't know whether this is valid, because I still got `us` version in my test.

And in PRC, the link must contains `zh` otherwise the website will return 404.

What's your opinion?