### PR TITLE
Update server-core-removed-roles.md

### DIFF
--- a/WindowsServerDocs/administration/server-core/server-core-removed-roles.md
+++ b/WindowsServerDocs/administration/server-core/server-core-removed-roles.md
@@ -19,68 +19,67 @@ The following roles, role services, and features have been removed from the Serv
 
 ## Roles not in Server Core
 
-- Fax
-- MultiPointServerRole
-- NPAS
-- WDS
+- Fax Server (**Fax**)
+- MultiPoint Services (**MultiPointServerRole**)
+- Network Policy and Access Services (**NPAS**)
+- Windows Deployment Services (**WDS**) *(before Windows Server version 1803)*
 
 ## Role Services not in Server Core
 Note that some Remote Desktop role services are included in Server Core (Connection Broker, Licensing, Virtualization Host), but others are NOT (Gateway, RD Session Host, Web Access).
 
-- Print-Scan-Server
-- Print-Internet
-- RDS-Gateway
-- RDS-RD-Server
-- RDS-Web-Access
-- Web-Mgmt-Console
-- Web-Lgcy-Mgmt-Console
-- WDS-Deployment
-- WDS-Transport *(before Windows Server version 1803)*
+- Print and Document Services \ Distributed Scan Server (**Print-Scan-Server**)
+- Print and Document Services \ Internet Printing (**Print-Internet**)
+- Remote Desktop Services \ Remote Desktop Gateway (**RDS-Gateway**)
+- Remote Desktop Services \ Remote Desktop Session Host (**RDS-RD-Server**)
+- Remote Desktop Services \ Remote Desktop Web Access (**RDS-Web-Access**)
+- Role Service Web Server (IIS) \ Management Tools \ IIS Management Console (**Web-Mgmt-Console**)
+- Role Service Web Server (IIS) \ Management Tools \ IIS 6 Management Compatibility \ IIS 6 Management Console (**Web-Lgcy-Mgmt-Console**)
+- Windows Deployment Services \ Deployment Server (**WDS-Deployment**)
+- Windows Deployment Services \ Transport Server (**WDS-Transport**) *(before Windows Server version 1803)*
 
 ## Features not in Server Core
-
-- BITS-IIS-Ext
-- BitLocker-NetworkUnlock
-- Direct-Play
-- Internet-Print-Client
-- LPR-Port-Monitor
-- MSMQ-Multicasting
-- CMAK
-- Remote-Assistance
-- RSAT-SMTP
-- RSAT-Feature-Tools-BitLocker-RemoteAdminTool
-- RSAT-Bits-Server
-- RSAT-NLB
-- RSAT-SNMP
-- RSAT-WINS
-- Hyper-V-Tools
-- RSAT-RDS-Tools
-- RSAT-RDS-Gateway
-- RSAT-RDS-Licensing-Diagnosis-UI
-- RDS-Licensing-UI
-- UpdateServices-UI
-- RSAT-ADCS
-- RSAT-ADCS-Mgmt
-- RSAT-Online-Responder
-- RSAT-ADRMS
-- RSAT-Fax
-- RSAT-File-Services
-- RSAT-DFS-Mgmt-Con
-- RSAT-FSRM-Mgmt
-- RSAT-NFS-Admin
-- RSAT-NPAS
-- RSAT-Print-Services
-- RSAT-VA-Tools
-- WDS-AdminPack
-- SMTP-Server
-- TFTP-Client
-- WebDAV-Redirector
-- Biometric-Framework
-- Windows-Defender-Gui
-- Windows-Identity-Foundation
-- PowerShell-ISE
-- Search-Service
-- Windows-TIFF-IFilter
-- Wireless-Networking
-- XPS-Viewer
-
+- Background Intelligent Transfer Service (BITS) \ IIS Server Extension (**BITS-IIS-Ext**)
+- BitLocker Network Unlock (**BitLocker-NetworkUnlock**)
+- Direct Play (**Direct-Play**)
+- Internet Printing Client (**Internet-Print-Client**)
+- LPR Port Monitor (**LPR-Port-Monitor**)
+- Message Queuing \ Message Queuing Services \ Multicasting Support (**MSMQ-Multicasting**)
+- RAS Connection Manager Administration Kit (**CMAK**)
+- Remote Assistance (**Remote-Assistance**)
+- Remote Server Administration Tools \ Feature Administration Tools \ SMTP Server Tools (**RSAT-SMTP**)
+- Remote Server Administration Tools \ Feature Administration Tools \ BitLocker Drive Encryption Administration Utilities \ BitLocker Drive Encryption Tools (**RSAT-Feature-Tools-BitLocker-RemoteAdminTool**)
+- Remote Server Administration Tools \ Feature Administration Tools \ BITS Server Extensions Tools (**RSAT-Bits-Server**)
+- Remote Server Administration Tools \ Feature Administration Tools \ Network Load Balancing Tools (**RSAT-NLB**)
+- Remote Server Administration Tools \ Feature Administration Tools \ SNMP Tools (**RSAT-SNMP**)
+- Remote Server Administration Tools \ Feature Administration Tools \ WINS Server Tools (**RSAT-WINS**)
+- Remote Server Administration Tools \ Role Administration Tools \ Hyper-V Management Tools \ Hyper-V GUI Management Tools (**Hyper-V-Tools**)
+- Remote Server Administration Tools \ Role Administration Tools \ Remote Desktop Services Tools \ Remote Desktop Gateway Tools (**RSAT-RDS-Tools**)
+- Remote Server Administration Tools \ Role Administration Tools \ Remote Desktop Services Tools \ Remote Desktop Gateway Tools (**RSAT-RDS-Gateway**)
+- Remote Server Administration Tools \ Role Administration Tools \ Remote Desktop Services Tools \ Remote Desktop Licensing Diagnoser Tools (**RSAT-RDS-Licensing-Diagnosis-UI**)
+- Remote Server Administration Tools \ Role Administration Tools \ Remote Desktop Services Tools \ Remote Desktop Licensing Tools (**RDS-Licensing-UI**)
+- Remote Server Administration Tools \ Role Administration Tools \ Windows Server Update Services Tools \ User Interface Management Console (**UpdateServices-UI**)
+- Remote Server Administration Tools \ Role Administration Tools \ Active Directory Certificate Services Tools (**RSAT-ADCS**)
+- Remote Server Administration Tools \ Role Administration Tools \ Active Directory Certificate Services Tools \ Certification Authority Management Tools (**RSAT-ADCS-Mgmt**)
+- Remote Server Administration Tools \ Role Administration Tools \ Active Directory Certificate Services Tools \ Online Responder Tools (**RSAT-Online-Responder**)
+- Remote Server Administration Tools \ Role Administration Tools \ Active Directory Rights Management Services Tools (**RSAT-ADRMS**)
+- Remote Server Administration Tools \ Role Administration Tools \ Fax Server Tools (**RSAT-Fax**)
+- Remote Server Administration Tools \ Role Administration Tools \ File Services Tools (**RSAT-File-Services**)
+- Remote Server Administration Tools \ Role Administration Tools \ File Services Tools \ DFS Management Tools (**RSAT-DFS-Mgmt-Con**)
+- Remote Server Administration Tools \ Role Administration Tools \ File Services Tools \ File Server Resource Manager Tools (**RSAT-FSRM-Mgmt**)
+- Remote Server Administration Tools \ Role Administration Tools \ File Services Tools \ Services for Network File System Management Tools (**RSAT-NFS-Admin**)
+- Remote Server Administration Tools \ Role Administration Tools \ Network Policy and Access Services Tools (**RSAT-NPAS**)
+- Remote Server Administration Tools \ Role Administration Tools \ Print and Document Services Tools (**RSAT-Print-Services**)
+- Remote Server Administration Tools \ Role Administration Tools \ Volume Activation Tools (**RSAT-VA-Tools**)
+- Remote Server Administration Tools \ Role Administration Tools \ Windows Deployment Services Tools (**WDS-AdminPack**)
+- Simple TCP/IP Services (**Simple-TCPIP**)
+- SMTP Server (**SMTP-Server**)
+- TFTP Client (**TFTP-Client**)
+- WebDAV Redirector (**WebDAV-Redirector**)
+- Windows Biometric Framework (**Biometric-Framework**)
+- Windows Defender Features \ GUI for Windows Defender (**Windows-Defender-Gui**)
+- Windows Identity Foundation 3.5 (**Windows-Identity-Foundation**)
+- Windows PowerShell \ Windows PowerShell ISE (**PowerShell-ISE**)
+- Windows Search Service (**Search-Service**)
+- Windows TIFF IFilter (**Windows-TIFF-IFilter**)
+- Wireless LAN Service (**Wireless-Networking**)
+- XPS Viewer (**XPS-Viewer**)


### PR DESCRIPTION
Expanded short names to full names with parent paths.

This line is in direct contradiction to the WDS Role not being supported?  If this is supported post 1803 then the role must be supported also.
- Transport Server (WDS-Transport) *(before Windows Server version 1803)*