### PR TITLE
reorder build files

### DIFF
--- a/WindowsServerDocs/docfx.json
+++ b/WindowsServerDocs/docfx.json
@@ -3,8 +3,8 @@
     "content": [
       {
         "files": [
-          "**/*.md",
-          "**/*.yml"
+          "**/*.yml",
+          "**/*.md"
         ],
         "exclude": [
           "**/obj/**",


### PR DESCRIPTION
Redirects in [.openpublishing.redirection.json](https://github.com/MicrosoftDocs/windowsserverdocs/blob/master/.openpublishing.redirection.json#L8620) are not working in live with the current docfx.json. For example, prior to this proposed update WindowsServerDocs/administration/kernel-soft-reboot.md does not redirect to /windows-server/windows-server.

I don't have access to test this proposed change in the review site, so please double check.