### PR TITLE
Fix TraceRPT documentation

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/tracerpt_1.md
+++ b/WindowsServerDocs/administration/windows-commands/tracerpt_1.md
@@ -37,8 +37,8 @@ tracerpt <[-l] <value [value [...]]>|-rt <session_name [session_name [...]]>> [o
 |                   -?                   |                                                         Displays context sensitive help.                                                          |
 |          -config \<filename>           |                                                 Load a settings file containing command options.                                                  |
 |                   -y                   |                                                  Answer yes to all questions without prompting.                                                   |
-|                -f \<XML                |                                                                       HTML>                                                                       |
-|               -of \<CSV                |                                                                       EVTX                                                                        |
+|            -f \<XML\|HTML>             |                                                                  Report format.                                                                   |
+|         -of \<CSV\|EVTX\|XML>          |                                                         Dump format, the default is XML.                                                          |
 |            -df \<filename>             |                                            Create a Microsoft-specific counting/reporting schema file.                                            |
 |            -int \<filename>            |                                            Dump the interpreted event structure to the specified file.                                            |
 |                  -rts                  |                        Report raw timestamp in the event trace header. Can only be used with -o, not -report or -summary.                         |


### PR DESCRIPTION
The TraceRPT help message contains pipe characters, which the autogenerated documentation does not escape correctly.