### PR TITLE
Update sxstrace.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/sxstrace.md
+++ b/WindowsServerDocs/administration/windows-commands/sxstrace.md
@@ -23,32 +23,32 @@ Diagnoses side-by-side problems.
 
 ## Syntax  
 ```  
-sxstrace [{[trace /logfile:<FileName> [/nostop]|[parse /logfile:<FileName> /outfile:<ParsedFile>  [/filter:<AppName>]}]  
+sxstrace [{[trace -logfile:<FileName> [-nostop]|[parse -logfile:<FileName> -outfile:<ParsedFile>  [-filter:<AppName>]}]  
 ```  
 
 ### Parameters  
 |Parameter|Description|  
 |-------|--------|  
 |trace|Enables tracing for sxs (side-by-side)|  
-|/logfile|Specifies the raw log file.|  
+|-logfile|Specifies the raw log file.|  
 |\<FileName>|Saves tracing log to *FileName*.|  
-|/nostop|Specifies no prompt to stop tracing.|  
+|-nostop|Specifies no prompt to stop tracing.|  
 |parse|Translates the raw trace file.|  
-|/outfile|Specifies the output filename.|  
+|-outfile|Specifies the output filename.|  
 |\<ParsedFile>|Specifies the filename of the parsed file.|  
-|/filter|Allows the output to be filtered.|  
+|-filter|Allows the output to be filtered.|  
 |\<AppName>|Specifies the name of the application.|  
 |stoptrace|Stop the trace if it is not stopped before.|  
-|/?|Displays help at the command prompt.|  
+|-?|Displays help at the command prompt.|  
 
 ## <a name="BKMK_Examples"></a>Examples  
 Enable tracing and save trace file to **sxstrace.etl**:  
 ```  
-sxstrace trace /logfile:sxstrace.etl  
+sxstrace trace -logfile:sxstrace.etl  
 ```  
 Translate the raw trace file into a human readable format and save the result to **sxstrace.txt**:  
 ```  
-sxstrace parse /logfile:sxstrace.etl /outfile:sxstrace.txt  
+sxstrace parse -logfile:sxstrace.etl -outfile:sxstrace.txt  
 ```  
 
 ## Additional references  


### PR DESCRIPTION
The `/` style options were not accepted using cmd.exe shell in windows versions: `Win 10 Pro, 1809, OS build 7763.678` and `Win 7 pro version 6.1 build 7601 SP1`