### PR TITLE
PAW/Restrict Administrators: MD indent correction

### DIFF
--- a/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
+++ b/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
@@ -507,7 +507,7 @@ In this section, you will create a new "PAW Configuration - User" GPO which prov
 In this section, we will configure group policies to prevent privileged administrative accounts from logging onto lower tier hosts.
 
 1. Create the new **Restrict Workstation Logon** GPO - this setting will restrict Tier 0 and Tier 1 administrator accounts from logging onto standard workstations.  This GPO should be linked to the "Workstations" top-level OU and have the following settings:
-   - In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job, select **Define these policy settings** and add the Tier 0 and Tier 1 groups:
+   * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job, select **Define these policy settings** and add the Tier 0 and Tier 1 groups:
      ```
      Enterprise Admins
      Domain Admins
@@ -566,7 +566,7 @@ In this section, we will configure group policies to prevent privileged administ
      > Note: This Group was created earlier in Phase 1
 
 2. Create the new **Restrict Server Logon** GPO - this setting will restrict Tier 0 administrator accounts from logging onto Tier 1 servers.  This GPO should be linked to the "Tier 1 Servers" top-level OU and have the following settings:
-   - In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job, select **Define these policy settings** and add the Tier 0 groups:
+   * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job, select **Define these policy settings** and add the Tier 0 groups:
      ```
      Enterprise Admins
      Domain Admins
@@ -590,7 +590,7 @@ In this section, we will configure group policies to prevent privileged administ
      > [!NOTE]
      > Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
 
-   - In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service, select **Define these policy settings** and add the Tier 0 groups:
+   * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service, select **Define these policy settings** and add the Tier 0 groups:
      ```
      Enterprise Admins
      Domain Admins

--- a/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
+++ b/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
@@ -536,7 +536,7 @@ In this section, we will configure group policies to prevent privileged administ
      > [!NOTE]
      > This Group was created earlier in Phase 1.
 
-   - In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service,  select **Define these policy settings** and add the Tier 0 and Tier 1 groups:
+   * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service,  select **Define these policy settings** and add the Tier 0 and Tier 1 groups:
      ```
      Enterprise Admins
      Domain Admins

--- a/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
+++ b/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
@@ -507,125 +507,136 @@ In this section, you will create a new "PAW Configuration - User" GPO which prov
 In this section, we will configure group policies to prevent privileged administrative accounts from logging onto lower tier hosts.
 
 1. Create the new **Restrict Workstation Logon** GPO - this setting will restrict Tier 0 and Tier 1 administrator accounts from logging onto standard workstations.  This GPO should be linked to the "Workstations" top-level OU and have the following settings:
-   * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job, select **Define these policy settings** and add the Tier 0 and Tier 1 groups:
-         Enterprise Admins
-         Domain Admins
-         Schema Admins
-         DOMAIN\Administrators
-         Account Operators
-         Backup Operators
-         Print Operators
-         Server Operators
-         Domain Controllers
-         Read-Only Domain Controllers
-         Group Policy Creators Owners
-         Cryptographic Operators
+   - In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job, select **Define these policy settings** and add the Tier 0 and Tier 1 groups:
+     ```
+     Enterprise Admins
+     Domain Admins
+     Schema Admins
+     DOMAIN\Administrators
+     Account Operators
+     Backup Operators
+     Print Operators
+     Server Operators
+     Domain Controllers
+     Read-Only Domain Controllers
+     Group Policy Creators Owners
+     Cryptographic Operators
+     ```
 
-         > [!NOTE]
-         > Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
-
-         Other Delegated Groups
-
-         > [!NOTE]
-         > Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
-
-         Tier 1 Admins
-
-         > [!NOTE]
-         > This Group was created earlier in Phase 1.
-
-   * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service,  select **Define these policy settings** and add the Tier 0 and Tier 1 groups:
-         Enterprise Admins
-         Domain Admins
-         Schema Admins
-         DOMAIN\Administrators
-         Account Operators
-         Backup Operators
-         Print Operators
-         Server Operators
-         Domain Controllers
-         Read-Only Domain Controllers
-         Group Policy Creators Owners
-         Cryptographic Operators
-
-         > [!NOTE]
-         > Note: Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
+     > [!NOTE]
+     > Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
 
          Other Delegated Groups
 
-         > [!NOTE]
-         > Note: Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
+     > [!NOTE]
+     > Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
 
          Tier 1 Admins
 
-         > [!NOTE]
-         > Note: This Group was created earlier in Phase 1
+     > [!NOTE]
+     > This Group was created earlier in Phase 1.
+
+   - In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service,  select **Define these policy settings** and add the Tier 0 and Tier 1 groups:
+     ```
+     Enterprise Admins
+     Domain Admins
+     Schema Admins
+     DOMAIN\Administrators
+     Account Operators
+     Backup Operators
+     Print Operators
+     Server Operators
+     Domain Controllers
+     Read-Only Domain Controllers
+     Group Policy Creators Owners
+     Cryptographic Operators
+     ```
+
+     > [!NOTE]
+     > Note: Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
+
+         Other Delegated Groups
+
+     > [!NOTE]
+     > Note: Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
+
+         Tier 1 Admins
+
+     > [!NOTE]
+     > Note: This Group was created earlier in Phase 1
 
 2. Create the new **Restrict Server Logon** GPO - this setting will restrict Tier 0 administrator accounts from logging onto Tier 1 servers.  This GPO should be linked to the "Tier 1 Servers" top-level OU and have the following settings:
-   * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job, select **Define these policy settings** and add the Tier 0 groups:
-         Enterprise Admins
-         Domain Admins
-         Schema Admins
-         DOMAIN\Administrators
-         Account Operators
-         Backup Operators
-         Print Operators
-         Server Operators
-         Domain Controllers
-         Read-Only Domain Controllers
-         Group Policy Creators Owners
-         Cryptographic Operators
+   - In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job, select **Define these policy settings** and add the Tier 0 groups:
+     ```
+     Enterprise Admins
+     Domain Admins
+     Schema Admins
+     DOMAIN\Administrators
+     Account Operators
+     Backup Operators
+     Print Operators
+     Server Operators
+     Domain Controllers
+     Read-Only Domain Controllers
+     Group Policy Creators Owners
+     Cryptographic Operators
+     ```
 
-         > [!NOTE]
-         > Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
-
-         Other Delegated Groups
-
-         > [!NOTE]
-         > Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
-
-   * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service, select **Define these policy settings** and add the Tier 0 groups:
-         Enterprise Admins
-         Domain Admins
-         Schema Admins
-         DOMAIN\Administrators
-         Account Operators
-         Backup Operators
-         Print Operators
-         Server Operators
-         Domain Controllers
-         Read-Only Domain Controllers
-         Group Policy Creators Owners
-         Cryptographic Operators
-
-         > [!NOTE]
-         > Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
+     > [!NOTE]
+     > Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
 
          Other Delegated Groups
 
-         > [!NOTE]
-         > Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
+     > [!NOTE]
+     > Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
+
+   - In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service, select **Define these policy settings** and add the Tier 0 groups:
+     ```
+     Enterprise Admins
+     Domain Admins
+     Schema Admins
+     DOMAIN\Administrators
+     Account Operators
+     Backup Operators
+     Print Operators
+     Server Operators
+     Domain Controllers
+     Read-Only Domain Controllers
+     Group Policy Creators Owners
+     Cryptographic Operators
+     ```
+
+     > [!NOTE]
+     > Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
+
+         Other Delegated Groups
+
+     > [!NOTE]
+     > Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
 
    * In Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on locally, select **Define these policy settings** and add the Tier 0 groups:
-         Enterprise Admins
-         Domain Admins
-         Schema Admins
-         Account Operators
-         Backup Operators
-         Print Operators
-         Server Operators
-         Domain Controllers
-         Read-Only Domain Controllers
-         Group Policy Creators Owners
-         Cryptographic Operators
+     ```
+     Enterprise Admins
+     Domain Admins
+     Schema Admins
+     DOMAIN\Administrators
+     Account Operators
+     Backup Operators
+     Print Operators
+     Server Operators
+     Domain Controllers
+     Read-Only Domain Controllers
+     Group Policy Creators Owners
+     Cryptographic Operators
+     ```
 
-         > [!NOTE]
-         > Note: Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
+     > [!NOTE]
+     > Note: Built-in Tier 0 Groups, see Tier 0 equivalency for more details.
 
          Other Delegated Groups
 
-         > [!NOTE]
-         > Note: Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
+     > [!NOTE]
+     > Note: Any custom created groups with effective Tier 0 access, see Tier 0 equivalency for more details.
 
 #### Deploy your PAW(s)
 


### PR DESCRIPTION
**Description:**

Privileged Access Workstations, section "Restrict Administrators from logging onto lower tier hosts"
(https://docs.microsoft.com/en-us/windows-server/identity/securing-privileged-access/privileged-access-workstations#restrict-administrators-from-logging-onto-lower-tier-hosts) 
(https://bit.ly/2msYHyz in case the long URL breaks) 
shows several Note sections marked as code to be copied and pasted, instead of having only the list of users/groups marked as code.

**Proposed changes:**
This PR aims to resolve this MarkDown mix-up issue by standardizing the indents of this section, to keep them within the same grouping.
MarkDown code fences around multi-line lists is also encouraged.

**issue ticket closure or reference:**

This indent issue is not reported as such, I discovered the issue after reading the ticket #1618 (Can't add DOMAIN\Administrators).