### PR TITLE
Get Started/Manage Nano Server: add missing space

### DIFF
--- a/WindowsServerDocs/get-started/Manage-Nano-Server.md
+++ b/WindowsServerDocs/get-started/Manage-Nano-Server.md
@@ -202,7 +202,7 @@ $scanResults = Invoke-CimMethod -InputObject $sess -MethodName ScanForUpdates -A
 **Note:**  
 These commands list what is installed, but do not specifically quote "installed" in the output. If you need output including that, such as for a report, you can run  
 ```PowerShell
-Get-WindowsPackage --Online
+Get-WindowsPackage -Online
 ```
 
 ### Using WSUS  

--- a/WindowsServerDocs/get-started/Manage-Nano-Server.md
+++ b/WindowsServerDocs/get-started/Manage-Nano-Server.md
@@ -201,9 +201,9 @@ $scanResults = Invoke-CimMethod -InputObject $sess -MethodName ScanForUpdates -A
 
 **Note:**  
 These commands list what is installed, but do not specifically quote "installed" in the output. If you need output including that, such as for a report, you can run  
-```  
-Get-WindowsPackage--Online  
-```  
+```PowerShell
+Get-WindowsPackage --Online
+```
 
 ### Using WSUS  
 ---  


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3372, the command `Get-WindowsPackage--Online`
is missing a space before the command argument.

**Proposed changes:**
- add the missing space in the command
- add "PowerShell" for code block syntax highlighting
- remove redundant white space at the line ends

(The whole document page contains a lot of redundant white space,
 but that is beyond the scope of this Pull Request.)

Thanks to @oneoneonepig for reporting this command example typo.

**issue ticket closure or reference:**

Closes #3372