### PR TITLE
Update rdpsign.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/rdpsign.md
+++ b/WindowsServerDocs/administration/windows-commands/rdpsign.md
@@ -33,14 +33,15 @@ rdpsign /sha1 <hash> [/q | /v |] [/l] <file_name.rdp>
 
 |Parameter|Description|
 |-------|--------|
-|/sha1 \<hash>|Specifies the thumbprint, which is the Secure Hash Algorithm 1 (SHA1) hash of the signing certificate that is included in the certificate store.|
+|/sha1 \<hash>|Specifies the thumbprint, which is the Secure Hash Algorithm 1 (SHA1) hash of the signing certificate that is included in the certificate store. Used in Windows Server 2012 R2 and older.|
+|/sha256 \<hash>|Specifies the thumbprint, which is the Secure Hash Algorithm 256 (SHA256) hash of the signing certificate that is included in the certificate store. Replaces /sha1 in Windows Server 2016 and newer.|
 |/q|Quiet mode. No output when the command succeeds and minimal output if the command fails.|
 |/v|verbose mode. Displays all warnings, messages, and status.|
 |/l|Tests the signing and output results without actually replacing any of the input files.|
 |/?|Displays help at the command prompt.|
 
 ## Remarks
--   The SHA1 certificate thumbprint should represent a trusted .rdp file publisher. To obtain the certificate thumbprint, open the Certificates snap-in, double-click the certificate that you want to use (either in the local computer's certificates store or in your personal certificates store), click the **details** tab, and then in the **Field** list, click **Thumbprint**.
+-   The SHA1 or SHA256 certificate thumbprint should represent a trusted .rdp file publisher. To obtain the certificate thumbprint, open the Certificates snap-in, double-click the certificate that you want to use (either in the local computer's certificates store or in your personal certificates store), click the **details** tab, and then in the **Field** list, click **Thumbprint**.
 
     > [!NOTE]
     > When you copy the thumbprint for use with the rdpsign.exe tool, you must remove any spaces.


### PR DESCRIPTION
Added in the /sha256 parameter, which has replaced /sha1 as of Windows Server 2016, as well as clarification of which command to use when.