### PR TITLE
Add supported feature SecureBoot in Debian Buster

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/Supported-Debian-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-Debian-virtual-machines-on-Hyper-V.md
@@ -62,7 +62,7 @@ The following feature distribution map indicates the features that are present i
 | PCI Passthrough/DDA                                                                                                                          | 2019, 2016                                  | &#10004; Note 8       | &#10004; Note 8       |                       |                       |
 | **[Generation 2 virtual machines](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#generation-2-virtual-machines)** |                                             |                       |                       |                       |                       |
 | Boot using UEFI                                                                                                                              | 2019, 2016, 2012 R2                         | &#10004; Note 7       | &#10004; Note 7       | &#10004; Note 7       |                       |
-| Secure boot                                                                                                                                  | 2019, 2016                                  |                       |                       |                       |                       |
+| Secure boot                                                                                                                                  | 2019, 2016                                  | &#10004;              |                       |                       |                       |
 
 
 ## <a name="BKMK_notes"></a>Notes


### PR DESCRIPTION
Closes #3048 

This PR indicates the supported Secure Boot feature available since Debian Buster.