### PR TITLE
Update Hyper-V and Debian versions

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/Supported-Debian-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-Debian-virtual-machines-on-Hyper-V.md
@@ -14,7 +14,7 @@ ms.date: 10/03/2016
 ---
 # Supported Debian virtual machines on Hyper-V
 
->Applies To: Windows Server 2016, Hyper-V Server 2016, Windows Server 2012 R2, Hyper-V Server 2012 R2, Windows Server 2012, Hyper-V Server 2012, Windows Server 2008 R2, Windows 10, Windows 8.1, Windows 8, Windows 7.1, Windows 7
+>Applies To: Windows Server 2019, Hyper-V Server 2019, Windows Server 2016, Hyper-V Server 2016, Windows Server 2012 R2, Hyper-V Server 2012 R2, Windows Server 2012, Hyper-V Server 2012, Windows Server 2008 R2, Windows 10, Windows 8.1, Windows 8, Windows 7.1, Windows 7
 
 The following feature distribution map indicates the features that are present in each version. The known issues and workarounds for each distribution are listed after the table.
 
@@ -26,7 +26,7 @@ The following feature distribution map indicates the features that are present i
 
 * (*blank*) - Feature not available
 
-| **Feature**                                                                                                                                  | **Windows Server operating system version** | **10 (buster)** | **9.0-9.6 (stretch)** | **8.0-8.11 (jessie)** | **7.0-7.11 (wheezy)** |
+| **Feature**                                                                                                                                  | **Windows Server operating system version** | **10.x (buster)** | **9.x (stretch)** | **8.x (jessie)** | **7.x (wheezy)** |
 |----------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------|-----------------------|-----------------------|-----------------------|-----------------------|
 | **Availability**                                                                                                                             |                                             | Built in              | Built in              | Built in              | Built in (Note 6)     |
 | **[Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#core)**                                                   | 2019, 2016, 2012 R2, 2012, 2008 R2          | &#10004;              | &#10004;              | &#10004;              | &#10004;              |


### PR DESCRIPTION
**Updated Hyper-V Versions**
The documentation `Applies to` section is updated to include Server 2019 and Hyper-V 2019.

**Updated Debian Versions**
All Debian versions are updated to use `MAJOR.x` version naming convention to reduce the need to regularly update this section on the latest compatibility. In any case, this page is not regularly updated anyway, so keeping to this style will avoid giving readers the ambiguity as to whether a new minor version of Debian is supported by Hyper-V or not.