### PR TITLE
Syntax fix to show the actual command

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/wmic.md
+++ b/WindowsServerDocs/administration/windows-commands/wmic.md
@@ -26,7 +26,7 @@ For examples of how to use this command, see [Examples](#BKMK_examples).
 ## Syntax
 
 ```
-command </parameter>
+wmic </parameter>
 ```
 
 ## Sub-commands
@@ -39,14 +39,6 @@ The following sub-commands are available at all times:
 |path|Escapes from the default alias mode of WMIC to access instances in the WMI schema directly.|
 |context|Displays the current values of all global switches.|
 |[quit \| exit]|Exits the WMIC command shell.|
-
-## Parameters
-
-|Parameter|Description|
-|---------|-----------|
-|</parameter>|\<Concise description, starts with a verb.>|
-|</param2>|\<Another concise description, starts with a verb.>|
-
 
 ## <a name="BKMK_examples"></a>Examples
 


### PR DESCRIPTION
And removed the parameters section, since it was empty. Furthermore, shouldn't it be the same as [win32/wmisdk/wmic](https://docs.microsoft.com/en-us/windows/win32/wmisdk/wmic)?