### PR TITLE
Privileged Access Workstations: DOMAIN vs BUILTIN

### DIFF
--- a/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
+++ b/WindowsServerDocs/identity/securing-privileged-access/privileged-access-workstations.md
@@ -512,7 +512,7 @@ In this section, we will configure group policies to prevent privileged administ
      Enterprise Admins
      Domain Admins
      Schema Admins
-     DOMAIN\Administrators
+     BUILTIN\Administrators
      Account Operators
      Backup Operators
      Print Operators
@@ -541,7 +541,7 @@ In this section, we will configure group policies to prevent privileged administ
      Enterprise Admins
      Domain Admins
      Schema Admins
-     DOMAIN\Administrators
+     BUILTIN\Administrators
      Account Operators
      Backup Operators
      Print Operators
@@ -571,7 +571,7 @@ In this section, we will configure group policies to prevent privileged administ
      Enterprise Admins
      Domain Admins
      Schema Admins
-     DOMAIN\Administrators
+     BUILTIN\Administrators
      Account Operators
      Backup Operators
      Print Operators
@@ -595,7 +595,7 @@ In this section, we will configure group policies to prevent privileged administ
      Enterprise Admins
      Domain Admins
      Schema Admins
-     DOMAIN\Administrators
+     BUILTIN\Administrators
      Account Operators
      Backup Operators
      Print Operators
@@ -619,7 +619,7 @@ In this section, we will configure group policies to prevent privileged administ
      Enterprise Admins
      Domain Admins
      Schema Admins
-     DOMAIN\Administrators
+     BUILTIN\Administrators
      Account Operators
      Backup Operators
      Print Operators


### PR DESCRIPTION
**Description:**

According to user feedback and various Microsoft documentation, the local Administrators' group belong to the BUILTIN category.
There is no category named "DOMAIN" in the AD object browser.

Thanks to @MichaelFirsov for reporting this issue and to @4fd81048a9cd8a3fd43f1f4e52f84181 (Brian Buchanan) for referencing existing material documenting this fact.
- https://docs.microsoft.com/en-us/windows-server/identity/securing-privileged-access/securing-privileged-access-reference-material?redirectedfrom=MSDN#tier-0-equivalency

**Changes proposed:**

- replace "DOMAIN\Administrators" with BUILTIN\Administrators (5 occurrences)

**issue ticket closure or reference:**

Closes #1618