### PR TITLE
IP Address Management/broken link: Server cmdlets

### DIFF
--- a/WindowsServerDocs/networking/technologies/ipam/ipam-top.md
+++ b/WindowsServerDocs/networking/technologies/ipam/ipam-top.md
@@ -15,14 +15,14 @@ author: shortpatti
 ---
 # IP Address Management (IPAM)
 
->Applies to: Windows Server (Semi-Annual Channel), Windows Server 2016
+> Applies to: Windows Server (Semi-Annual Channel), Windows Server 2016
 
-IP Address Management (IPAM) is an integrated suite of tools to enable end-to-end planning, deploying, managing and monitoring of your IP address infrastructure, with a rich user experience. IPAM automatically discovers IP address infrastructure servers and Domain Name System (DNS) servers on your network and enables you to manage them from a central interface.  
-  
-> [!NOTE]  
-> In addition to this topic, the following IPAM content is available.  
->   
-> -   [What's New in IPAM](../../technologies/ipam/What-s-New-in-IPAM.md)  
-> -   [Manage IPAM](../../technologies/ipam/Manage-IPAM.md)  
-> -   [IP Address Management (IPAM) Server Cmdlets in Windows PowerShell](https://technet.microsoft.com/library/jj553807.aspx)  
-> -   Video: [Windows Server 2016: DNS management in IPAM](https://channel9.msdn.com/Blogs/windowsserver/Windows-Server-2016-DNS-management-in-IPAM)  
+IP Address Management (IPAM) is an integrated suite of tools to enable end-to-end planning, deploying, managing and monitoring of your IP address infrastructure, with a rich user experience. IPAM automatically discovers IP address infrastructure servers and Domain Name System (DNS) servers on your network and enables you to manage them from a central interface.
+
+> [!NOTE]
+> In addition to this topic, the following IPAM content is available.
+>
+> - [What's New in IPAM](../../technologies/ipam/What-s-New-in-IPAM.md)
+> - [Manage IPAM](../../technologies/ipam/Manage-IPAM.md)
+> - [IP Address Management (IPAM) Server Cmdlets in Windows PowerShell](https://docs.microsoft.com/en-us/powershell/module/ipamserver/?view=win10-ps)
+> - Video: [Windows Server 2016: DNS management in IPAM](https://channel9.msdn.com/Blogs/windowsserver/Windows-Server-2016-DNS-management-in-IPAM)

--- a/WindowsServerDocs/networking/technologies/ipam/ipam-top.md
+++ b/WindowsServerDocs/networking/technologies/ipam/ipam-top.md
@@ -24,5 +24,5 @@ IP Address Management (IPAM) is an integrated suite of tools to enable end-to-en
 >
 > - [What's New in IPAM](../../technologies/ipam/What-s-New-in-IPAM.md)
 > - [Manage IPAM](../../technologies/ipam/Manage-IPAM.md)
-> - [IP Address Management (IPAM) Server Cmdlets in Windows PowerShell](https://docs.microsoft.com/en-us/powershell/module/ipamserver/?view=win10-ps)
+> - [IP Address Management (IPAM) Server Cmdlets in Windows PowerShell](https://docs.microsoft.com/powershell/module/ipamserver/?view=win10-ps)
 > - Video: [Windows Server 2016: DNS management in IPAM](https://channel9.msdn.com/Blogs/windowsserver/Windows-Server-2016-DNS-management-in-IPAM)


### PR DESCRIPTION
**Description:**

Based on community feedback in issue ticket #3477 and #608, the link to
IP Address Management (IPAM) Server Cmdlets in Windows PowerShell
is broken again, if it was ever fixed back in April 2018.

Thanks to @vicslive and @Verox- for reporting this issue, even though
this did not get noticed before today in the new issue ticket (#3477).

**Changes proposed:**
- replace the broken TechNet link with a working docs.microsoft.com one
- clear up whitespace for codestyle adherence

**issue ticket closure or reference:**

Closes #3477