### PR TITLE
EssentialsDocs/install: remove wrong MD code block

### DIFF
--- a/EssentialsDocs/install/Before-You-Install-Windows-Server-Essentials.md
+++ b/EssentialsDocs/install/Before-You-Install-Windows-Server-Essentials.md
@@ -22,11 +22,8 @@ manager: dongill
 
 -   **Ensure that your computer meets the minimum hardware requirements**. This includes determining if you need additional hardware and verifying that the drivers for your hardware are supported by  Windows Server Essentials. For more information, see [System Requirements for Windows Server Essentials](../get-started/system-requirements.md).   
 
-
-~~~
 > [!IMPORTANT]
->  Before you install  Windows Server Essentials on a pre-existing computer, we recommend that you fully format and then repartition the hard disks of the pre-existing computer. By formatting and repartitioning the hard disks, you remove the possibility that hidden partitions remain on the hard disks.  
-~~~
+> Before you install  Windows Server Essentials on a pre-existing computer, we recommend that you fully format and then repartition the hard disks of the pre-existing computer. By formatting and repartitioning the hard disks, you remove the possibility that hidden partitions remain on the hard disks.  
 
 - **Prepare your network** To prepare your network to install  Windows Server Essentials, do the following:  
 


### PR DESCRIPTION
**Description:**

As pointed out in issue ticket #3495 (Rendering Issue with "Before You Install Windows Server Essentials" page), an Important Note blurb is incorrectly wrapped in a MarkDown code block, disabling the rendering of the MD Note blurb code.

Thanks to Werner Strydom (@bloudraak) for reporting this page issue.

**Changes proposed:**

- remove the 2 code block lines, containing 3 tildes in each
- remove a redundant blank line
- remove a redundant blank character space (whitespace)

**issue ticket closure or reference:**

Closes #3495