### PR TITLE
Added /elevate to start command

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/start.md
+++ b/WindowsServerDocs/administration/windows-commands/start.md
@@ -27,7 +27,7 @@ For examples of how to use this command, see [Examples](#BKMK_examples).
 ## Syntax
 
 ```
-start ["<Title>"] [/d <Path>] [/i] [{/min | /max}] [{/separate | /shared}] [{/low | /normal | /high | /realtime | /abovenormal | belownormal}] [/affinity <HexAffinity>] [/wait] [/b {<Command> | <Program>} [<Parameters>]]
+start ["<Title>"] [/d <Path>] [/i] [{/min | /max}] [{/separate | /shared}] [{/low | /normal | /high | /realtime | /abovenormal | belownormal}] [/affinity <HexAffinity>] [/wait] [/elevate] [/b {<Command> | <Program>} [<Parameters>]]
 ```
 
 ## Parameters
@@ -42,6 +42,7 @@ start ["<Title>"] [/d <Path>] [/i] [{/min | /max}] [{/separate | /shared}] [{/lo
 |/low \| /normal \| /high \| /realtime \| /abovenormal \| /belownormal|Starts an application in the specified priority class. Valid priority class values are **/low**, **/normal**, **/high**, **/realtime**, **/abovenormal**, and **/belownormal**.|
 |/affinity \<HexAffinity>|Applies the specified processor affinity mask (expressed as a hexadecimal number) to the new application.|
 |/wait|Starts an application and waits for it to end.|
+|/elevate|Runs application as administrator.|
 |/b|Starts an application without opening a new Command Prompt window. CTRL+C handling is ignored unless the application enables CTRL+C processing. Use CTRL+BREAK to interrupt the application.|
 |/b \<Command> \| \<Program>|Specifies the command or program to start.|
 |\<Parameters>|Specifies parameters to pass to the command or program.|


### PR DESCRIPTION
fixes #3520 

This command flag was missing from the documentation.