### PR TITLE
AD FS OBO/user_impersonation scope: revert URL

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/development/ad-fs-on-behalf-of-authentication-in-windows-server.md
+++ b/WindowsServerDocs/identity/ad-fs/development/ad-fs-on-behalf-of-authentication-in-windows-server.md
@@ -125,7 +125,7 @@ In order to enable on-behalf-of authentication, we need to ensure that AD FS ret
     => issue(claim = c);
 
     @RuleName = "Issue user_impersonation scope"
-    => issue(Type = "https://schemas.microsoft.com/identity/claims/scope", Value = "user_impersonation");
+    => issue(Type = "http://schemas.microsoft.com/identity/claims/scope", Value = "user_impersonation");
 
 ![AD FS OBO](media/AD-FS-On-behalf-of-Authentication-in-Windows-Server-2016/ADFS_OBO10.PNG)
 


### PR DESCRIPTION
**Description:**

As pointed out in the issue ticket #3000 (**Typo in user_impersonation claim issuance that prevents tutorial from working**), the URL should be http instead of https to make AD FS 2016 issue the SCP claim on the JWT token.

The occurrence of https in this scenario comes from commit bbc102cb76cc where 765 files had their URL changed from http to https for normal URL links used in public pages, regardless of code or non-code URLs.
This PR change effectively reverts this specific URL in a code sample.

Thanks to @tobyartisan for reporting and pointing out this issue, as well as @riesm for confirming the issue.

**Proposed change:**

- Change https back to http to make the code work as described.

**issue closure or reference:**

Closes #3000