### PR TITLE
Update getting-started-with-group-managed-service-accounts.md

### DIFF
--- a/WindowsServerDocs/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts.md
+++ b/WindowsServerDocs/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts.md
@@ -161,7 +161,7 @@ Membership in **Domain Admins**, **Account Operators** or ability to create msDS
     |ManagedPasswordIntervalInDays|Password change interval in days (default is 30 days if not provided)|90|
     |PrincipalsAllowedToRetrieveManagedPassword|The computer accounts of the member hosts or the security group that the member hosts are a member of|ITFarmHosts|
     |SamAccountName|NetBIOS name for the service if not same as Name|ITFarm1|
-    |ServicePrincipalNames|Service Principal Names (SPNs) for the service|http/ITFarm1.contoso.com/contoso.com, http/ITFarm1.contoso.com/contoso, http/ITFarm1/contoso.com, http/ITFarm1/contoso, MSSSQLSvc/ITFarm1.contoso.com:1433, MSSQLSvc/ITFarm1.contoso.com:INST01|
+    |ServicePrincipalNames|Service Principal Names (SPNs) for the service|http/ITFarm1.contoso.com/contoso.com, http/ITFarm1.contoso.com/contoso, http/ITFarm1/contoso.com, http/ITFarm1/contoso, MSSQLSvc/ITFarm1.contoso.com:1433, MSSQLSvc/ITFarm1.contoso.com:INST01|
 
     > [!IMPORTANT]
     > The password change interval can only be set during creation. If you need to change the interval, you must create a new gMSA and set it at creation time.

--- a/WindowsServerDocs/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts.md
+++ b/WindowsServerDocs/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts.md
@@ -141,19 +141,23 @@ You can create a gMSA only if the forest schema has been updated to  Windows Ser
 
 Membership in **Domain Admins**, **Account Operators** or ability to create msDS-GroupManagedServiceAccount objects, is the minimum required to complete the following procedures.
 
+> [!NOTE]
+> A value for the -Name parameter is always required (whether you specify -Name or not), with -DNSHostName, -RestrictToSingleComputer, and -RestrictToOutboundAuthentication being secondary requirements for the three deployment scenarios.    
+
+
 #### <a name="BKMK_CreateGMSA"></a>To create a gMSA using the New-ADServiceAccount cmdlet
 
 1.  On the Windows Server 2012 domain controller, run Windows PowerShell from the Taskbar.
 
 2.  At the command prompt for the Windows PowerShell, type the following commands, and then press ENTER. (The Active Directory module will load automatically.)
 
-    **New-ADServiceAccount [-Name] <string> -DNSHostName <string> [-KerberosEncryptionType <ADKerberosEncryptionType>] [-ManagedPasswordIntervalInDays <Nullable[Int32]>] [-PrincipalsAllowedToRetrieveManagedPassword <ADPrincipal[]>] -SamAccountName <string> -ServicePrincipalNames <string[]>**
+    **New-ADServiceAccount [-Name] &lt;string&gt; -DNSHostName &lt;string&gt; [-KerberosEncryptionType &lt;ADKerberosEncryptionType&gt;] [-ManagedPasswordIntervalInDays <Nullable[Int32]>] [-PrincipalsAllowedToRetrieveManagedPassword <ADPrincipal[]>] [-SamAccountName &lt;string&gt;] [-ServicePrincipalNames <string[]>]**
 
     |Parameter|String|Example|
     |-------|-----|------|
     |Name|Name of the account|ITFarm1|
     |DNSHostName|DNS host name of service|ITFarm1.contoso.com|
-    |KerberosEncryptionType|Any encryption types supported by the host servers|RC4, AES128, AES256|
+    |KerberosEncryptionType|Any encryption types supported by the host servers|None, RC4, AES128, AES256|
     |ManagedPasswordIntervalInDays|Password change interval in days (default is 30 days if not provided)|90|
     |PrincipalsAllowedToRetrieveManagedPassword|The computer accounts of the member hosts or the security group that the member hosts are a member of|ITFarmHosts|
     |SamAccountName|NetBIOS name for the service if not same as Name|ITFarm1|
@@ -161,7 +165,7 @@ Membership in **Domain Admins**, **Account Operators** or ability to create msDS
 
     > [!IMPORTANT]
     > The password change interval can only be set during creation. If you need to change the interval, you must create a new gMSA and set it at creation time.
-
+   
     **Example**
 
     Enter the command on a single line, even though they might appear word-wrapped across several lines here because of formatting constraints.
@@ -179,7 +183,7 @@ Membership in **Domain Admins**, **Account Operators**, or ability to create msD
 
 2.  At the command prompt for the Windows PowerShell Active Directory module, type the following commands, and then press ENTER:
 
-    **New-ADServiceAccount [-Name] <string> -RestrictToOutboundAuthenticationOnly [-ManagedPasswordIntervalInDays <Nullable[Int32]>] [-PrincipalsAllowedToRetrieveManagedPassword <ADPrincipal[]>]**
+    **New-ADServiceAccount [-Name] &lt;string&gt; -RestrictToOutboundAuthenticationOnly [-ManagedPasswordIntervalInDays <Nullable[Int32]>] [-PrincipalsAllowedToRetrieveManagedPassword <ADPrincipal[]>]**
 
     |Parameter|String|Example|
     |-------|-----|------|
@@ -189,8 +193,8 @@ Membership in **Domain Admins**, **Account Operators**, or ability to create msD
 
     > [!IMPORTANT]
     > The password change interval can only be set during creation. If you need to change the interval, you must create a new gMSA and set it at creation time.
-
-**Example**
+    
+  **Example**
 
 ```
 New-ADServiceAccount ITFarm1 -RestrictToOutboundAuthenticationOnly - PrincipalsAllowedToRetrieveManagedPassword ITFarmHosts
@@ -241,11 +245,11 @@ Membership in **Domain Admins**, **Account Operators**, or ability to manage msD
 
 2.  At the command prompt for the Windows PowerShell Active Directory module, type the following commands, and then press ENTER:
 
-    **Get-ADServiceAccount [-Name] <string> -PrincipalsAllowedToRetrieveManagedPassword**
+    **Get-ADServiceAccount [-Name] &lt;string&gt; -PrincipalsAllowedToRetrieveManagedPassword**
 
 3.  At the command prompt for the Windows PowerShell Active Directory module, type the following commands, and then press ENTER:
 
-    **Set-ADServiceAccount [-Name] <string> -PrincipalsAllowedToRetrieveManagedPassword <ADPrincipal[]>**
+    **Set-ADServiceAccount [-Name] &lt;string&gt; -PrincipalsAllowedToRetrieveManagedPassword <ADPrincipal[]>**
 
 |Parameter|String|Example|
 |-------|-----|------|
@@ -301,11 +305,11 @@ Membership in **Domain Admins**, **Account Operators**, or ability to manage msD
 
 2.  At the command prompt for the Windows PowerShell Active Directory module, type the following commands, and then press ENTER:
 
-    **Get-ADServiceAccount [-Name] <string> -PrincipalsAllowedToRetrieveManagedPassword**
+    **Get-ADServiceAccount [-Name] &lt;string&gt; -PrincipalsAllowedToRetrieveManagedPassword**
 
 3.  At the command prompt for the Windows PowerShell Active Directory module, type the following commands, and then press ENTER:
 
-    **Set-ADServiceAccount [-Name] <string> -PrincipalsAllowedToRetrieveManagedPassword <ADPrincipal[]>**
+    **Set-ADServiceAccount [-Name] &lt;string&gt; -PrincipalsAllowedToRetrieveManagedPassword <ADPrincipal[]>**
 
 |Parameter|String|Example|
 |-------|-----|------|
@@ -337,7 +341,7 @@ Membership in **Administrators**, or equivalent, is the minimum required to comp
 
 2.  At the command prompt for the Windows PowerShell Active Directory module, type the following commands, and then press ENTER:
 
-    **Uninstall-ADServiceAccount < ADServiceAccount>**
+    **Uninstall-ADServiceAccount &lt;ADServiceAccount&gt;**
 
     **Example**
 

--- a/WindowsServerDocs/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts.md
+++ b/WindowsServerDocs/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts.md
@@ -161,7 +161,7 @@ Membership in **Domain Admins**, **Account Operators** or ability to create msDS
     |ManagedPasswordIntervalInDays|Password change interval in days (default is 30 days if not provided)|90|
     |PrincipalsAllowedToRetrieveManagedPassword|The computer accounts of the member hosts or the security group that the member hosts are a member of|ITFarmHosts|
     |SamAccountName|NetBIOS name for the service if not same as Name|ITFarm1|
-    |ServicePrincipalNames|Service Principal Names (SPNs) for the service|http/ITFarm1.contoso.com/contoso.com, http/ITFarm1.contoso.com/contoso, http/ITFarm1/contoso.com, http/ITFarm1/contoso|
+    |ServicePrincipalNames|Service Principal Names (SPNs) for the service|http/ITFarm1.contoso.com/contoso.com, http/ITFarm1.contoso.com/contoso, http/ITFarm1/contoso.com, http/ITFarm1/contoso, MSSSQLSvc/ITFarm1.contoso.com:1433, MSSQLSvc/ITFarm1.contoso.com:INST01|
 
     > [!IMPORTANT]
     > The password change interval can only be set during creation. If you need to change the interval, you must create a new gMSA and set it at creation time.


### PR DESCRIPTION
The current document has incorrect syntax for many of the commands.  Changed <string> to &lt;string&gt; in all scenarios to ensure that the code snippets were displayed correctly, as well as any other less-than/greater-than scenarios.  Added a note about the syntax of the command, as example 1 had some optional switches outside of [square brackets], causing confusion.