### PR TITLE
Remote Access/IP Helper service: PS cmdlet typo

### DIFF
--- a/WindowsServerDocs/remote/remote-access/ras/monitoring-and-accounting/Identify-and-resolve-Remote-Access-server-operations-problems.md
+++ b/WindowsServerDocs/remote/remote-access/ras/monitoring-and-accounting/Identify-and-resolve-Remote-Access-server-operations-problems.md
@@ -70,7 +70,7 @@ Turning off the IP Helper service will cause a serious error on the Remote Acces
   
     **Resolution**  
   
-    1.  To ensure that the service is running, type **Get-Service iphlpsc** at a Windows PowerShell prompt.  
+    1.  To ensure that the service is running, type **Get-Service iphlpsvc** at a Windows PowerShell prompt.  
   
     2.  To enable the service, type **Start-Service iphlpsvc** from an elevated Windows PowerShell prompt.  
   
@@ -89,9 +89,6 @@ To restore the IP Helper service on your Remote Access server, you can follow th
   
 The following Windows PowerShell cmdlet or cmdlets perform the same function as the preceding procedure. Enter each cmdlet on a single line, even though they may appear word-wrapped across several lines here because of formatting constraints.  
   
-```  
+```PowerShell
 PS> Get-RemoteAccessHealth | Where-Object {$_.Component -eq "IP-HTTPS"} | Format-List -Property *  
-```  
-  
-
-
+```


### PR DESCRIPTION
**Description:**

As described in issue ticket #3568 (It appears there is a spelling mistake on the page.), the service name IPHlpSvc is misspelled in the PowerShell cmdlet to use for checking if the service is running.

Thank you to @termanix for finding and reporting this typo.

**Proposed changes:**

- add the missing letter v to "iphlpsc" in the cmdlet
- add the MD syntax highlight keyword PowerShell to the MD code block
- remove the empty whitespace lines at the end of the document

**issue ticket closure or reference:**

Closes #3568