### PR TITLE
OpenSSH/Key Management: simple path typo

### DIFF
--- a/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
+++ b/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
@@ -141,7 +141,7 @@ After completing these steps, whenever a private key is needed for authenticatio
 
 ## Deploying the public key
 
-To use the user key that was created above, the public key needs to be placed on the server into a text file called *authorized_keys* under users\username\ssh. 
+To use the user key that was created above, the public key needs to be placed on the server into a text file called *authorized_keys* under users\username\.ssh\. 
 The OpenSSH tools include scp, which is a secure file-transfer utility, to help with this.
 
 To move the contents of your public key (~\.ssh\id_ed25519.pub) into a text file called authorized_keys in ~\.ssh\ on your server/host.


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3570, the path to _authorized_keys_ on this page is missing a period as part of the name of the specific directory.

Thanks to @p-equals-np for reporting this typo.

**Proposed change:**
- add the missing period to the ssh directory name
- add an ending backslash to mark the path end (which also matches logically with the period ending the sentence)

**issue ticket closure or reference:**

Closes #3570