### PR TITLE
Fix Protected Users event logs location

### DIFF
--- a/WindowsServerDocs/security/credentials-protection-and-management/protected-users-security-group.md
+++ b/WindowsServerDocs/security/credentials-protection-and-management/protected-users-security-group.md
@@ -109,7 +109,7 @@ Non-configurable settings to the TGTs expiration are established for every accou
 For more information, see [How to Configure Protected Accounts](how-to-configure-protected-accounts.md).
 
 ## Troubleshooting
-Two operational administrative logs are available to help troubleshoot events that are related to Protected Users. These new logs are located in Event Viewer and are disabled by default, and are located under **Applications and Services Logs\Microsoft\Windows\Microsoft\Authentication**.
+Two operational administrative logs are available to help troubleshoot events that are related to Protected Users. These new logs are located in Event Viewer and are disabled by default, and are located under **Applications and Services Logs\Microsoft\Windows\Authentication**.
 
 |Event ID and Log|Description|
 |----------|--------|


### PR DESCRIPTION
Here is an example of the path:
![image](https://user-images.githubusercontent.com/550823/71258838-6ac9b980-2337-11ea-9808-14bc5d2d3cab.png)
