### PR TITLE
Windows Commands/Secedit: add missing slash

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/secedit-generaterollback.md
+++ b/WindowsServerDocs/administration/windows-commands/secedit-generaterollback.md
@@ -24,7 +24,7 @@ Allows you to generate a rollback template for a specified configuration templat
 ## Syntax
 
 ```
-Secedit /generaterollback /db <database file name> /cfg <configuration file name> /rbk <rollback template file name> [log <log file name>] [/quiet]
+Secedit /generaterollback /db <database file name> /cfg <configuration file name> /rbk <rollback template file name> [/log <log file name>] [/quiet]
 ```
 
 ### Parameters


### PR DESCRIPTION
**Description:**

As pointed out in issue ticket #3690 (**Missing backslash**), the optional command parameter /log is missing its slash in the Syntax line. 
The slash is used in the example section below, so it must have been forgotten in this Syntax section.

Thanks to Francisco Celedon (@fceledon) for pointing out the typo.

**Proposed change:**
- add missing slash for the /log option

**issue ticket closure or reference:**

Closes #3690