### PR TITLE
Windows Commands/robocopy: wildcard MD format

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/robocopy.md
+++ b/WindowsServerDocs/administration/windows-commands/robocopy.md
@@ -27,12 +27,12 @@ robocopy <Source> <Destination> [<File>[ ...]] [<Options>]
 
 ## Parameters
 
-|   Parameter    |                                                                                            Description                                                                                             |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   \<Source>    |                                                                            Specifies the path to the source directory.                                                                             |
-| \<Destination> |                                                                          Specifies the path to the destination directory.                                                                          |
-|    \<File>     | Specifies the file or files to be copied. You can use wildcard characters (**&#42;** or **?**), if you want. If the **File** parameter is not specified, **\*.\\**\* is used as the default value. |
-|   \<Options>   |                                                                    Specifies options to be used with the **robocopy** command.                                                                     |
+|   Parameter    |                                                                                            Description                                                                                           |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   \<Source>    |                                                                            Specifies the path to the source directory.                                                                           |
+| \<Destination> |                                                                          Specifies the path to the destination directory.                                                                        |
+|    \<File>     | Specifies the file or files to be copied. You can use wildcard characters (**&#42;** or **?**), if you want. If the **File** parameter is not specified, **\*.\*** is used as the default value. |
+|   \<Options>   |                                                                    Specifies options to be used with the **robocopy** command.                                                                   |
 
 ### Copy options
 


### PR DESCRIPTION
**Description:**

As discussed in issue ticket #3707 (**Default \<File\> value**), the File parameter description contains a backslash as part of the default file wildcard parameter, but this notation is erroneous and causes an error message when tested with the `robocopy` command.

This unexpected backslash is caused by incorrect use of the escape character backslash ( \ ) by placing 2 more backslashes than needed in the affected wildcard `*.*` in the description.

Thanks to @tdillon for reporting this issue and confirming the solution.

**Changes proposed:**
- remove 2 surplus backslashes from the wildcard representation
- reduce the total width of the table accordingly, 2 spaces / dashes

**issue ticket closure or reference:**

Closes #3707