### PR TITLE
Windows Commands/bitsadmin getstate: restore table

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-getstate.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-getstate.md
@@ -1,6 +1,6 @@
 ---
 title: bitsadmin getstate
-description: "Windows Commands topic for **** - "
+description: "Windows Commands topic for bitsadmin getstate"
 ms.custom: na
 ms.prod: windows-server
 ms.reviewer: na
@@ -18,7 +18,6 @@ ms.date: 10/16/2017
 # bitsadmin getstate
 
 
-
 Retrieves the state of the specified job.
 
 ## Syntax
@@ -29,27 +28,30 @@ bitsadmin /GetState <Job>
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
+| Parameter | Description |
+| --------- | ----------- |
+|    Job    | The job's display name or GUID |
 
 ## Remarks
 
 The possible states are:
 
-|-----|-----|
-|QUEUED|The job is waiting to run.|
-|CONNECTING|BITS is contacting the server.|
-|TRANSFERRING|BITS is transferring data.|
-|SUSPENDED|The job is paused.|
-|ERROR|A non-recoverable error occurred; the transfer will not be retried.|
-|TRANSIENT_ERROR|A recoverable error occurred; the transfer retries when the minimum retry delay expires.|
-|ACKNOWLEDGED|The job was completed.|
-|CANCELED|The job was canceled.|
+|      State      | Description |
+| --------------- | ----------- |
+| QUEUED          | The job is waiting to run. |
+| CONNECTING      | BITS is contacting the server. |
+| TRANSFERRING    | BITS is transferring data. |
+| TRANSFERRED     | BITS has successfully transferred all files in the job. |
+| SUSPENDED       | The job is paused. |
+| ERROR           | A non-recoverable error occurred; the transfer will not be retried. |
+| TRANSIENT_ERROR | A recoverable error occurred; the transfer retries when the minimum retry delay expires. |
+| ACKNOWLEDGED    | The job was completed. |
+| CANCELED        | The job was canceled. |
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example retrieves the state for the job named *myDownloadJob*.
+
 ```
 C:\>bitsadmin /GetState myDownloadJob
 ```


### PR DESCRIPTION
**Description:**

As pointed out in the issue ticket #3703 (**Broken table and Missing State in Bitsadmin\getstate**), the Remarks table was broken due to a missing header row and could therefore not render properly, neither in the GitHub page using MarkDown source nor the target HTML page on docs.microsoft.com .

This PR should resolve the table issue as well as clean up the page source for future editing. Thanks to @WiVi71 for reporting this issue.

**Changes proposed:**
- restore table structure by adding the missing header row
- clean up table formatting by adding spacing to make it more justified
- add a partially missing description in the metadata section
- add a couple of blank lines for editing clarity
- remove a redundant blank line after the page title

**issue ticket closure or reference:**

Closes #3703