### PR TITLE
Support/Troubleshooting: use supported MD formats

### DIFF
--- a/WindowsServerDocs/manage/windows-admin-center/support/troubleshooting.md
+++ b/WindowsServerDocs/manage/windows-admin-center/support/troubleshooting.md
@@ -160,8 +160,10 @@ When installing Windows Admin Center, you are given the option to let Windows Ad
 
    > [!TIP]
    > For an easy way to set all TrustedHosts at once, you can use a wildcard.
-   > 
-   >     Set-Item WSMan:\localhost\Client\TrustedHosts -Value '*'
+   >
+   > ```powershell
+   > Set-Item WSMan:\localhost\Client\TrustedHosts -Value '*'
+   > ```
 
 4. When you are done testing, you can issue the following command from an elevated PowerShell session to clear your TrustedHosts setting:
 


### PR DESCRIPTION
**Description:**

As shown in issue ticket #3716 (Codebox broken in localized pages), one of the MarkDown Note tip code boxes uses spaced indent instead of MD back ticks to create a fenced code block. This causes an issue with the Machine Translation tool, showing HTML code for the spaced indent.

This PR intends to correct this issue by replacing the spaced indent with MD back ticks to create the fenced code block.

Thanks to @CeciAc (Cecilia Acevedo) for the useful feedback from the team, highlighting the specific details causing this issue.

**Proposed change:**
- replace spaced indent with MD back ticks for the fenced code block

**issue ticket closure or reference:**

Ref. #3716 (wait until migrated to the localized pages before closing)