### PR TITLE
AD FS OBO: secure WebAPIOBOController with Authorize attribute

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/development/ad-fs-on-behalf-of-authentication-in-windows-server.md
+++ b/WindowsServerDocs/identity/ad-fs/development/ad-fs-on-behalf-of-authentication-in-windows-server.md
@@ -218,14 +218,13 @@ In order to complete the on-behalf-of flow, you need to create a backend resourc
 
 ![AD FS OBO](media/AD-FS-On-behalf-of-Authentication-in-Windows-Server-2016/ADFS_OBO3.PNG)
 
-* Give appropriate controller name
+* Give the controller an appropriate name.
 
 ![AD FS OBO](media/AD-FS-On-behalf-of-Authentication-in-Windows-Server-2016/ADFS_OBO13.PNG)
 
-* Add the following code in the controller
+* Add the following code in the controller:
 
-
-~~~
+```cs
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -234,15 +233,16 @@ In order to complete the on-behalf-of flow, you need to create a backend resourc
     using System.Web.Http;
     namespace WebAPIOBO.Controllers
     {
+        [Authorize]
         public class WebAPIOBOController : ApiController
         {
             public IHttpActionResult Get()
             {
-                return Ok("WebAPI via OBO");
+                return Ok($"WebAPI via OBO (user: {User.Identity.Name}");
             }
         }
     }
-~~~
+```
 
 This code will simply return the string when anyone puts a Get request for the WebAPI WebAPIOBO
 


### PR DESCRIPTION
**Description:**

As discussed in issue ticket #3061 (**Shouldn't `WebAPIOBOController` be secured with an `Authorize` attribute?**),
the WebAPIOBOController controller should be secured with an Authorize attribute to validate the OAuth token when the ToDoListService calls the WebAPIOBO API, otherwise the AD FS configuration for WebAPIOBOController will never really be tested when running this locally.

Thanks to Toby Artisan (@tobyartisan) for making us aware of this issue.

**Changes proposed:**
- add the [Authorize] attribute within the AD FS OBO Controller code
- add user: {User.Identity.Name} to the output string
- add MarkDown syntax highlighting to the code snippet
- improve the grammar/readability of preceding instructions
- change the MD code block fence characters to back ticks

**issue ticket closure or reference:**

Closes #3061