### PR TITLE
Fix link rot by adding AppCenter links

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-mac.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-mac.md
@@ -34,7 +34,7 @@ Follow these steps to get started with Remote Desktop on your Mac:
 3. Add a Remote Desktop connection or a remote resource. You use a connection to connect directly to a Windows PC and a remote resource to use a RemoteApp program, session-based desktop, or a virtual desktop published on-premises using RemoteApp and Desktop Connections. This feature is typically available in corporate environments.
 
 ## What about the Mac beta client?
-We're testing new features on our preview channel on HockeyApp. Want to check it out? Go to [Microsoft Remote Desktop for Mac](https://go.microsoft.com/fwlink/?LinkID=619698) and click **Download**. You don't need to create an account or sign into HockeyApp to download the beta client.
+We're testing new features on our preview channel on AppCenter. Want to check it out? Go to [Microsoft Remote Desktop for Mac](https://aka.ms/rdmacbeta) and click **Download**. You don't need to create an account or sign into AppCenter to download the beta client.
 
 If you already have the client, you can check for updates to ensure you have the latest version. In the beta client, click **Microsoft Remote Desktop Beta** at the top, and then click **Check for updates**. 
 


### PR DESCRIPTION
Added AppCenter links for the RD Mac beta client. This reflects HockeyApp's decommissioning & migration to AppCenter.