### PR TITLE
Hyper-V/Deploy: typos & whitespace corrections

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/deploy/configure-virtual-local-areal-networks-for-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/deploy/configure-virtual-local-areal-networks-for-Hyper-V.md
@@ -13,43 +13,43 @@ ms.author: kathydav
 ms.date: 10/11/2016
 ---
 # Configure virtual local area networks for Hyper-V
-Virtual local area networks \(VLANs\) offer one way to isolate network traffic. VLANs are configured in switches and routers that support 802.1q. If you configure multiple VLANs and want communication to occur between them, you'll need to configure the network devices to allow that. 
+Virtual local area networks \(VLANs\) offer one way to isolate network traffic. VLANs are configured in switches and routers that support 802.1q. If you configure multiple VLANs and want communication to occur between them, you'll need to configure the network devices to allow that.
 
-You will need the following to configure VLANs:  
-  
--   A physical network adapter and driver that supports 802.1q VLAN tagging.  
--   A physical network switch that supports 802.1q VLAN tagging.  
-  
-On the host, you'll configure the virtual switch to allow network traffic on the physical switch port. This is for the VLAN IDs that you want to use internally with virtual machines. Next, you configure the virtual machine to specify the VLAN that the virtual machine will use for all network communications.  
-  
-#### To allow a virtual switch to use a VLAN  
-  
-1.  Open Hyper\-V Manager.  
-  
-2.  From the Actions menu, click **Virtual Switch Manager**.  
-  
-3.  Under **Virtual Switches**, select a virtual switch connected to a physical network adapter that supports VLANs. 
+You will need the following to configure VLANs:
 
-4. In the right pane, under VLAN ID, select **Enable virtual LAN identification** and then type a number for the VLAN ID.  
-  
-    All traffic that goes through the physical network adapter connected to the virtual switch will be tagged with the VLAN ID you set.  
-  
-#### To allow a virtual machine to use a VLAN  
-  
-1.  Open Hyper\-V Manager.  
-  
-2.  In the results pane, under **Virtual Machines**, select the appropriate virtual machine and then right-click **Settings**.  
+- A physical network adapter and driver that supports 802.1q VLAN tagging.
+- A physical network switch that supports 802.1q VLAN tagging.
 
-3.  Under **Hardware**, select an virtual switch that's set up with a VLAN.
-  
-4.  In the right pane, select **Enable virtual LAN identification**, and then type the same VLAN ID as the one you specified for the virtual switch. 
+On the host, you'll configure the virtual switch to allow network traffic on the physical switch port. This is for the VLAN IDs that you want to use internally with virtual machines. Next, you configure the virtual machine to specify the VLAN that the virtual machine will use for all network communications.
 
-If the virtual machine needs to use more VLANs, do one of the following:  
-  
--   Connect more virtual network adapters to appropriate virtual switches and assign the VLAN IDs. Make sure to configure the IP addresses correctly and that the traffic you want to route through the VLAN also uses the correct IP address.  
-  
--   Configure the virtual network word adapter in trunk mode using the [Set\-VMNetworkAdapterVlan](https://technet.microsoft.com/library/hh848475.aspx) cmdlt.
-  
-## See Also  
- 
+#### To allow a virtual switch to use a VLAN
+
+1. Open Hyper\-V Manager.
+
+2. From the Actions menu, click **Virtual Switch Manager**.
+
+3. Under **Virtual Switches**, select a virtual switch connected to a physical network adapter that supports VLANs.
+
+4. In the right pane, under VLAN ID, select **Enable virtual LAN identification** and then type a number for the VLAN ID.
+
+    All traffic that goes through the physical network adapter connected to the virtual switch will be tagged with the VLAN ID you set.
+
+#### To allow a virtual machine to use a VLAN
+
+1. Open Hyper\-V Manager.
+
+2. In the results pane, under **Virtual Machines**, select the appropriate virtual machine and then right-click **Settings**.
+
+3. Under **Hardware**, select an virtual switch that's set up with a VLAN.
+
+4. In the right pane, select **Enable virtual LAN identification**, and then type the same VLAN ID as the one you specified for the virtual switch.
+
+If the virtual machine needs to use more VLANs, do one of the following:
+
+- Connect more virtual network adapters to appropriate virtual switches and assign the VLAN IDs. Make sure to configure the IP addresses correctly and that the traffic you want to route through the VLAN also uses the correct IP address.
+
+- Configure the virtual network adapter in trunk mode using the [Set\-VMNetworkAdapterVlan](https://technet.microsoft.com/library/hh848475.aspx) cmdlet.
+
+## See Also
+
 [Hyper\-V Virtual Switch](https://technet.microsoft.com/windows-server-docs/networking/technologies/hyper-v-virtual-switch/hyper-v-virtual-switch)


### PR DESCRIPTION
**Description:**

As pointed out in issue ticket #3852 (**Typo ” word ” instead of "work"**), the last sentence before the "See Also" section contains a typo.

Thanks to @B-Art for pointing out the grammatical & readability issue.

**Proposed changes:**
- Remove "word" from the sentence (it does not belong there)
- Correction of "cmdlt" to *cmdlet*
- Remove redundant end-of-line whitespace from all lines
- Remove surplus whitespace in numbered lists & bullet point lists
- Insert missing NewLine at end of file (after the See Also link)

Because of all the whitespace corrections, you may want to review using the GitHub feature "Hide whitespace changes" in the source view page.

**Ticket closure or reference:**

Closes #3852