### PR TITLE
Replace blogs.technet.microsoft.com link

### DIFF
--- a/WindowsServerDocs/storage/folder-redirection/deploy-folder-redirection.md
+++ b/WindowsServerDocs/storage/folder-redirection/deploy-folder-redirection.md
@@ -193,6 +193,6 @@ The following table summarizes some of the most important changes to this topic.
 * [Folder Redirection, Offline Files, and Roaming User Profiles](folder-redirection-rup-overview.md)
 * [Deploy Primary Computers for Folder Redirection and Roaming User Profiles](deploy-primary-computers.md)
 * [Enable Advanced Offline Files Functionality](enable-always-offline.md)
-* [Microsoft's Support Statement Around Replicated User Profile Data](https://techcommunity.microsoft.com/t5/ask-the-directory-services-team/microsoft-8217-s-support-statement-around-replicated-user/ba-p/398230)
+* [Microsoft's Support Statement Around Replicated User Profile Data](https://docs.microsoft.com/archive/blogs/askds/microsofts-support-statement-around-replicated-user-profile-data)
 * [Sideload Apps with DISM](<https://docs.microsoft.com/previous-versions/windows/it-pro/windows-8.1-and-8/hh852635(v=win.10)>)
 * [Troubleshooting packaging, deployment, and query of Windows Runtime-based apps](https://msdn.microsoft.com/library/windows/desktop/hh973484.aspx)

--- a/WindowsServerDocs/storage/folder-redirection/deploy-folder-redirection.md
+++ b/WindowsServerDocs/storage/folder-redirection/deploy-folder-redirection.md
@@ -193,6 +193,6 @@ The following table summarizes some of the most important changes to this topic.
 * [Folder Redirection, Offline Files, and Roaming User Profiles](folder-redirection-rup-overview.md)
 * [Deploy Primary Computers for Folder Redirection and Roaming User Profiles](deploy-primary-computers.md)
 * [Enable Advanced Offline Files Functionality](enable-always-offline.md)
-* [Microsoft's Support Statement Around Replicated User Profile Data](https://blogs.technet.microsoft.com/askds/2010/09/01/microsofts-support-statement-around-replicated-user-profile-data/)
+* [Microsoft's Support Statement Around Replicated User Profile Data](https://techcommunity.microsoft.com/t5/ask-the-directory-services-team/microsoft-8217-s-support-statement-around-replicated-user/ba-p/398230)
 * [Sideload Apps with DISM](<https://docs.microsoft.com/previous-versions/windows/it-pro/windows-8.1-and-8/hh852635(v=win.10)>)
 * [Troubleshooting packaging, deployment, and query of Windows Runtime-based apps](https://msdn.microsoft.com/library/windows/desktop/hh973484.aspx)


### PR DESCRIPTION
Replace the link to a blog post on blogs.technet.microsoft.com to the migrated copy at techcommunity.microsoft.com