### PR TITLE
Windows Commands/Rundll32: Remove Recursive Link

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/rundll32.md
+++ b/WindowsServerDocs/administration/windows-commands/rundll32.md
@@ -37,7 +37,7 @@ Rundll32 <DLLname>
 
 ## Remarks
 
-Rundll32 can only call functions from a DLL that are explicitly written to be called by Rundll32. For more information about Rundll32 requirements see [article 164787](https://go.microsoft.com/fwlink/?LinkID=165773) in the Microsoft Knowledge Base (https://go.microsoft.com/fwlink/?LinkID=165773).
+Rundll32 can only call functions from a DLL that are explicitly written to be called by Rundll32.
 
 #### Additional references
 

--- a/WindowsServerDocs/administration/windows-commands/rundll32.md
+++ b/WindowsServerDocs/administration/windows-commands/rundll32.md
@@ -37,7 +37,7 @@ Rundll32 <DLLname>
 
 ## Remarks
 
-Rundll32 can only call functions from a DLL that are explicitly written to be called by Rundll32.
+Rundll32 can only call functions from a DLL explicitly written to be called by Rundll32.
 
 #### Additional references
 


### PR DESCRIPTION
**Description:**

As pointed out in issue tickets **#3654** (**Missing information**) and **#3894** (**Link to article 164787 links back to this page**), the linked Knowledge Base article 164787 is, for the time being, the same as this page.

Conclusion: Remove the link text until valid info can be provided.

Thank you to @thanks4wifi & @binki for pointing out this issue.

**Proposed change:**
- Remove the sentence referencing and linking to KB 164787
- Remove incorrect & redundant "that are" in the same line
- Add NewLine at End-Of-File (default MarkDown file format)

**Ticket closure or reference:**

Closes #3654
Closes #3894