### PR TITLE
Deploy Always On VPN: Restore Larger image Link

### DIFF
--- a/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/always-on-vpn-deploy-deployment.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/always-on-vpn-deploy-deployment.md
@@ -22,10 +22,10 @@ In this section, you learn about the workflow for deploying Always On VPN connec
 
 The following diagram illustrates the workflow process for the different scenarios when deploying Always On VPN:
 
-![Flow chart of the Always On VPN deployment workflow](../../../../media/Always-On-Vpn/always-on-vpn-deployment-workflow-sm.png)
+[![Flow chart of the Always On VPN deployment workflow](../../../../media/Always-On-Vpn/always-on-vpn-deployment-workflow-sm.png)](../../../../media/Always-On-Vpn/always-on-vpn-deployment-workflow.png)
 
->[!IMPORTANT]
->For this deployment, it is not a requirement that your infrastructure servers, such as computers running Active Directory Domain Services, Active Directory Certificate Services, and Network Policy Server, are running Windows Server 2016. You can use earlier versions of Windows Server, such as Windows Server 2012 R2, for the infrastructure servers and for the server that is running Remote Access.
+> [!IMPORTANT]
+> For this deployment, it is not a requirement that your infrastructure servers, such as computers running Active Directory Domain Services, Active Directory Certificate Services, and Network Policy Server, are running Windows Server 2016. You can use earlier versions of Windows Server, such as Windows Server 2012 R2, for the infrastructure servers and for the server that is running Remote Access.
 
 ## [Step 1. Plan the Always On VPN Deployment](always-on-vpn-deploy-planning.md)
 


### PR DESCRIPTION
**Description:**

As pointed out in the issue tickets #3178 (**image size very small**) and #3474 (**Image in article is unreadable**), the workflow process image is too small for the text content to be read (even opening the image in a new browser tab to enlarge it, the text is pixelated and blurry, so one can barely guess what the text says anyway).

2 years ago, in 2018, there used to be a working HTML link from that very image in this page to the larger version of the same image (always-on-vpn-deployment-workflow.png), but some time during the last 2 years, this link has disappeared. This PR is an attempt to restore it.

Thanks to @LeonB87 (Léon) and @tomdan-MSFT for posting the issue tickets to make us aware of this image readability issue.

**Changes proposed:**
- Restore HTML link via MarkDown, point the Small image (-sm) to Large
- Add MarkDown compatibility spacing to the [!IMPORTANT] blob markers

**Ticket closure or reference:**
Closes #3178
Closes #3474

Also thanks to @shortpatti for posting an update in the above 2 issues regarding her incorrect remaining name in the article metadata, as she no longer is part of the team.