### PR TITLE
Windows Commands/call: remove unintended backslash

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/call.md
+++ b/WindowsServerDocs/administration/windows-commands/call.md
@@ -73,7 +73,7 @@ The following table shows how you can combine modifiers with the batch parameter
 |%~dp$PATH:1|Searches the directories listed in the PATH environment variable for **%1**, and then expands to the drive letter and path of the first directory found.|
 |%~ftza1|Expands **%1** to display output similar to the **dir** command.|
 
-In the above examples, **%1** and PATH can be replaced by other valid values. The <strong>%~</strong> syntax is terminated by a valid argument number. The <strong>%~</strong> modifiers cannot be used with **%\\\***.
+In the above examples, **%1** and PATH can be replaced by other valid values. The <strong>%~</strong> syntax is terminated by a valid argument number. The <strong>%~</strong> modifiers cannot be used with **%\***.
 
 ## Remarks
 
@@ -93,7 +93,7 @@ In the above examples, **%1** and PATH can be replaced by other valid values. Th
 
     If command extensions are enabled, **call** accepts *Label* as the target of the call. The correct syntax is as follows:
 
-    `call :\<Label> <Arguments>`
+    `call :<Label> <Arguments>`
 
 ## <a name="BKMK_examples"></a>Examples
 


### PR DESCRIPTION
**Description:**
As pointed out in issue ticket #3685 (**To(o) many backslashes**), there are two call command usage examples in this page containing incorrect backslashes where no backslash is intended or used by the command.

Thanks to Thomas Stein (@tom1stein) for pointing out these typos.

**Changes proposed:**

- Remove surplus backslashes in the sentence "The % modifiers cannot be used with %\\*."
- Remove the backslash in `call :\<Label> <Arguments>`

**Ticket closure or reference:**

Closes #3685

Ref. #3687 (the old PR I mangled by incorrect rebase or merge)