### PR TITLE
In-Box VSS Writers: purge links to removed content

### DIFF
--- a/WindowsServerDocs/storage/file-server/volume-shadow-copy-service.md
+++ b/WindowsServerDocs/storage/file-server/volume-shadow-copy-service.md
@@ -14,34 +14,34 @@ Applies to: Windows Server 2019, Windows Server 2016, Windows Server 2012 R2, Wi
 
 Backing up and restoring critical business data can be very complex due to the following issues:
 
-  - The data usually needs to be backed up while the applications that produce the data are still running. This means that some of the data files might be open or they might be in an inconsistent state.  
-      
-  - If the data set is large, it can be difficult to back up all of it at one time.  
-      
+  - The data usually needs to be backed up while the applications that produce the data are still running. This means that some of the data files might be open or they might be in an inconsistent state.
+
+  - If the data set is large, it can be difficult to back up all of it at one time.
+
 
 Correctly performing backup and restore operations requires close coordination between the backup applications, the line-of-business applications that are being backed up, and the storage management hardware and software. The Volume Shadow Copy Service (VSS), which was introduced in Windows Server® 2003, facilitates the conversation between these components to allow them to work better together. When all the components support VSS, you can use them to back up your application data without taking the applications offline.
 
 VSS coordinates the actions that are required to create a consistent shadow copy (also known as a snapshot or a point-in-time copy) of the data that is to be backed up. The shadow copy can be used as-is, or it can be used in scenarios such as the following:
 
-  - You want to back up application data and system state information, including archiving data to another hard disk drive, to tape, or to other removable media.  
-      
-  - You are data mining.  
-      
-  - You are performing disk-to-disk backups.  
-      
-  - You need a fast recovery from data loss by restoring data to the original LUN or to an entirely new LUN that replaces an original LUN that failed.  
-      
+  - You want to back up application data and system state information, including archiving data to another hard disk drive, to tape, or to other removable media.
+
+  - You are data mining.
+
+  - You are performing disk-to-disk backups.
+
+  - You need a fast recovery from data loss by restoring data to the original LUN or to an entirely new LUN that replaces an original LUN that failed.
+
 
 Windows features and applications that use VSS include the following:
 
-  - [Windows Server Backup](https://go.microsoft.com/fwlink/?linkid=180891) (https://go.microsoft.com/fwlink/?LinkId=180891)  
-      
-  - [Shadow Copies of Shared Folders](https://go.microsoft.com/fwlink/?linkid=142874) (https://go.microsoft.com/fwlink/?LinkId=142874)  
-      
-  - [System Center Data Protection Manager](https://go.microsoft.com/fwlink/?linkid=180892) (https://go.microsoft.com/fwlink/?LinkId=180892)  
-      
-  - [System Restore](https://go.microsoft.com/fwlink/?linkid=180893) (https://go.microsoft.com/fwlink/?LinkId=180893)  
-      
+  - [Windows Server Backup](https://go.microsoft.com/fwlink/?linkid=180891) (https://go.microsoft.com/fwlink/?LinkId=180891)
+
+  - [Shadow Copies of Shared Folders](https://go.microsoft.com/fwlink/?linkid=142874) (https://go.microsoft.com/fwlink/?LinkId=142874)
+
+  - [System Center Data Protection Manager](https://go.microsoft.com/fwlink/?linkid=180892) (https://go.microsoft.com/fwlink/?LinkId=180892)
+
+  - [System Restore](https://go.microsoft.com/fwlink/?linkid=180893) (https://go.microsoft.com/fwlink/?LinkId=180893)
+
 
 ## How Volume Shadow Copy Service Works
 
@@ -71,31 +71,31 @@ This section puts the various roles of the requester, writer, and provider into 
 
 To create a shadow copy, the requester, writer, and provider perform the following actions:
 
-1.  The requester asks the Volume Shadow Copy Service to enumerate the writers, gather the writer metadata, and prepare for shadow copy creation.  
-      
-2.  Each writer creates an XML description of the components and data stores that need to be backed up and provides it to the Volume Shadow Copy Service. The writer also defines a restore method, which is used for all components. The Volume Shadow Copy Service provides the writer's description to the requester, which selects the components that will be backed up.  
-      
-3.  The Volume Shadow Copy Service notifies all the writers to prepare their data for making a shadow copy.  
-      
-4.  Each writer prepares the data as appropriate, such as completing all open transactions, rolling transaction logs, and flushing caches. When the data is ready to be shadow-copied, the writer notifies the Volume Shadow Copy Service.  
-      
-5.  The Volume Shadow Copy Service tells the writers to temporarily freeze application write I/O requests (read I/O requests are still possible) for the few seconds that are required to create the shadow copy of the volume or volumes. The application freeze is not allowed to take longer than 60 seconds. The Volume Shadow Copy Service flushes the file system buffers and then freezes the file system, which ensures that the file system metadata is recorded correctly and the data to be shadow-copied is written in a consistent order.  
-      
-6.  The Volume Shadow Copy Service tells the provider to create the shadow copy. The shadow copy creation period lasts no more than 10 seconds, during which all write I/O requests to the file system remain frozen.  
-      
-7.  The Volume Shadow Copy Service releases file system write I/O requests.  
-      
-8.  VSS tells the writers to thaw application write I/O requests. At this point applications are free to resume writing data to the disk that is being shadow-copied.  
-      
+1.  The requester asks the Volume Shadow Copy Service to enumerate the writers, gather the writer metadata, and prepare for shadow copy creation.
+
+2.  Each writer creates an XML description of the components and data stores that need to be backed up and provides it to the Volume Shadow Copy Service. The writer also defines a restore method, which is used for all components. The Volume Shadow Copy Service provides the writer's description to the requester, which selects the components that will be backed up.
+
+3.  The Volume Shadow Copy Service notifies all the writers to prepare their data for making a shadow copy.
+
+4.  Each writer prepares the data as appropriate, such as completing all open transactions, rolling transaction logs, and flushing caches. When the data is ready to be shadow-copied, the writer notifies the Volume Shadow Copy Service.
+
+5.  The Volume Shadow Copy Service tells the writers to temporarily freeze application write I/O requests (read I/O requests are still possible) for the few seconds that are required to create the shadow copy of the volume or volumes. The application freeze is not allowed to take longer than 60 seconds. The Volume Shadow Copy Service flushes the file system buffers and then freezes the file system, which ensures that the file system metadata is recorded correctly and the data to be shadow-copied is written in a consistent order.
+
+6.  The Volume Shadow Copy Service tells the provider to create the shadow copy. The shadow copy creation period lasts no more than 10 seconds, during which all write I/O requests to the file system remain frozen.
+
+7.  The Volume Shadow Copy Service releases file system write I/O requests.
+
+8.  VSS tells the writers to thaw application write I/O requests. At this point applications are free to resume writing data to the disk that is being shadow-copied.
+
 
 > [!NOTE]
-> The shadow copy creation can be aborted if the writers are kept in the freeze state for longer than 60 seconds or if the providers take longer than 10 seconds to commit the shadow copy. 
+> The shadow copy creation can be aborted if the writers are kept in the freeze state for longer than 60 seconds or if the providers take longer than 10 seconds to commit the shadow copy.
 <br>
 
-9. The requester can retry the process (go back to step 1) or notify the administrator to retry at a later time.  
-      
-10. If the shadow copy is successfully created, the Volume Shadow Copy Service returns the location information for the shadow copy to the requester. In some cases, the shadow copy can be temporarily made available as a read-write volume so that VSS and one or more applications can alter the contents of the shadow copy before the shadow copy is finished. After VSS and the applications make their alterations, the shadow copy is made read-only. This phase is called Auto-recovery, and it is used to undo any file-system or application transactions on the shadow copy volume that were not completed before the shadow copy was created.  
-      
+9. The requester can retry the process (go back to step 1) or notify the administrator to retry at a later time.
+
+10. If the shadow copy is successfully created, the Volume Shadow Copy Service returns the location information for the shadow copy to the requester. In some cases, the shadow copy can be temporarily made available as a read-write volume so that VSS and one or more applications can alter the contents of the shadow copy before the shadow copy is finished. After VSS and the applications make their alterations, the shadow copy is made read-only. This phase is called Auto-recovery, and it is used to undo any file-system or application transactions on the shadow copy volume that were not completed before the shadow copy was created.
+
 
 ### How the Provider Creates a Shadow Copy
 
@@ -111,10 +111,10 @@ A hardware or software shadow copy provider uses one of the following methods fo
 
 A complete copy is usually created by making a "split mirror" as follows:
 
-1.  The original volume and the shadow copy volume are a mirrored volume set.  
-      
-2.  The shadow copy volume is separated from the original volume. This breaks the mirror connection.  
-      
+1. The original volume and the shadow copy volume are a mirrored volume set.
+
+2. The shadow copy volume is separated from the original volume. This breaks the mirror connection.
+
 
 After the mirror connection is broken, the original volume and the shadow copy volume are independent. The original volume continues to accept all changes (write I/O requests), while the shadow copy volume remains an exact read-only copy of the original data at the time of the break.
 
@@ -240,25 +240,21 @@ The component files that make up the system provider are swprv.dll and volsnap.s
 
 The Windows operating system includes a set of VSS writers that are responsible for enumerating the data that is required by various Windows features.
 
-For more information about these writers, see the following Microsoft Web sites:
+For more information about these writers, see the following Microsoft Docs Web page:
 
-  - [In-Box VSS Writers](https://go.microsoft.com/fwlink/?linkid=180895) (https://go.microsoft.com/fwlink/?LinkId=180895)  
-      
-  - [New In-Box VSS Writers for Windows Server 2008 and Windows Vista SP1](https://go.microsoft.com/fwlink/?linkid=180896) (https://go.microsoft.com/fwlink/?LinkId=180896)  
-      
-  - [New In-Box VSS Writers for Windows Server 2008 R2 and Windows 7](https://go.microsoft.com/fwlink/?linkid=180897) (https://go.microsoft.com/fwlink/?LinkId=180897)  
-      
+- [In-Box VSS Writers](https://docs.microsoft.com/windows/win32/vss/in-box-vss-writers) (https://docs.microsoft.com/windows/win32/vss/in-box-vss-writers)
+
 
 ## How Shadow Copies Are Used
 
 In addition to backing up application data and system state information, shadow copies can be used for a number of purposes, including the following:
 
-  - Restoring LUNs (LUN resynchronization and LUN swapping)  
-      
-  - Restoring individual files (Shadow Copies for Shared Folders)  
-      
-  - Data mining by using transportable shadow copies  
-      
+  - Restoring LUNs (LUN resynchronization and LUN swapping)
+
+  - Restoring individual files (Shadow Copies for Shared Folders)
+
+  - Data mining by using transportable shadow copies
+
 
 ### Restoring LUNs (LUN resynchronization and LUN swapping)
 
@@ -268,7 +264,7 @@ The shadow copy can be a full clone or a differential shadow copy. In either cas
 
 
 > [!NOTE]
-> The shadow copy must be a transportable hardware shadow copy. 
+> The shadow copy must be a transportable hardware shadow copy.
 <br>
 
 
@@ -276,16 +272,15 @@ Most arrays allow production I/O operations to resume shortly after the resync o
 
 LUN resynchronization is different from LUN swapping. A LUN swap is a fast recovery scenario that VSS has supported since Windows Server 2003 SP1. In a LUN swap, the shadow copy is imported and then converted into a read-write volume. The conversion is an irreversible operation, and the volume and underlying LUN cannot be controlled with the VSS APIs after that. The following list describes how LUN resynchronization compares with LUN swapping:
 
-  - In LUN resynchronization, the shadow copy is not altered, so it can be used several times. In LUN swapping, the shadow copy can be used only once for a recovery. For the most safety-conscious administrators, this is important. When LUN resynchronization is used, the requester can retry the entire restore operation if something goes wrong the first time.  
-      
-  - At the end of a LUN swap, the shadow copy LUN is used for production I/O requests. For this reason, the shadow copy LUN must use the same quality of storage as the original production LUN to ensure that performance is not impacted after the recovery operation. If LUN resynchronization is used instead, the hardware provider can maintain the shadow copy on storage that is less expensive than production-quality storage.  
-      
-  - If the destination LUN is unusable and needs to be recreated, LUN swapping may be more economical because it doesn't require a destination LUN.  
-      
+  - In LUN resynchronization, the shadow copy is not altered, so it can be used several times. In LUN swapping, the shadow copy can be used only once for a recovery. For the most safety-conscious administrators, this is important. When LUN resynchronization is used, the requester can retry the entire restore operation if something goes wrong the first time.
+
+  - At the end of a LUN swap, the shadow copy LUN is used for production I/O requests. For this reason, the shadow copy LUN must use the same quality of storage as the original production LUN to ensure that performance is not impacted after the recovery operation. If LUN resynchronization is used instead, the hardware provider can maintain the shadow copy on storage that is less expensive than production-quality storage.
+
+  - If the destination LUN is unusable and needs to be recreated, LUN swapping may be more economical because it doesn't require a destination LUN.
 
 
 > [!WARNING]
-> All of the operations listed are LUN-level operations. If you attempt to recover a specific volume by using LUN resynchronization, you are unwittingly going to revert all the other volumes that are sharing the LUN. 
+> All of the operations listed are LUN-level operations. If you attempt to recover a specific volume by using LUN resynchronization, you are unwittingly going to revert all the other volumes that are sharing the LUN.
 <br>
 
 
@@ -315,7 +310,7 @@ With the Volume Shadow Copy Service and a storage array with a hardware provider
 
 
 > [!NOTE]
-> A transportable shadow copy that is created on Windows Server 2003 cannot be imported onto a server that is running Windows Server 2008 or Windows Server 2008 R2. A transportable shadow copy that was created on Windows Server 2008 or Windows Server 2008 R2 cannot be imported onto a server that is running Windows Server 2003. However, a shadow copy that is created on Windows Server 2008 can be imported onto a server that is running Windows Server 2008 R2 and vice versa. 
+> A transportable shadow copy that is created on Windows Server 2003 cannot be imported onto a server that is running Windows Server 2008 or Windows Server 2008 R2. A transportable shadow copy that was created on Windows Server 2008 or Windows Server 2008 R2 cannot be imported onto a server that is running Windows Server 2003. However, a shadow copy that is created on Windows Server 2008 can be imported onto a server that is running Windows Server 2008 R2 and vice versa.
 <br>
 
 
@@ -357,10 +352,10 @@ It is possible to disable the Volume Shadow Copy Service by using the Microsoft 
 
 For more information, see the following Microsoft TechNet Web sites:
 
-  - [System Restore](https://go.microsoft.com/fwlink/?linkid=157113) (https://go.microsoft.com/fwlink/?LinkID=157113)  
-      
-  - [Windows Server Backup](https://go.microsoft.com/fwlink/?linkid=180891) (https://go.microsoft.com/fwlink/?LinkID=180891)  
-      
+- [System Restore](https://go.microsoft.com/fwlink/?linkid=157113) (https://go.microsoft.com/fwlink/?LinkID=157113)
+
+- [Windows Server Backup](https://go.microsoft.com/fwlink/?linkid=180891) (https://go.microsoft.com/fwlink/?LinkID=180891)
+
 
 ### Can I exclude files from a shadow copy to save space?
 
@@ -370,7 +365,7 @@ To exclude specific files from shadow copies, use the following registry key: **
 
 
 > [!NOTE]
-> The <STRONG>FilesNotToSnapshot</STRONG> registry key is intended to be used only by applications. Users who attempt to use it will encounter limitations such as the following: 
+> The <STRONG>FilesNotToSnapshot</STRONG> registry key is intended to be used only by applications. Users who attempt to use it will encounter limitations such as the following:
 > <br>
 > <UL>
 > <LI>It cannot delete files from a shadow copy that was created on a Windows Server by using the Previous Versions feature.<BR><BR>
@@ -401,14 +396,14 @@ The diff area can be located on any local volume. However, it must be located on
 
 The following criteria are evaluated, in this order, to determine the diff area location:
 
-  - If a volume already has an existing shadow copy, that location is used.  
-      
-  - If there is a preconfigured manual association between the original volume and the shadow copy volume location, then that location is used.  
-      
-  - If the previous two criteria do not provide a location, the shadow copy service chooses a location based on available free space. If more than one volume is being shadow copied, the shadow copy service creates a list of possible snapshot locations based on the size of free space, in descending order. The number of locations provided is equal to the number of volumes being shadow copied.  
-      
-  - If the volume being shadow copied is one of the possible locations, then a local association is created. Otherwise an association with the volume with the most available space is created.  
-      
+  - If a volume already has an existing shadow copy, that location is used.
+
+  - If there is a preconfigured manual association between the original volume and the shadow copy volume location, then that location is used.
+
+  - If the previous two criteria do not provide a location, the shadow copy service chooses a location based on available free space. If more than one volume is being shadow copied, the shadow copy service creates a list of possible snapshot locations based on the size of free space, in descending order. The number of locations provided is equal to the number of volumes being shadow copied.
+
+  - If the volume being shadow copied is one of the possible locations, then a local association is created. Otherwise an association with the volume with the most available space is created.
+
 
 ### Can VSS create shadow copies of non-NTFS volumes?
 
@@ -436,25 +431,25 @@ Shadow copies for the volume are deleted, beginning with the oldest shadow copy.
 
 The Windows operating system provides the following tools for working with VSS:
 
-  - [DiskShadow](https://go.microsoft.com/fwlink/?linkid=180907) (https://go.microsoft.com/fwlink/?LinkId=180907)  
-      
-  - [VssAdmin](https://go.microsoft.com/fwlink/?linkid=84008) (https://go.microsoft.com/fwlink/?LinkId=84008)  
-      
+  - [DiskShadow](https://go.microsoft.com/fwlink/?linkid=180907) (https://go.microsoft.com/fwlink/?LinkId=180907)
+
+  - [VssAdmin](https://go.microsoft.com/fwlink/?linkid=84008) (https://go.microsoft.com/fwlink/?LinkId=84008)
+
 
 ### DiskShadow
 
 DiskShadow is a VSS requester that you can use to manage all the hardware and software snapshots that you can have on a system. DiskShadow includes commands such as the following:
 
-  - **list**: Lists VSS writers, VSS providers, and shadow copies  
-      
-  - **create**: Creates a new shadow copy  
-      
-  - **import**: Imports a transportable shadow copy  
-      
-  - **expose**: Exposes a persistent shadow copy (as a drive letter, for example)  
-      
-  - **revert**: Reverts a volume back to a specified shadow copy  
-      
+  - **list**: Lists VSS writers, VSS providers, and shadow copies
+
+  - **create**: Creates a new shadow copy
+
+  - **import**: Imports a transportable shadow copy
+
+  - **expose**: Exposes a persistent shadow copy (as a drive letter, for example)
+
+  - **revert**: Reverts a volume back to a specified shadow copy
+
 
 This tool is intended for use by IT professionals, but developers might also find it useful when testing a VSS writer or VSS provider.
 
@@ -466,16 +461,16 @@ VssAdmin is used to create, delete, and list information about shadow copies. It
 
 VssAdmin includes commands such as the following:
 
-  - **create shadow**: Creates a new shadow copy  
-      
-  - **delete shadows**: Deletes shadow copies  
-      
-  - **list providers**: Lists all registered VSS providers  
-      
-  - **list writers**: Lists all subscribed VSS writers  
-      
-  - **resize shadowstorage**: Changes the maximum size of the shadow copy storage area  
-      
+  - **create shadow**: Creates a new shadow copy
+
+  - **delete shadows**: Deletes shadow copies
+
+  - **list providers**: Lists all registered VSS providers
+
+  - **list writers**: Lists all subscribed VSS writers
+
+  - **resize shadowstorage**: Changes the maximum size of the shadow copy storage area
+
 
 VssAdmin can only be used to administer shadow copies that are created by the system software provider.
 
@@ -485,12 +480,12 @@ VssAdmin is available on Windows client and Windows Server operating system vers
 
 The following registry keys are available for use with VSS:
 
-  - **VssAccessControl**  
-      
-  - **MaxShadowCopies**  
-      
-  - **MinDiffAreaFileSize**  
-      
+  - **VssAccessControl**
+
+  - **MaxShadowCopies**
+
+  - **MinDiffAreaFileSize**
+
 
 ### VssAccessControl
 
@@ -498,10 +493,10 @@ This key is used to specify which users have access to shadow copies.
 
 For more information, see the following entries on the MSDN Web site:
 
-  - [Security Considerations for Writers](https://go.microsoft.com/fwlink/?linkid=157739) (https://go.microsoft.com/fwlink/?LinkId=157739)  
-      
-  - [Security Considerations for Requesters](https://go.microsoft.com/fwlink/?linkid=180908) (https://go.microsoft.com/fwlink/?LinkId=180908)  
-      
+  - [Security Considerations for Writers](https://go.microsoft.com/fwlink/?linkid=157739) (https://go.microsoft.com/fwlink/?LinkId=157739)
+
+  - [Security Considerations for Requesters](https://go.microsoft.com/fwlink/?linkid=180908) (https://go.microsoft.com/fwlink/?LinkId=180908)
+
 
 ### MaxShadowCopies
 
@@ -519,7 +514,7 @@ For more information, see the following entry on the MSDN Web site:
 
 **MinDiffAreaFileSize** under [Registry Keys for Backup and Restore](https://go.microsoft.com/fwlink/?linkid=180910) (https://go.microsoft.com/fwlink/?LinkId=180910)
 
-`##`#` Supported Operating System Versions
+### Supported Operating System Versions
 
 The following table lists the minimum supported operating system versions for VSS features.
 


### PR DESCRIPTION
**Description:**

As pointed out in issue ticket **#3947** (**Broken Links**), the links to [New In-Box VSS Writers for Windows Server 2008 and Windows Vista SP1] and [New In-Box VSS Writers for Windows Server 2008 R2 and Windows 7] are now pointing to a page saying "Content Removed (This content has been removed.)" The links are, respectively:
- https://go.microsoft.com/fwlink/?linkid=180896 => https://docs.microsoft.com/en-us/previous-versions//ee517247(v=vs.85)?redirectedfrom=MSDN
- https://go.microsoft.com/fwlink/?linkid=180897 => https://docs.microsoft.com/en-us/previous-versions//ee517248(v=vs.85)?redirectedfrom=MSDN

Thanks to @SauerKraut51 for opening the ticket to point out this issue.

In addition, the remaining link "In-Box VSS Writers" (https://go.microsoft.com/fwlink/?LinkId=180895) is now permanently redirected from MSDN to the docs.microsoft.com site.

**Changes proposed:**
- Remove the 2 links, along with the title text
- Modify the preceding text to indicate that only 1 link will follow
- Replace the remaining link with the direct link to the MS Docs page
- Also indicate that this is the case by modifying the preceding text
- Restore the H3 heading MarkDown format title code before the title "Supported Operating System Versions" in row 517 (was 522)
- Add proper NewLine to the last line of the page (EOF)
- Cosmetic/codestyle: reduce the amount of whitespace by removing 1 out of 3 continuous blank lines

**Ticket reference or closure:**

Closes #3947