### PR TITLE
correct missing path separators

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/manage/troubleshoot/Configuring-a-Computer-for-Troubleshooting.md
+++ b/WindowsServerDocs/identity/ad-ds/manage/troubleshoot/Configuring-a-Computer-for-Troubleshooting.md
@@ -37,7 +37,7 @@ Reliability and Performance Monitor also includes Reliability Monitor, an MMC sn
 
 ### Set logging levels
 
-If the information that you receive in the Directory Service log in Event Viewer is not sufficient for troubleshooting, raise the logging levels by using the appropriate registry entry in **HKEY_LOCAL_MACHINESYSTEMCurrentControlSetServicesNTDSDiagnostics**.
+If the information that you receive in the Directory Service log in Event Viewer is not sufficient for troubleshooting, raise the logging levels by using the appropriate registry entry in **HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NTDS\Diagnostics**.
 
 By default, the logging levels for all entries are set to **0**, which provides the minimum amount of information. The highest logging level is **5**. Increasing the level for an entry causes additional events to be logged in the Directory Service event log.
 


### PR DESCRIPTION
Also, the "Recommended version" link at the top of the old article at 

- https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd941829(v=ws.10)?redirectedfrom=MSDN 

points to a useless index, instead of properly pointing to this page. I don't know if it's possible to update that, but it would be very helpful.