### PR TITLE
Windows commands/Netcfg: additions

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/netcfg.md
+++ b/WindowsServerDocs/administration/windows-commands/netcfg.md
@@ -18,50 +18,53 @@ ms.date: 10/16/2017
 
 >Applies To: Windows Server (Semi-Annual Channel), Windows Server 2016, Windows Server 2012 R2, Windows Server 2012
 
-Installs the Windows Preinstallation Environment (WinPE), a lightweight version of Windows used to deploy workstations.   
-## Syntax  
-```  
-netcfg [/v] [/e] [/winpe] [/l ] /c /i  
-```  
-### Parameters  
-|Parameter|Description|  
-|-------|--------|  
-|/v|Run in verbose (detailed) mode|  
-|/e|Use servicing environment variables during install and uninstall|  
-|/winpe|Installs TCP/IP, NetBIOS and Microsoft Client for Windows preinstallation envrionment|  
-|/l|Provides the location of INF|  
-|/c|Provides the class of the component to be installed; protocol, Service, or client|  
-|/i|Provides the component ID|  
-|/s|Provides the type of components to show<br /><br />\ta = adapters, n = net components|  
-|/?|Displays help at the command prompt.|  
-## <a name="BKMK_Examples"></a>Examples  
-To install the protocol *example* using c:\oemdir\example.inf:  
-```  
-netcfg /l c:\oemdir\example.inf /c p /i example  
-```  
-To install the *MS_Server* service:  
-```  
-netcfg /c s /i MS_Server  
-```  
-To install TCP/IP, NetBIOS and Microsoft Client for Windows preinstallation environment  
-```  
-netcfg /v /winpe  
-```  
-To display if component *MS_IPX* is installed:  
-```  
-netcfg /q MS_IPX  
-```  
-To uninstall component *MS_IPX*:  
-```  
-netcfg /u MS_IPX  
-```  
-To show all installed net components:  
-```  
-netcfg /s n  
-```  
-To shows binding paths containing *MS_TCPIP*:  
-```  
-netcfg /b ms_tcpip  
-```  
-## additional references  
--   [Command-Line Syntax Key](command-line-syntax-key.md)  
+Installs the Windows Preinstallation Environment (WinPE), a lightweight version of Windows used to deploy workstations.
+## Syntax
+```
+netcfg [/v] [/e] [/winpe] [/l ] /c /i
+```
+### Parameters
+|Parameter|Description|
+|-------|--------|
+|/v|Run in **verbose** (detailed) mode|
+|/e|Use servicing **environment** variables during install and uninstall|
+|/winpe|Installs TCP/IP, NetBIOS and Microsoft Client for Windows preinstallation environment (WinPE)|
+|/l|Provides the **location** of INF|
+|/c|Provides the **class** of the component to be installed; protocol, Service, or client|
+|/i|Provides the component **ID**|
+|/s|Provides the type of components to **show**.<br /><br />\ta = adapters, n = net components|
+|/b|Displays the **binding paths**, when followed by a string containing the name of the path.|
+|/?|Displays **help** at the command prompt.|
+
+## <a name="BKMK_Examples"></a>Examples
+
+To install the protocol *example* using c:\oemdir\example.inf:
+```
+netcfg /l c:\oemdir\example.inf /c p /i example
+```
+To install the *MS_Server* service:
+```
+netcfg /c s /i MS_Server
+```
+To install TCP/IP, NetBIOS and Microsoft Client for Windows preinstallation environment
+```
+netcfg /v /winpe
+```
+To display if component *MS_IPX* is installed:
+```
+netcfg /q MS_IPX
+```
+To uninstall component *MS_IPX*:
+```
+netcfg /u MS_IPX
+```
+To show all installed net components:
+```
+netcfg /s n
+```
+To display binding paths containing *MS_TCPIP*:
+```
+netcfg /b ms_tcpip
+```
+## additional references
+-   [Command-Line Syntax Key](command-line-syntax-key.md)


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3990 (/b option not documented), there is no explanation or listing of the option or parameter "/b" in this page.

Thanks to druske for reporting this missing detail.

**Changes proposed:**
- Add a table row with description for the /b option
- Highlighting in bold the words associated with the option letter
- Grammar: replace "shows" with "display" in the example text for /b
- Whitespace removal: "Trim Trailing Space" (blanks at end-of-line)

Use **Hide whitespace changes** to see the effective changes.

**Additional note:**
Just in case you disagree with the added formatting, I am open to modifying this PR if you want to keep only the added table row.

**Ticket closure or reference:**

Closes #3990