### PR TITLE
In the section Configuration Information

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Configure-AD-FS-Extranet-Smart-Lockout-Protection.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Configure-AD-FS-Extranet-Smart-Lockout-Protection.md
@@ -30,7 +30,7 @@ Extranet Smart Lockout in AD FS 2019 adds the following advantages compared to A
 ### Configuration information
 When ESL is enabled, a new table in the Artifact database, AdfsArtifactStore.AccountActivity, is created and a node is selected in the AD FS farm as the “User Activity” master. In a WID configuration, this node is always the primary node. In a SQL configuration, one node is selected to be the User Activity master.  
 
-To view the node selected as the User Activity master. Get-AdfsFarmInformation.FarmRoles
+To view the node selected as the User Activity master. (Get-AdfsFarmInformation).FarmRoles
 
 All secondary nodes will contact the master node on each fresh login through Port 80 to learn the latest value of the bad password counts and new familiar location values, and update that node after the login is processed.
 


### PR DESCRIPTION
We have stated that the command to use to view the node selected as User Activity master is Get-AdfsFarmInformation.FarmRoles and if we run the command as it is it will error stating "Get-AdfsFarmInformation.FarmRoles : The term 'Get-AdfsFarmInformation.FarmRoles' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again".  The revised command to be used is (Get-AdfsFarmInformation).FarmRoles