### PR TITLE
Azure AD Application Proxy related information

### DIFF
--- a/WindowsServerDocs/manage/windows-admin-center/support/known-issues.md
+++ b/WindowsServerDocs/manage/windows-admin-center/support/known-issues.md
@@ -65,7 +65,7 @@ Windows Admin Center is not tested with Mozilla Firefox, but most functionality 
 
 ## WebSocket compatibility when using a proxy service
 
-Remote Desktop, PowerShell, and Events modules in Windows Admin Center utilize the WebSocket protocol, which is often not supported when using a proxy service. Websocket support in Azure AD Application Proxy compatibility is in [preview](https://blogs.technet.microsoft.com/applicationproxyblog/2018/03/28/limited-websocket-support-now-in-public-preview/) and looking for feedback on compatibility.
+Remote Desktop, PowerShell, and Events modules in Windows Admin Center utilize the WebSocket protocol, which is often not supported when using a proxy service. 
 
 ## Support for Windows Server versions before 2016 (2012 R2, 2012, 2008 R2)
 


### PR DESCRIPTION
I'd like to ask you to remove the sentence related to Azure AD Application Proxy. It's misleading. The correct statement is located here: https://docs.microsoft.com/bs-latn-ba/azure/active-directory/manage-apps/application-proxy-faq 

WebSocket
Does WebSocket support work for applications other than QlikSense?
Currently, WebSocket protocol support is still in public preview and it may not work for other applications. Some customers have had mixed success using WebSocket protocol with other applications. If you test such scenarios, we would love to hear your results. Please send us your feedback at aadapfeedback@microsoft.com.

Features (Eventlogs, Powershell and Remote Desktop Services) in Windows Admin Center (WAC) or Remote Desktop Web Client do not work through Azure AD Application Proxy presently.