### PR TITLE
Updated Profile Name in PowerSHell Example

### DIFF
--- a/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-client-vpn-connections.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-client-vpn-connections.md
@@ -258,7 +258,7 @@ The following are example values for parameters used in the commands below. Ensu
 
 ```xml
 $TemplateName = 'Template'
-$ProfileName = 'Contoso AlwaysOn VPN'
+$ProfileName = 'Contoso%20AlwaysOn%20VPN'
 $Servers = 'vpn.contoso.com'
 $DnsSuffix = 'corp.contoso.com'
 $DomainName = '.corp.contoso.com'


### PR DESCRIPTION
As outlined in the text above of the modification, if the "$Profilename" "has a space or other non-alphanumeric character, it must be properly escaped according to the URL encoding standard." But in the given example, there are just whitespaces. This commit does change that.