### PR TITLE
manage-bde/changekey: hyphen instead of en dash

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/manage-bde-changekey.md
+++ b/WindowsServerDocs/administration/windows-commands/manage-bde-changekey.md
@@ -42,7 +42,7 @@ manage-bde -changekey [<Drive>] [<PathToExternalKeyDirectory>] [-computername <N
 
 The following example illustrates using the **-changekey** command to create a new startup key on drive E to use with BitLocker encryption on drive C.
 ```
-manage-bde –changekey C: E:\
+manage-bde -changekey C: E:\
 ```
 
 #### Additional references


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4068 (Incorrect characters used in example text.),
the en dash instead of regular hyphen in the example may not work as expected.

Thanks to Scott (@S-T-S) for reporting this specific character issue.

**Proposed change:**
- Replace en dash with a regular hyphen (copied from the command name)

**Ticket closure or reference:**

Closes #4068