### PR TITLE
Admin/FTP: turn hidden 'put' parameters visible

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/ftp-put.md
+++ b/WindowsServerDocs/administration/windows-commands/ftp-put.md
@@ -1,6 +1,6 @@
 ---
 title: ftp put
-description: "Windows Commands topic for **** - "
+description: "Windows Commands topic for FTP - put"
 ms.custom: na
 ms.prod: windows-server
 ms.reviewer: na
@@ -12,37 +12,37 @@ ms.assetid: 95cc1e3f-523d-4374-98b8-16e6c276b2ca vhorne
 author: coreyp-at-msft
 ms.author: coreyp
 manager: dongill
-ms.date: 10/16/2017
+ms.date: 03/30/2020
 ---
 # ftp: put
 
->Applies To: Windows Server (Semi-Annual Channel), Windows Server 2016, Windows Server 2012 R2, Windows Server 2012
+> Applies To: Windows Server (Semi-Annual Channel), Windows Server 2016, Windows Server 2012 R2, Windows Server 2012
 
-Copies a local file to the remote computer using the current file transfer type.   
-## Syntax  
-```  
-put <LocalFile> [<remoteFile>]  
-```  
-### Parameters  
+Copies a local file to the remote computer using the current file transfer type.
+## Syntax
+```
+put <LocalFile> [<remoteFile>]
+```
+### Parameters
 
-|   Parameter    |                    Description                    |
-|----------------|---------------------------------------------------|
-|  <LocalFile>   |         Specifies the local file to copy.         |
-| [<remoteFile>] | Specifies the name to use on the remote computer. |
+|    Parameter     |                    Description                    |
+|------------------|---------------------------------------------------|
+|   `<LocalFile>`  |         Specifies the local file to copy.         |
+| `[<remoteFile>]` | Specifies the name to use on the remote computer. |
 
-## Remarks  
-- The **put** command is identical to the **send** command.  
-- if *remoteFile* is not specified, the file is given the *LocalFile* name.  
-  ## <a name="BKMK_Examples"></a>Examples  
-  copy the local file **test.txt** and name it **test1.txt** on the remote computer.  
-  ```  
-  put test.txt test1.txt  
-  ```  
-  copy the local file **program.exe** to the remote computer.  
-  ```  
-  put program.exe  
-  ```  
-  ## additional references  
-- [ftp: ascii](ftp-ascii.md)  
-- [ftp: binary](ftp-binary.md)  
-- [Command-Line Syntax Key](command-line-syntax-key.md)  
+## Remarks
+- The **put** command is identical to the **send** command.
+- if *remoteFile* is not specified, the file is given the *LocalFile* name.
+  ## <a name="BKMK_Examples"></a>Examples
+  copy the local file **test.txt** and name it **test1.txt** on the remote computer.
+  ```
+  put test.txt test1.txt
+  ```
+  copy the local file **program.exe** to the remote computer.
+  ```
+  put program.exe
+  ```
+  ## additional references
+- [ftp: ascii](ftp-ascii.md)
+- [ftp: binary](ftp-binary.md)
+- [Command-Line Syntax Key](command-line-syntax-key.md)


### PR DESCRIPTION
**Description:**

Based on the feedback comment in ticket #4086 (**Excellent ftp reference**), I discovered that this page does not show the parameters in their table. The angle brackets are the cause of this issue,

`<` and `>`, also known as the "Less Than" and "Greater Than" symbols, often indicate HTML tags in web page encoding. The table entries need to be escaped or encapsulated to avoid being interpreted as hidden code. Based on the syntax view, I will prefer to use MarkDown back tick encapsulation.

Thanks to @pernak01 (Ken Perna) for the opportunity.

**Changes proposed:**
- Add MD backticks around the bracketed table entries
- Add metadata details "FTP - put" for this command
- Whitespace changes:
    - Remove end-of-line whitespace (trim trailing space)
    - Add MD indent marker comp. spacing in "Applies To:"
    - Add alignment spacing and hyphens to the MD table.

**Ticket closure or reference:**

Closes #4086