### PR TITLE
Windows commands/bitsadmin: multi-page corrections

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-getclientcertificate.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-getclientcertificate.md
@@ -17,8 +17,6 @@ ms.date: 10/16/2017
 
 # bitsadmin getclientcertificate
 
-
-
 Retrieves the client certificate from the job.
 
 ## Syntax
@@ -29,15 +27,16 @@ bitsadmin /GetClientCertificate <Job>
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
+| Parameter | Description                    |
+| --------- | ------------------------------ |
+| Job       | The job's display name or GUID |
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example retrieves the client certificate for the job named *myDownloadJob*.
+
 ```
-C:\>bitsadmin / GetClientCertificate myDownloadJob
+C:\>bitsadmin /GetClientCertificate myDownloadJob
 ```
 
 #### Additional references

--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-getnotifyflags.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-getnotifyflags.md
@@ -17,8 +17,6 @@ ms.date: 10/16/2017
 
 # bitsadmin getnotifyflags
 
-
-
 Retrieves the notify flags for the specified job.
 
 ## Syntax
@@ -29,23 +27,25 @@ bitsadmin /GetNotifyFlags <Job>
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
+| Parameter | Description                    |
+| --------- | ------------------------------ |
+|    Job    | The job's display name or GUID |
 
 ## Remarks
 
 The job can contain one or more of the following notification flags.
 
-|-----|-----|
-|0x001|Generate an event when all files in the job have been transferred.|
-|0x002|Generate an event when an error occurs.|
-|0x004|Disable notifications.|
-|0x008|Generate an event when the job is modified or transfer progress is made.|
+| Flag  | Description                                                              |
+| ----- | ------------------------------------------------------------------------ |
+| 0x001 | Generate an event when all files in the job have been transferred.       |
+| 0x002 | Generate an event when an error occurs.                                  |
+| 0x004 | Disable notifications.                                                   |
+| 0x008 | Generate an event when the job is modified or transfer progress is made. |
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example retrieves the notify flags for the job named *myDownloadJob*.
+
 ```
 C:\>bitsadmin /GetNotifyFlags myDownloadJob
 ```

--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-setclientcertificatebyid.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-setclientcertificatebyid.md
@@ -17,8 +17,6 @@ ms.date: 10/16/2017
 
 # bitsadmin setclientcertificatebyid
 
-
-
 Specifies the identifier of the client certificate to use for client authentication in an HTTPS (SSL) request.
 
 ## Syntax
@@ -29,18 +27,19 @@ bitsadmin /SetClientCertificateByID <Job> <store_location> <store_name> hexa-dec
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
-|Store_location|Identifies the location of a system store to use for looking up the certificate. Possible values include:</br>1 (CURRENT_USER)</br>2 (LOCAL_MACHINE)</br>3 (CURRENT_SERVICE)</br>4 (SERVICES)</br>5 (USERS)</br>6 (CURRENT_USER_GROUP_POLICY)</br>7 (LOCAL_MACHINE_GROUP_POLICY)</br>8 (LOCAL_MACHINE_ENTERPRISE)|
-|Store_name|The name of the certificate store. Possible values include:</br>CA (Certification Authority certificates)</br>MY (Personal certificates)</br>ROOT (Root certificates)</br>SPC (Software Publisher Certificate)|
-|Hexadecimal_cert_id|A hexadecimal number representing the hash of the certificate|
+|      Parameter      | Description                    |
+| ------------------- | ------------------------------ |
+|         Job         | The job's display name or GUID |
+| Store_location      | Identifies the location of a system store to use for looking up the certificate. Possible values include:</br>1 (CURRENT_USER)</br>2 (LOCAL_MACHINE)</br>3 (CURRENT_SERVICE)</br>4 (SERVICES)</br>5 (USERS)</br>6 (CURRENT_USER_GROUP_POLICY)</br>7 (LOCAL_MACHINE_GROUP_POLICY)</br>8 (LOCAL_MACHINE_ENTERPRISE) |
+| Store_name          | The name of the certificate store. Possible values include:</br>CA (Certification Authority certificates)</br>MY (Personal certificates)</br>ROOT (Root certificates)</br>SPC (Software Publisher Certificate) |
+| Hexadecimal_cert_id | A hexadecimal number representing the hash of the certificate |
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example specifies the identifier of the client certificate to use for client authentication in an HTTPS (SSL) request for the job named *myJob*.
+
 ```
-C:\>bitsadmin Bitsadmin /SetClientCertificateByID myJob BG_CERT_STORE_LOCATION_CURRENT_USER MY A106B52356D3FBCD1853A41B619358BD 
+C:\>bitsadmin /SetClientCertificateByID myJob BG_CERT_STORE_LOCATION_CURRENT_USER MY A106B52356D3FBCD1853A41B619358BD 
 ```
 
 #### Additional references

--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-setclientcertificatebyname.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-setclientcertificatebyname.md
@@ -17,30 +17,29 @@ ms.date: 10/16/2017
 
 # bitsadmin setclientcertificatebyname
 
-
-
 Specifies the subject name of the client certificate to use for client authentication in an HTTPS (SSL) request.
 
 ## Syntax
 
 ```
-bitsadmin /SetClientCertificateByID <Job> <store_location> <store_name> <subject_name>
+bitsadmin /SetClientCertificateByName <Job> <store_location> <store_name> <subject_name>
 ```
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
-|Store_location|Identifies the location of a system store to use for looking up the certificate. Possible values include:</br>1 (CURRENT_USER)</br>2 (LOCAL_MACHINE)</br>3 (CURRENT_SERVICE)</br>4 (SERVICES)</br>5 (USERS)</br>6 (CURRENT_USER_GROUP_POLICY)</br>7 (LOCAL_MACHINE_GROUP_POLICY)</br>8 (LOCAL_MACHINE_ENTERPRISE)|
-|Store_name|The name of the certificate store. Possible values include:</br>CA (Certification Authority certificates)</br>MY (Personal certificates)</br>ROOT (Root certificates)</br>SPC (Software Publisher Certificate)|
-|Subject_name|Name of the certificate|
+|    Parameter   | Description                    |
+| -------------- | ------------------------------ |
+|       Job      | The job's display name or GUID |
+| Store_location | Identifies the location of a system store to use for looking up the certificate. Possible values include:</br>1 (CURRENT_USER)</br>2 (LOCAL_MACHINE)</br>3 (CURRENT_SERVICE)</br>4 (SERVICES)</br>5 (USERS)</br>6 (CURRENT_USER_GROUP_POLICY)</br>7 (LOCAL_MACHINE_GROUP_POLICY)</br>8 (LOCAL_MACHINE_ENTERPRISE) |
+| Store_name     | The name of the certificate store. Possible values include:</br>CA (Certification Authority certificates)</br>MY (Personal certificates)</br>ROOT (Root certificates)</br>SPC (Software Publisher Certificate) |
+| Subject_name   | Name of the certificate        |
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example specifies the name of the client certificate *myCertificate* to use for client authentication in an HTTPS (SSL) request for the job named *myJob*.
+
 ```
-C:\>bitsadmin Bitsadmin /SetClientCertificateByName myJob 1 MY myCertificate 
+C:\>bitsadmin /SetClientCertificateByName myJob 1 MY myCertificate 
 ```
 
 #### Additional references

--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-setcredentials.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-setcredentials.md
@@ -29,19 +29,20 @@ bitsadmin /SetCredentials <Job> <Target> <Scheme> <Username> <Password>
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
-|Target|SERVER or PROXY|
-|Scheme|One of the following:</br>-   BASIC—authentication scheme in which the user name and password are sent in clear-text to the server or proxy.</br>-   DIGEST—a challenge-response authentication scheme that uses a server-specified data string for the challenge.</br>-   NTLM—a challenge-response authentication scheme that uses the credentials of the user for authentication in a Windows network environment.</br>-   NEGOTIATE—also known as the Simple and Protected Negotiation protocol (Snego) is a challenge-response authentication scheme that negotiates with the server or proxy to determine which scheme to use for authentication. Examples are the Kerberos protocol and NTLM.</br>-   PASSPORT—a centralized authentication service provided by Microsoft that offers a single logon for member sites.|
-|Username|The name of the provided credentials|
-|Password|The password associated with the provided *Username*|
+| Parameter | Description                                          |
+| --------- | ---------------------------------------------------- |
+| Job       | The job's display name or GUID                       |
+| Target    | SERVER or PROXY                                      |
+| Scheme    | One of the following:</br>- BASIC—authentication scheme in which the user name and password are sent in clear-text to the server or proxy.</br>- DIGEST—a challenge-response authentication scheme that uses a server-specified data string for the challenge.</br>-   NTLM—a challenge-response authentication scheme that uses the credentials of the user for authentication in a Windows network environment.</br>-   NEGOTIATE—also known as the Simple and Protected Negotiation protocol (Snego) is a challenge-response authentication scheme that negotiates with the server or proxy to determine which scheme to use for authentication. Examples are the Kerberos protocol and NTLM.</br>- PASSPORT—a centralized authentication service provided by Microsoft that offers a single logon for member sites. |
+| Username  | The name of the provided credentials                 |
+| Password  | The password associated with the provided *Username* |
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example Adds credentials to the job named *myDownloadJob*.
+
 ```
-C:\>bitsadmin /RemoveCredentials myDownloadJob SERVER BASIC Edward Password20
+C:\>bitsadmin /SetCredentials myDownloadJob SERVER BASIC Edward Password20
 ```
 
 #### Additional references

--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-setcustomheaders.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-setcustomheaders.md
@@ -12,37 +12,36 @@ ms.assetid: ed926410-80d0-46ed-9a90-f752c164bb9a
 author: coreyp-at-msft
 ms.author: coreyp
 manager: dongill
-ms.date: 10/16/2017 
+ms.date: 10/16/2017
 ---
 
 # bitsadmin setcustomheaders
-
-
 
 Add a custom HTTP header to a GET request.
 
 ## Syntax
 
 ```
-bitsadmin /SetCustomHeaders <Job> <Header1> <Header2> <. . .>
+bitsadmin /SetCustomHeaders <Job> <Header1> <Header2> < ... >
 ```
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
-|Header1 Header2 . . .|The custom headers for the job|
+|      Parameter      | Description                    |
+| ------------------- | ------------------------------ |
+| Job                 | The job's display name or GUID |
+| Header1 Header2 ... | The custom headers for the job |
 
 ## Remarks
 
--   This switch is used to add a custom HTTP header to a GET request sent to an HTTP server.
+- This switch is used to add a custom HTTP header to a GET request sent to an HTTP server.
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example adds a custom HTTP header for the job named *myDownloadJob*.
+
 ```
-C:\>bitsadmin / SetCustomHeaders myDownloadJob "Accept-encoding:deflate/gzip"
+C:\>bitsadmin /SetCustomHeaders myDownloadJob "Accept-encoding:deflate/gzip"
 ```
 
 #### Additional references

--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-sethttpmethod.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-sethttpmethod.md
@@ -21,15 +21,15 @@ Sets the HTTP verb to use.
 ## Syntax
 
 ```
-bitsadmin /GetHttpMethod <Job> <HTTPMethod>
+bitsadmin /SetHttpMethod <Job> <HTTPMethod>
 ```
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
-|HTTPMethod|The HTTP verb to use|
+| Parameter  | Description                    |
+| ---------  | ------------------------------ |
+| Job        | The job's display name or GUID |
+| HTTPMethod | The HTTP verb to use           |
 
 #### Additional references
 

--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-setnotifyflags.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-setnotifyflags.md
@@ -27,23 +27,25 @@ bitsadmin /SetNotifyFlags <Job> <NotifyFlags>
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
-|NotifyFlags|See Remarks|
+|  Parameter   | Description                     |
+| ------------ | ------------------------------- |
+|     Job      |  The job's display name or GUID |
+|  NotifyFlags |  See Remarks                    |
 
 ## Remarks
 
 The **NotifyFlags** parameter can contain one or more of the following notification flags.
 
-|-----|-----|
-|1|Generate an event when all files in the job have been transferred.|
-|2|Generate an event when an error occurs.|
-|4|Disable notifications.|
+| Flag | Description                                                        |
+| ---- | ------------------------------------------------------------------ |
+|   1  | Generate an event when all files in the job have been transferred. |
+|   2  | Generate an event when an error occurs.                            |
+|   4  | Disable notifications.                                             |
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example sets the notify flags for transferred and error events job for job named *myDownloadJob*.
+
 ```
 C:\>bitsadmin /SetNotifyFlags myDownloadJob 3
 ```

--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-setpeercachingflags.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-setpeercachingflags.md
@@ -17,28 +17,27 @@ ms.date: 10/16/2017
 
 # bitsadmin setpeercachingflags
 
-
-
 Sets flags that determine if the files of the job can be cached and served to peers and if the job can download content from peers.
 
 ## Syntax
 
 ```
-bitsadmin /SetPeerCachingFlags <Job> <value> 
+bitsadmin /SetPeerCachingFlags <Job> <value>
 ```
 
 ## Parameters
 
-|Parameter|Description|
-|---------|-----------|
-|Job|The job's display name or GUID|
-|Value|The value is an unsigned integer with the following interpretation for the bits in the binary representation.</br>1 - The job can download content from peers.</br>2 - The files of the job can be cached and served to peers.|
+| Parameter | Description                    |
+| --------- | ------------------------------ |
+| Job       | The job's display name or GUID |
+| Value     | The value is an unsigned integer with the following interpretation for the bits in the binary representation.</br>1 - The job can download content from peers.</br>2 - The files of the job can be cached and served to peers. |
 
 ## <a name="BKMK_examples"></a>Examples
 
 The following example sets flags for the job named *myJob* which allows it to download content from peers.
+
 ```
-C:\>bitsadmin / SetPeerCachingFlags myJob 1 
+C:\>bitsadmin /SetPeerCachingFlags myJob 1
 ```
 
 #### Additional references


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4137 (**Some mistakes in bitsadmin /***), there are a few issues in these 9 pages.
- Broken table (2 pages)
- Double commands (2 pages)
- Wrong examples (2 pages)
- Unexpected space (3 pages)

Thanks to @WiVi71 for reporting these issues.

**Changes proposed:**
- Add missing MD table header (2 pages)
- Remove duplicate command (2 pages)
- Correct example parameter (2 pages)
- Remove unexpected space (3 pages)
- Formatting readability improvements:
    - Remove redundant blank lines below title header
    - Align MD table grid characters (readability/within reason)
    - Add recommended blank line before example MD code fence
    - Add missing NewLine before EOF (end-of-file)

**Additional note:**

Regarding the comment "_And also value 3 is missing_":

No, 3 is a bitwise combination of 1 + 2, meaning the combination of parameter flags 1 + 2 = 3.
Logically speaking, this implies the following list of options:

1 : Generate an event when all files in the job have been transferred.
2 : Generate an event when an error occurs.
3 : Generate events for both instances above.
4 : Disable notifications.

If you want me to add that bitwise combination value & description to the table for bitsadmin /SetNotifyFlags , please comment in the PR.
(Otherwise, I will refer to this as an obvious conclusion for coders.)

**Ticket closure or reference:**

Closes #4137