### PR TITLE
Remove unnecessary white-space

### DIFF
--- a/WindowsServerDocs/identity/software-restriction-policies/determine-allow-deny-list-and-application-inventory-for-software-restriction-policies.md
+++ b/WindowsServerDocs/identity/software-restriction-policies/determine-allow-deny-list-and-application-inventory-for-software-restriction-policies.md
@@ -42,7 +42,7 @@ To effectively use the Allow default rule, you need to determine exactly which a
 
 2.  Create the following registry value in order to enable the advanced logging feature and set the path to where the log file should be written.
 
-    **"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Safer\ CodeIdentifiers"**
+    **"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Safer\CodeIdentifiers"**
 
     String Value: *NameLogFile path to NameLogFile*
 

--- a/WindowsServerDocs/identity/software-restriction-policies/determine-allow-deny-list-and-application-inventory-for-software-restriction-policies.md
+++ b/WindowsServerDocs/identity/software-restriction-policies/determine-allow-deny-list-and-application-inventory-for-software-restriction-policies.md
@@ -44,7 +44,7 @@ To effectively use the Allow default rule, you need to determine exactly which a
 
     **"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Safer\CodeIdentifiers"**
 
-    String Value: *NameLogFile path to NameLogFile*
+    String Value: *LogFileName path to LogFileName*
 
     Because SRP is evaluating all applications when they run, an entry is written to the log file *NameLogFile* each time that application is run.
 
@@ -63,5 +63,4 @@ To effectively use the Allow default rule, you need to determine exactly which a
     An example of the output written to a log file:
 
 **explorer.exe (PID = 4728) identifiedC:\Windows\system32\onenote.exe as Unrestricted usingpath rule, Guid ={320bd852-aa7c-4674-82c5-9a80321670a3}**    All applications and associated code that SRP checks and set to block will be noted in the log file, which you then can use to determine which executables should be considered for your Allowed list.
-
 


### PR DESCRIPTION
This registry path isn't correct. (Correct is that there is no space.)
Remove unnecessary white-space.
![pr](https://user-images.githubusercontent.com/12828432/79319447-4bd4e000-7f43-11ea-9a98-c7fc601dd45c.png)