### PR TITLE
Diagnostics Hub Standard Collector service text

### DIFF
--- a/WindowsServerDocs/security/windows-services/security-guidelines-for-disabling-system-services-in-windows-server.md
+++ b/WindowsServerDocs/security/windows-services/security-guidelines-for-disabling-system-services-in-windows-server.md
@@ -20,2683 +20,2481 @@ However, some enterprise customers may prefer a more security-focused balance fo
 
 The guidance is only for Windows Server 2016 with Desktop Experience (unless used as a desktop replacement for end users). Beginning with Windows Server 2019, these guidelines are configured by default. Each service on the system is categorized as follows:
 
--   **Should Disable:** A security-focused enterprise will most likely prefer to disable this service and forego its functionality (see additional details below).
-- **OK to Disable:** This service provides functionality that is useful to some but not all enterprises, and security-focused enterprises that don't use it can safely disable it.
+- **Should Disable:** A security-focused enterprise will most likely prefer to disable this service and forego its functionality (see additional details below).
+- **OK to Disable:**  This service provides functionality that is useful to some but not all enterprises, and security-focused enterprises that don't use it can safely disable it.
 - **Do Not Disable:** Disabling this service will impact essential functionality or prevent specific roles or features from functioning correctly. Therefore it should not be disabled.
--  **(No guidance):** The impact of disabling these services has not been fully evaluated. Therefore, the default configuration of these services should not be changed.
-
+- **(No guidance):**  The impact of disabling these services has not been fully evaluated. Therefore, the default configuration of these services should not be changed.
 
 Customers can configure their Windows PCs and servers to disable selected services using the Security Templates in their Group Policies or using PowerShell automation. In some cases, the guidance includes specific Group Policy settings that disable the service's functionality directly, as an alternative to disabling the service itself.
 
 Microsoft recommends that customers disable the following services and their respective scheduled tasks on Windows Server 2016 with Desktop Experience:
 
-Services: 
+Services:
 1. Xbox Live Auth Manager
 2. Xbox Live Game Save
 
-Scheduled tasks: 
+Scheduled tasks:
 1. \Microsoft\XblGameSave\XblGameSaveTask
 2. \Microsoft\XblGameSave\XblGameSaveTaskLogon
 
 (You can also access the information on all services detailed in this article by viewing the attached Microsoft Excel spreadsheet: [Guidance on Disabling System Services on Windows Server 2016 with Desktop Experience](https://msdnshared.blob.core.windows.net/media/2017/05/Service-management-WS2016.xlsx))
 
 
-
 ### Disabling services not installed by default
 
 Microsoft recommends against applying policies to disable services that are not installed by default.
--  The service is usually needed if the feature is installed. Installing the service or the feature requires administrative rights. Disallow the feature installation, not the service startup.
--  Blocking the Microsoft Windows service doesn't stop an admin (or non-admin in some cases) from installing a similar third-party equivalent, perhaps one with a higher security risk.
--  A baseline or benchmark that disables a non-default Windows service (for example, W3SVC) will give some auditors the mistaken impression that the technology (for example, IIS) is inherently insecure and should never be used.
--  If the feature (and service) is never installed, this just adds unnecessary bulk to the baseline and to verification work.
+- The service is usually needed if the feature is installed. Installing the service or the feature requires administrative rights. Disallow the feature installation, not the service startup.
+- Blocking the Microsoft Windows service doesn't stop an admin (or non-admin in some cases) from installing a similar third-party equivalent, perhaps one with a higher security risk.
+- A baseline or benchmark that disables a non-default Windows service (for example, W3SVC) will give some auditors the mistaken impression that the technology (for example, IIS) is inherently insecure and should never be used.
+- If the feature (and service) is never installed, this just adds unnecessary bulk to the baseline and to verification work.
 
-
-For all system services listed in this document, the two tables that follow offer an explanation of columns and Microsoft recommendations for enabling and disabling system services in Windows Server 2016 with Desktop Experience: 
-
+For all system services listed in this document, the two tables that follow offer an explanation of columns and Microsoft recommendations for enabling and disabling system services in Windows Server 2016 with Desktop Experience:
 
 
 ### Explanation of columns
 
-| | |
-|---|---|
-|**Service description**|   The service's description, from sc.exe qdescription.|
-|**Name** |Key (internal) name of the service|
-|**Installation** | *Always installed*: Service is installed on Windows Server 2016 Core and Windows Server 2016 with Desktop Experience. *Only with Desktop Experience*: Service is on Windows Server 2016 with Desktop Experience, but is ***not*** installed on Server Core. |
-|**StartType**  |Service start type on Windows Server 2016|
-|**Recommendation** |Microsoft recommendation/advice about disabling this service on Windows Server 2016 in a typical, well-managed enterprise deployment and where the server is not being used as an end-user desktop replacement.|
-|**Comments** |Additional explanation|
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Key (internal) name of the service|
+| **Description**    | The service's description, from sc.exe qdescription.|
+| **Installation**   | *Always installed*: Service is installed on Windows Server 2016 Core and Windows Server 2016 with Desktop Experience. *Only with Desktop Experience*: Service is on Windows Server 2016 with Desktop Experience, but is ***not*** installed on Server Core. |
+| **Startup type**   | Service Startup type on Windows Server 2016|
+| **Recommendation** | Microsoft recommendation/advice about disabling this service on Windows Server 2016 in a typical, well-managed enterprise deployment and where the server is not being used as an end-user desktop replacement.|
+| **Comments**       | Additional explanation|
 
 
 ### Explanation of Microsoft recommendations
 
-| | |
-|---|---|
-|**Do not disable** |This service should not be disabled|
-|**OK to disable**| This service can be disabled if the feature it supports is not being used.|
-|**Already disabled**|  This service is disabled by default; no need to enforce with policy|
-|**Should be disabled** |This service should never be enabled on a well-managed enterprise system.|
-
-
+|                        |      |
+| ---------------------- | ---- |
+| **Do not disable**     | This service should not be disabled |
+| **OK to disable**      | This service can be disabled if the feature it supports is not being used. |
+| **Already disabled**   | This service is disabled by default; no need to enforce with policy |
+| **Should be disabled** | This service should never be enabled on a well-managed enterprise system. |
 
 The following tables offer Microsoft guidance on disabling system services on Windows Server 2016 with Desktop Experience:
 
 
-
 ##  ActiveX Installer (AxInstSV)
 
-| | |
-|---|---|
-|   **Service description** |   Provides User Account Control validation for the installation of ActiveX controls from the Internet and enables management of ActiveX control installation based on Group Policy settings. This service is started on demand and if disabled the installation of ActiveX controls will behave according to default browser settings.    |
-|   **Service name**    |   AxInstSV    |
-|   **Installation**    |   Only with Desktop Experience    |
-|   **StartType**   |   Manual  |
-|   **Recommendation**  |   OK to disable   |
-|   **Comments**    |   OK to disable if feature not needed |
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | AxInstSV    |
+| **Description**    | Provides User Account Control validation for the installation of ActiveX controls from the Internet and enables management of ActiveX control installation based on Group Policy settings. This service is started on demand and if disabled the installation of ActiveX controls will behave according to default browser settings.    |
+| **Installation**   | Only with Desktop Experience    |
+| **Startup type**   | Manual  |
+| **Recommendation** | OK to disable   |
+| **Comments**       | OK to disable if feature not needed |
 
 
+## AllJoyn Router Service
 
-
-## AllJoyn Router Service   
-
-| | |
-|---|---|
-|   **Service description** |   Routes AllJoyn messages for the local AllJoyn clients. If this service is stopped the AllJoyn clients that do not have their own bundled routers will be unable to run. |
-|   **Service name**    |   AJRouter    |
-|   **Installation**    |   Only with Desktop Experience    |
-|   **StartType**   |   Manual  |
-|   **Recommendation**  | No guidance       |
-|   **Comments**    |       |
-| | |
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | AJRouter    |
+| **Description**    | Routes AllJoyn messages for the local AllJoyn clients. If this service is stopped the AllJoyn clients that do not have their own bundled routers will be unable to run. |
+| **Installation**   | Only with Desktop Experience    |
+| **Startup type**   | Manual  |
+| **Recommendation** | No guidance       |
+| **Comments**       |     |
+|||
 
 
 ## App Readiness
 
-| | |
-|---|---|
-**Service description** |   Gets apps ready for use the first time a user signs in to this PC and when adding new apps.
-**Service name**    |   AppReadiness
-**Installation**    |   Only with Desktop Experience
-**StartType**   |   Manual
-**Recommendation**  |   Do not disable
-**Comments**    |   
-| | |
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | AppReadiness
+| **Description**    | Gets apps ready for use the first time a user signs in to this PC and when adding new apps.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       |
+|||
 
 
 ##  Application Identity
 
-| | |       
-|---|---|   
-**Service description** |   Determines and verifies the identity of an application. Disabling this service will prevent AppLocker from being enforced.
-**Service name**    |   AppIDSvc
-**Installation**    |   Always installed
-**StartType**   |   Manual
-**Recommendation**  |No guidance    
-**Comments**    |   
-|||     
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | AppIDSvc
+| **Description**    | Determines and verifies the identity of an application. Disabling this service will prevent AppLocker from being enforced.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+##  Application Information
 
-##  Application Information 
-
-| | |       
-|---|---|   
-|   **Service description** |   Facilitates the running of interactive applications with additional administrative privileges.  If this service is stopped, users will be unable to launch applications with the additional administrative privileges they may require to perform desired user tasks.
-|   **Service name**    |   Appinfo
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   Supports UAC same-desktop elevation
-|||     
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Appinfo
+| **Description**    | Facilitates the running of interactive applications with additional administrative privileges.  If this service is stopped, users will be unable to launch applications with the additional administrative privileges they may require to perform desired user tasks.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       | Supports UAC same-desktop elevation
+|||
 
 
-##  Application Layer Gateway Service       
+##  Application Layer Gateway Service
 
-| | |           
-|---|---|           
-|   **Service description** |   Provides support for third-party protocol plug-ins for Internet Connection Sharing
-|   **Service name**    |   ALG
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |No guidance    
-|   **Comments**    |   
-|||     
-
-
-
-##  Application Management      
-
-| | |           
-|---|---|       
-|   **Service description** |   Processes installation, removal, and enumeration requests for software deployed through Group Policy. If the service is disabled, users will be unable to install, remove, or enumerate software deployed through Group Policy. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   AppMgmt
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | ALG
+| **Description**    | Provides support for third-party protocol plug-ins for Internet Connection Sharing
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+##  Application Management
 
-##  AppX Deployment Service (AppXSVC)       
-
-| | |           
-|---|---|
-|   **Service description** |   Provides infrastructure support for deploying Store applications. This service is started on demand and if disabled Store applications will not be deployed to the system, and may not function properly.
-|   **Service name**    |   AppXSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | AppMgmt
+| **Description**    | Processes installation, removal, and enumeration requests for software deployed through Group Policy. If the service is disabled, users will be unable to install, remove, or enumerate software deployed through Group Policy. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Auto Time Zone Updater           
+##  AppX Deployment Service (AppXSVC)
 
-| | |           
-|---|---|           
-|   **Service description** |   Automatically sets the system time zone.
-|   **Service name**    |   tzautoupdate
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   
-|||         
-
-
-
-## Background Intelligent Transfer Service          
-
-| | |           
-|---|---|   
-|   **Service description** |   Transfers files in the background using idle network bandwidth. If the service is disabled, then any applications that depend on BITS, such as Windows Update or MSN Explorer, will be unable to automatically download programs and other information.
-|   **Service name**    |   BITS
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | AppXSvc
+| **Description**    | Provides infrastructure support for deploying Store applications. This service is started on demand and if disabled Store applications will not be deployed to the system, and may not function properly.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Auto Time Zone Updater
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | tzautoupdate
+| **Description**    | Automatically sets the system time zone.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       |
+|||
 
 
-## Background Tasks Infrastructure Service      
+## Background Intelligent Transfer Service
 
-| | |           
-|---|---|   
-|   **Service description** |   Windows infrastructure service that controls which background tasks can run on the system.
-|   **Service name**    |   BrokerInfrastructure
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Base Filtering Engine            
-
-| | |           
-|---|---|       
-|   **Service description** |   The Base Filtering Engine (BFE) is a service that manages firewall and Internet Protocol security (IPsec) policies and implements user mode filtering. Stopping or disabling the BFE service will significantly reduce the security of the system. It will also result in unpredictable behavior in IPsec management and firewall applications.
-|   **Service name**    |   BFE
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | BITS
+| **Description**    | Transfers files in the background using idle network bandwidth. If the service is disabled, then any applications that depend on BITS, such as Windows Update or MSN Explorer, will be unable to automatically download programs and other information.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Background Tasks Infrastructure Service
 
-## Bluetooth Support Service            
-
-| | |           
-|---|---|   
-|   **Service description** |   The Bluetooth service supports discovery and association of remote Bluetooth devices.  Stopping or disabling this service may cause already installed Bluetooth devices to fail to operate properly and prevent new devices from being discovered or associated.
-|   **Service name**    |   bthserv
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   OK to disable if not used. Another disabling mechanism: https://technet.microsoft.com/library/dd252791.aspx
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | BrokerInfrastructure
+| **Description**    | Windows infrastructure service that controls which background tasks can run on the system.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Base Filtering Engine
 
-## CDPUserSvc           
-
-| | |           
-|---|---|   
-|   **Service description** |   This user service is used for Connected Devices Platform scenarios
-|   **Service name**    |   CDPUserSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   User service template
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | BFE
+| **Description**    | The Base Filtering Engine (BFE) is a service that manages firewall and Internet Protocol security (IPsec) policies and implements user mode filtering. Stopping or disabling the BFE service will significantly reduce the security of the system. It will also result in unpredictable behavior in IPsec management and firewall applications.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Bluetooth Support Service
 
-##  Certificate Propagation     
-
-| | |           
-|---|---|
-|   **Service description** |   Copies user certificates and root certificates from smart cards into the current user's certificate store, detects when a smart card is inserted into a smart card reader, and if needed, installs the smart card Plug and Play minidriver.
-|   **Service name**    |   CertPropSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | bthserv
+| **Description**    | The Bluetooth service supports discovery and association of remote Bluetooth devices.  Stopping or disabling this service may cause already installed Bluetooth devices to fail to operate properly and prevent new devices from being discovered or associated.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | OK to disable if not used. Another disabling mechanism: https://technet.microsoft.com/library/dd252791.aspx
+|||
 
 
-##  Client License Service (ClipSVC)        
+## CDPUserSvc
 
-| | |           
-|---|---|   
-|   **Service description** |   Provides infrastructure support for the Microsoft Store. This service is started on demand and if disabled applications bought using Microsoft Store will not behave correctly.
-|   **Service name**    |   ClipSVC
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | CDPUserSvc
+| **Description**    | This user service is used for Connected Devices Platform scenarios
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | OK to disable
+| **Comments**       | User service template
+|||
 
+
+##  Certificate Propagation
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | CertPropSvc
+| **Description**    | Copies user certificates and root certificates from smart cards into the current user's certificate store, detects when a smart card is inserted into a smart card reader, and if needed, installs the smart card Plug and Play minidriver.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Client License Service (ClipSVC)
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | ClipSVC
+| **Description**    | Provides infrastructure support for the Microsoft Store. This service is started on demand and if disabled applications bought using Microsoft Store will not behave correctly.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
 ## CNG Key Isolation
 
-| | |           
-|---|---|   
-|   **Service description** |   The CNG key isolation service is hosted in the LSA process. The service provides key process isolation to private keys and associated cryptographic operations as required by the Common Criteria. The service stores and uses long-lived keys in a secure process complying with Common Criteria requirements.
-|   **Service name**    |   KeyIso
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | KeyIso
+| **Description**    | The CNG key isolation service is hosted in the LSA process. The service provides key process isolation to private keys and associated cryptographic operations as required by the Common Criteria. The service stores and uses long-lived keys in a secure process complying with Common Criteria requirements.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+##  COM+ Event System
 
-##  COM+ Event System       
-
-| | |           
-|---|---|       
-|   **Service description** |   Supports System Event Notification Service (SENS), which provides automatic distribution of events to subscribing Component Object Model (COM) components. If the service is stopped, SENS will close and will not be able to provide logon and logoff notifications. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   EventSystem
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | EventSystem
+| **Description**    | Supports System Event Notification Service (SENS), which provides automatic distribution of events to subscribing Component Object Model (COM) components. If the service is stopped, SENS will close and will not be able to provide logon and logoff notifications. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-##  COM+ System Application     
+##  COM+ System Application
 
-| | |           
-|---|---|       
-|   **Service description** |   Manages the configuration and tracking of Component Object Model (COM)+-based components. If the service is stopped, most COM+-based components will not function properly. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   COMSysApp
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Computer Browser        
-
-| | |           
-|---|---|       
-|   **Service description** |   Maintains an updated list of computers on the network and supplies this list to computers designated as browsers. If this service is stopped, this list will not be updated or maintained. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   Browser
-|   **Installation**    |   Always installed
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | COMSysApp
+| **Description**    | Manages the configuration and tracking of Component Object Model (COM)+-based components. If the service is stopped, most COM+-based components will not function properly. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+##  Computer Browser
 
-## Connected Devices Platform Service       
-
-| | |           
-|---|---|       
-|   **Service description** |   This service is used for Connected Devices and Universal Glass scenarios
-|   **Service name**    |   CDPSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Browser
+| **Description**    | Maintains an updated list of computers on the network and supplies this list to computers designated as browsers. If this service is stopped, this list will not be updated or maintained. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       |
+|||
 
 
-## Connected User Experiences and Telemetry     
+## Connected Devices Platform Service
 
-| | |           
-|---|---|       
-|   **Service description** |   The Connected User Experiences and Telemetry service enables features that support in-application and connected user experiences. Additionally, this service manages the event-driven collection and transmission of diagnostic and usage information (used to improve the experience and quality of the Windows Platform) when the diagnostics and usage privacy option settings are enabled under Feedback and Diagnostics.
-|   **Service name**    |   DiagTrack
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Contact Data        
-
-| | |           
-|---|---|       
-|   **Service description** |   Indexes contact data for fast contact searching. If you stop or disable this service, contacts might be missing from your search results.
-|   **Service name**    |   PimIndexMaintenanceSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   User service template
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | CDPSvc
+| **Description**    | This service is used for Connected Devices and Universal Glass scenarios
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Connected User Experiences and Telemetry
 
-## CoreMessaging            
-
-| | |           
-|---|---|           
-|   **Service description** |   Manages communication between system components.
-|   **Service name**    |   CoreMessagingRegistrar
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DiagTrack
+| **Description**    | The Connected User Experiences and Telemetry service enables features that support in-application and connected user experiences. Additionally, this service manages the event-driven collection and transmission of diagnostic and usage information (used to improve the experience and quality of the Windows Platform) when the diagnostics and usage privacy option settings are enabled under Feedback and Diagnostics.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Credential Manager           
+##  Contact Data
 
-| | |           
-|---|---|       
-|   **Service description** |   Provides secure storage and retrieval of credentials to users, applications and security service packages.
-|   **Service name**    |   VaultSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Cryptographic Services           
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides three management services: Catalog Database Service, which confirms the signatures of Windows files and allows new programs to be installed; Protected Root Service, which adds and removes Trusted Root Certification Authority certificates from this computer; and Automatic Root Certificate Update Service, which retrieves root certificates from Windows Update and enable scenarios such as SSL. If this service is stopped, these management services will not function properly. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   CryptSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | PimIndexMaintenanceSvc
+| **Description**    | Indexes contact data for fast contact searching. If you stop or disable this service, contacts might be missing from your search results.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | User service template
+|||
 
 
+## CoreMessaging
 
-## Data Sharing Service         
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides data brokering between applications.
-|   **Service name**    |   DsSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | CoreMessagingRegistrar
+| **Description**    | Manages communication between system components.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## DataCollectionPublishingService          
+## Credential Manager
 
-| | |           
-|---|---|       
-|   **Service description** |   The DCP (Data Collection and Publishing) service supports first-party apps to upload data to cloud.
-|   **Service name**    |   DcpSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## DCOM Server Process Launcher         
-
-| | |           
-|---|---|       
-|   **Service description** |   The DCOMLAUNCH service launches COM and DCOM servers in response to object activation requests. If this service is stopped or disabled, programs using COM or DCOM will not function properly. It is strongly recommended that you have the DCOMLAUNCH service running.
-|   **Service name**    |   DcomLaunch
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  |No guidance    
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | VaultSvc
+| **Description**    | Provides secure storage and retrieval of credentials to users, applications and security service packages.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Cryptographic Services
 
-##  Device Association Service      
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | CryptSvc
+| **Description**    | Provides three management services: Catalog Database Service, which confirms the signatures of Windows files and allows new programs to be installed; Protected Root Service, which adds and removes Trusted Root Certification Authority certificates from this computer; and Automatic Root Certificate Update Service, which retrieves root certificates from Windows Update and enable scenarios such as SSL. If this service is stopped, these management services will not function properly. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
-| | |           
-|---|---|       
-|   **Service description** |   Enables pairing between the system and wired or wireless devices.
-|   **Service name**    |   DeviceAssociationService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
 
+## Data Sharing Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DsSvc
+| **Description**    | Provides data brokering between applications.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## DataCollectionPublishingService
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DcpSvc
+| **Description**    | The DCP (Data Collection and Publishing) service supports first-party apps to upload data to cloud.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## DCOM Server Process Launcher
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DcomLaunch
+| **Description**    | The DCOMLAUNCH service launches COM and DCOM servers in response to object activation requests. If this service is stopped or disabled, programs using COM or DCOM will not function properly. It is strongly recommended that you have the DCOMLAUNCH service running.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+|   **Recommendation** |No guidance
+| **Comments**       |
+|||
+
+
+##  Device Association Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DeviceAssociationService
+| **Description**    | Enables pairing between the system and wired or wireless devices.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
 ##  Device Install Service
 
-| | |
-|---|---|
-|   **Service description** |   Enables a computer to recognize and adapt to hardware changes with little or no user input. Stopping or disabling this service will result in system instability.
-|   **Service name**    |   DeviceInstall
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance
-|   **Comments**    |
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DeviceInstall
+| **Description**    | Enables a computer to recognize and adapt to hardware changes with little or no user input. Stopping or disabling this service will result in system instability.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
 |||
 
 
+##  Device Management Enrollment Service
 
-##  Device Management Enrollment Service        
-
-| | |           
-|---|---|       
-|   **Service description** |   Performs Device Enrollment Activities for Device Management
-|   **Service name**    |   DmEnrollmentSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DmEnrollmentSvc
+| **Description**    | Performs Device Enrollment Activities for Device Management
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Device Setup Manager         
+## Device Setup Manager
 
-| | |           
-|---|---|       
-|   **Service description** |   Enables the detection, download and installation of device-related software. If this service is disabled, devices may be configured with outdated software, and may not work correctly.
-|   **Service name**    |   DsmSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## DevQuery Background Discovery Broker         
-
-| | |           
-|---|---|           
-|   **Service description** |   Enables apps to discover devices with a backgroud task
-|   **Service name**    |   DevQueryBroker
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DsmSvc
+| **Description**    | Enables the detection, download and installation of device-related software. If this service is disabled, devices may be configured with outdated software, and may not work correctly.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## DevQuery Background Discovery Broker
 
-## DHCP Client          
-
-| | |           
-|---|---|       
-|   **Service description** |   Registers and updates IP addresses and DNS records for this computer. If this service is stopped, this computer will not receive dynamic IP addresses and DNS updates. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   Dhcp
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DevQueryBroker
+| **Description**    | Enables apps to discover devices with a backgroud task
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Diagnostic Policy Service            
+## DHCP Client
 
-| | |           
-|---|---|       
-|   **Service description** |   The Diagnostic Policy Service enables problem detection, troubleshooting and resolution for Windows components.  If this service is stopped, diagnostics will no longer function.
-|   **Service name**    |   DPS
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Diagnostic Service Host     
-
-| | |           
-|---|---|       
-|   **Service description** |   The Diagnostic Service Host is used by the Diagnostic Policy Service to host diagnostics that need to run in a Local Service context.  If this service is stopped, any diagnostics that depend on it will no longer function.
-|   **Service name**    |   WdiServiceHost
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Dhcp
+| **Description**    | Registers and updates IP addresses and DNS records for this computer. If this service is stopped, this computer will not receive dynamic IP addresses and DNS updates. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Diagnostic Policy Service
 
-## Diagnostic System Host           
-
-| | |           
-|---|---|       
-|   **Service description** |   The Diagnostic System Host is used by the Diagnostic Policy Service to host diagnostics that need to run in a Local System context.  If this service is stopped, any diagnostics that depend on it will no longer function.
-|   **Service name**    |   WdiSystemHost
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | DPS
+| **Description**    | The Diagnostic Policy Service enables problem detection, troubleshooting and resolution for Windows components.  If this service is stopped, diagnostics will no longer function.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-##  Distributed Link Tracking Client            
+##  Diagnostic Service Host
 
-| | |           
-|---|---|   
-|   **Service description** |   Maintains links between NTFS files within a computer or across computers in a network.
-|   **Service name**    |   TrkWks
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Distributed Transaction Coordinator     
-
-| | |           
-|---|---|   
-|   **Service description** |   Coordinates transactions that span multiple resource managers, such as databases, message queues, and file systems. If this service is stopped, these transactions will fail. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   MSDTC
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WdiServiceHost
+| **Description**    | The Diagnostic Service Host is used by the Diagnostic Policy Service to host diagnostics that need to run in a Local Service context.  If this service is stopped, any diagnostics that depend on it will no longer function.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Diagnostic System Host
 
-##  dmwappushsvc        
-
-| | |           
-|---|---|       
-|   **Service description** |   WAP Push Message Routing Service
-|   **Service name**    |   dmwappushservice
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Service required on client devices for Intune, MDM and similar management technologies, and for Unified Write Filter. Not needed for Server.
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WdiSystemHost
+| **Description**    | The Diagnostic System Host is used by the Diagnostic Policy Service to host diagnostics that need to run in a Local System context.  If this service is stopped, any diagnostics that depend on it will no longer function.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-##  DNS Client      
+##  Distributed Link Tracking Client
 
-| | |           
-|---|---|       
-|   **Service description** |   The DNS Client service (dnscache) caches Domain Name System (DNS) names and registers the full computer name for this computer. If the service is stopped, DNS names will continue to be resolved. However, the results of DNS name queries will not be cached and the computer's name will not be registered. If the service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   Dnscache
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Downloaded Maps Manager     
-
-| | |           
-|---|---|   
-|   **Service description** |   Windows service for application access to downloaded maps. This service is started on-demand by application accessing downloaded maps. Disabling this service will prevent apps from accessing maps.
-|   **Service name**    |   MapsBroker
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Disabling breaks apps that rely on the service; OK to disable if apps not relying on it
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | TrkWks
+| **Description**    | Maintains links between NTFS files within a computer or across computers in a network.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+##  Distributed Transaction Coordinator
 
-## Embedded Mode            
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | MSDTC
+| **Description**    | Coordinates transactions that span multiple resource managers, such as databases, message queues, and file systems. If this service is stopped, these transactions will fail. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
-| | |           
-|---|---|       
-|   **Service description** |   The Embedded Mode service enables scenarios related to Background Applications.  Disabling this service will prevent Background Applications from being activated.
-|   **Service name**    |   embeddedmode
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
 
+##  dmwappushsvc
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | dmwappushservice
+| **Description**    | WAP Push Message Routing Service
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | Service required on client devices for Intune, MDM and similar management technologies, and for Unified Write Filter. Not needed for Server.
+|||
+
+
+##  DNS Client
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Dnscache
+| **Description**    | The DNS Client service (dnscache) caches Domain Name System (DNS) names and registers the full computer name for this computer. If the service is stopped, DNS names will continue to be resolved. However, the results of DNS name queries will not be cached and the computer's name will not be registered. If the service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Downloaded Maps Manager
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | MapsBroker
+| **Description**    | Windows service for application access to downloaded maps. This service is started on-demand by application accessing downloaded maps. Disabling this service will prevent apps from accessing maps.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | OK to disable
+| **Comments**       | Disabling breaks apps that rely on the service; OK to disable if apps not relying on it
+|||
+
+
+## Embedded Mode
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | embeddedmode
+| **Description**    | The Embedded Mode service enables scenarios related to Background Applications.  Disabling this service will prevent Background Applications from being activated.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
 ## Encrypting File System (EFS)
 
-| | |                   
-|---|---|           
-|   **Service description** | Provides the core file encryption technology used to store encrypted files on NTFS file system volumes. If this service is stopped or disabled, applications will be unable to access encrypted files.            
-|   **Service name**  |  EFS            
-|   **Installation**  |  Always installed           
-|   **StartType**   |  Manual           
-|   **Recommendation**  | No guidance           
-|   **Comments**   |
-|||                 
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   |  EFS
+| **Description**    | Provides the core file encryption technology used to store encrypted files on NTFS file system volumes. If this service is stopped or disabled, applications will be unable to access encrypted files.
+| **Installation**   |  Always installed
+| **Startup type**   |  Manual
+| **Recommendation** | No guidance
+|   **Comments**     |
+|||
 
 
+## Enterprise App Management Service
 
-## Enterprise App Management Service            
-
-| | |           
-|---|---|       
-|   **Service description** |   Enables enterprise application management.
-|   **Service name**    |   EntAppSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | EntAppSvc
+| **Description**    | Enables enterprise application management.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Extensible Authentication Protocol           
+## Extensible Authentication Protocol
 
-| | |           
-|---|---|   
-|   **Service description** |   The Extensible Authentication Protocol (EAP) service provides network authentication in such scenarios as 802.1x wired and wireless, VPN, and Network Access Protection (NAP).  EAP also provides application programming interfaces (APIs) that are used by network access clients, including wireless and VPN clients, during the authentication process.  If you disable this service, this computer is prevented from accessing networks that require EAP authentication.
-|   **Service name**    |   EapHost
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Function Discovery Provider Host         
-
-| | |           
-|---|---|       
-|   **Service description** |   The FDPHOST service hosts the Function Discovery (FD) network discovery providers. These FD providers supply network discovery services for the Simple Services Discovery Protocol (SSDP) and Web Services - Discovery (WS-D) protocol. Stopping or disabling the FDPHOST service will disable network discovery for these protocols when using FD. When this service is unavailable, network services using FD and relying on these discovery protocols will be unable to find network devices or resources.
-|   **Service name**    |   fdPHost
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | EapHost
+| **Description**    | The Extensible Authentication Protocol (EAP) service provides network authentication in such scenarios as 802.1x wired and wireless, VPN, and Network Access Protection (NAP).  EAP also provides application programming interfaces (APIs) that are used by network access clients, including wireless and VPN clients, during the authentication process.  If you disable this service, this computer is prevented from accessing networks that require EAP authentication.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Function Discovery Provider Host
 
-## Function Discovery Resource Publication      
-
-| | |           
-|---|---|       
-|   **Service description** |   Publishes this computer and resources attached to this computer so they can be discovered over the network.  If this service is stopped, network resources will no longer be published and they will not be discovered by other computers on the network.
-|   **Service name**    |   FDResPub
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | fdPHost
+| **Description**    | The FDPHOST service hosts the Function Discovery (FD) network discovery providers. These FD providers supply network discovery services for the Simple Services Discovery Protocol (SSDP) and Web Services - Discovery (WS-D) protocol. Stopping or disabling the FDPHOST service will disable network discovery for these protocols when using FD. When this service is unavailable, network services using FD and relying on these discovery protocols will be unable to find network devices or resources.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Geolocation Service          
+## Function Discovery Resource Publication
 
-| | |           
-|---|---|       
-|   **Service description** |   This service monitors the current location of the system and manages geofences (a geographical location with associated events).  If you turn off this service, applications will be unable to use or receive notifications for geolocation or geofences.
-|   **Service name**    |   lfsvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Disabling breaks apps that rely on the service; OK to disable if apps not relying on it
-|||         
-
-
-
-##  Group Policy Client     
-
-| | |           
-|---|---|       
-|   **Service description** |   The service is responsible for applying settings configured by administrators for the computer and users through the Group Policy component. If the service is disabled, the settings will not be applied and applications and components will not be manageable through Group Policy. Any components or applications that depend on the Group Policy component might not be functional if the service is disabled.
-|   **Service name**    |   gpsvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | FDResPub
+| **Description**    | Publishes this computer and resources attached to this computer so they can be discovered over the network.  If this service is stopped, network resources will no longer be published and they will not be discovered by other computers on the network.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Geolocation Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | lfsvc
+| **Description**    | This service monitors the current location of the system and manages geofences (a geographical location with associated events).  If you turn off this service, applications will be unable to use or receive notifications for geolocation or geofences.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | Disabling breaks apps that rely on the service; OK to disable if apps not relying on it
+|||
 
 
-## Human Interface Device Service           
+##  Group Policy Client
 
-| | |           
-|---|---|       
-|   **Service description** |   Activates and maintains the use of hot buttons on keyboards, remote controls, and other multimedia devices. It is recommended that you keep this service running.
-|   **Service name**    |   hidserv
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  HV Host Service     
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides an interface for the Hyper-V hypervisor to provide per-partition performance counters to the host operating system.
-|   **Service name**    |   HvHost
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Performance enhancers for guest VMs. Not used today except for explicitly populated VMs, but will be used in Application Guard
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | gpsvc
+| **Description**    | The service is responsible for applying settings configured by administrators for the computer and users through the Group Policy component. If the service is disabled, the settings will not be applied and applications and components will not be manageable through Group Policy. Any components or applications that depend on the Group Policy component might not be functional if the service is disabled.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Human Interface Device Service
 
-## Hyper-V Data Exchange Service        
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides a mechanism to exchange data between the virtual machine and the operating system running on the physical computer.
-|   **Service name**    |   vmickvpexchange
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   See HvHost
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | hidserv
+| **Description**    | Activates and maintains the use of hot buttons on keyboards, remote controls, and other multimedia devices. It is recommended that you keep this service running.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Hyper-V Guest Service Interface          
+##  HV Host Service
 
-| | |           
-|---|---|   
-|   **Service description** |   Provides an interface for the Hyper-V host to interact with specific services running inside the virtual machine.
-|   **Service name**    |   vmicguestinterface
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   See HvHost
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | HvHost
+| **Description**    | Provides an interface for the Hyper-V hypervisor to provide per-partition performance counters to the host operating system.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Performance enhancers for guest VMs. Not used today except for explicitly populated VMs, but will be used in Application Guard
+|||
 
 
+## Hyper-V Data Exchange Service
 
-## Hyper-V Guest Shutdown Service           
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vmickvpexchange
+| **Description**    | Provides a mechanism to exchange data between the virtual machine and the operating system running on the physical computer.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | See HvHost
+|||
 
-| | |           
-|---|---|       
-|   **Service description** |   Provides a mechanism to shut down the operating system of this virtual machine from the management interfaces on the physical computer.
-|   **Service name**    |   vmicshutdown
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   See HvHost
-|||         
 
+## Hyper-V Guest Service Interface
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vmicguestinterface
+| **Description**    | Provides an interface for the Hyper-V host to interact with specific services running inside the virtual machine.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | See HvHost
+|||
+
+
+## Hyper-V Guest Shutdown Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vmicshutdown
+| **Description**    | Provides a mechanism to shut down the operating system of this virtual machine from the management interfaces on the physical computer.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | See HvHost
+|||
 
 
 ## Hyper-V Heartbeat Service
-| | |
-|---|---|
-|   **Service description** |   Monitors the state of this virtual machine by reporting a heartbeat at regular intervals. This service helps you identify running virtual machines that have stopped responding.
-|   **Service name**    |   vmicheartbeat
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   See HvHost
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vmicheartbeat
+| **Description**    | Monitors the state of this virtual machine by reporting a heartbeat at regular intervals. This service helps you identify running virtual machines that have stopped responding.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | See HvHost
 |||
 
 
+## Hyper-V PowerShell Direct Service
 
-## Hyper-V PowerShell Direct Service            
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides a mechanism to manage virtual machine with PowerShell via VM session without a virtual network.
-|   **Service name**    |   vmicvmsession
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   See HvHost
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vmicvmsession
+| **Description**    | Provides a mechanism to manage virtual machine with PowerShell via VM session without a virtual network.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | See HvHost
+|||
 
 
-## Hyper-V Remote Desktop Virtualization Service            
+## Hyper-V Remote Desktop Virtualization Service
 
-| | |           
-|---|---|       
-|   **Service description** |   Provides a platform for communication between the virtual machine and the operating system running on the physical computer.
-|   **Service name**    |   vmicrdv
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   See HvHost
-|||         
-
-
-
-## Hyper-V Time Synchronization Service         
-
-| | |           
-|---|---|       
-|   **Service description** |   Synchronizes the system time of this virtual machine with the system time of the physical computer.
-|   **Service name**    |   vmictimesync
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   See HvHost
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vmicrdv
+| **Description**    | Provides a platform for communication between the virtual machine and the operating system running on the physical computer.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | See HvHost
+|||
 
 
+## Hyper-V Time Synchronization Service
 
-## Hyper-V Volume Shadow Copy Requestor         
-
-| | |           
-|---|---|           
-|   **Service description** |   Coordinates the communications that are required to use Volume Shadow Copy Service to back up applications and data on this virtual machine from the operating system on the physical computer.
-|   **Service name**    |   vmicvss
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   See HvHost
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vmictimesync
+| **Description**    | Synchronizes the system time of this virtual machine with the system time of the physical computer.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | See HvHost
+|||
 
 
-## IKE and AuthIP IPsec Keying Modules          
+## Hyper-V Volume Shadow Copy Requestor
 
-| | |           
-|---|---|       
-|   **Service description** |   The IKEEXT service hosts the Internet Key Exchange (IKE) and Authenticated Internet Protocol (AuthIP) keying modules. These keying modules are used for authentication and key exchange in Internet Protocol security (IPsec). Stopping or disabling the IKEEXT service will disable IKE and AuthIP key exchange with peer computers. IPsec is typically configured to use IKE or AuthIP; therefore, stopping or disabling the IKEEXT service might result in an IPsec failure and might compromise the security of the system. It is strongly recommended that you have the IKEEXT service running.
-|   **Service name**    |   IKEEXT
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |    
-|||         
-
-
-
-## Interactive Services Detection           
-
-| | |           
-|---|---|   
-|   **Service description** |   Enables user notification of user input for interactive services, which enables access to dialogs created by interactive services when they appear. If this service is stopped, notifications of new interactive service dialogs will no longer function and there might not be access to interactive service dialogs. If this service is disabled, both notifications of and access to new interactive service dialogs will no longer function.
-|   **Service name**    |   UI0Detect
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vmicvss
+| **Description**    | Coordinates the communications that are required to use Volume Shadow Copy Service to back up applications and data on this virtual machine from the operating system on the physical computer.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | See HvHost
+|||
 
 
+## IKE and AuthIP IPsec Keying Modules
 
-## Internet Connection Sharing (ICS)            
-
-| | |           
-|---|---|           
-|   **Service description** |   Provides network address translation, addressing, name resolution and/or intrusion prevention services for a home or small office network.
-|   **Service name**    |   SharedAccess
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Required for clients used as WiFi hotspots, and also on both ends of Miracast projection. ICS can be blocked with GPO setting, "Prohibit use of Internet Connection Sharing on your DNS domain network"
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | IKEEXT
+| **Description**    | The IKEEXT service hosts the Internet Key Exchange (IKE) and Authenticated Internet Protocol (AuthIP) keying modules. These keying modules are used for authentication and key exchange in Internet Protocol security (IPsec). Stopping or disabling the IKEEXT service will disable IKE and AuthIP key exchange with peer computers. IPsec is typically configured to use IKE or AuthIP; therefore, stopping or disabling the IKEEXT service might result in an IPsec failure and might compromise the security of the system. It is strongly recommended that you have the IKEEXT service running.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## IP Helper            
+## Interactive Services Detection
 
-| | |           
-|---|---|       
-|   **Service description** |   Provides tunnel connectivity using IPv6 transition technologies (6to4, ISATAP, Port Proxy, and Teredo), and IP-HTTPS. If this service is stopped, the computer will not have the enhanced connectivity benefits that these technologies offer.
-|   **Service name**    |   iphlpsvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | UI0Detect
+| **Description**    | Enables user notification of user input for interactive services, which enables access to dialogs created by interactive services when they appear. If this service is stopped, notifications of new interactive service dialogs will no longer function and there might not be access to interactive service dialogs. If this service is disabled, both notifications of and access to new interactive service dialogs will no longer function.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-##  IPsec Policy Agent      
+## Internet Connection Sharing (ICS)
 
-| | |           
-|---|---|       
-|   **Service description** |   Internet Protocol security (IPsec) supports network-level peer authentication, data origin authentication, data integrity, data confidentiality (encryption), and replay protection.  This service enforces IPsec policies created through the IP Security Policies snap-in or the command-line tool "netsh ipsec".  If you stop this service, you may experience network connectivity issues if your policy requires that connections use IPsec.  Also, remote management of Windows Firewall is not available when this service is stopped.
-|   **Service name**    |   PolicyAgent
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  KDC Proxy Server service (KPS)      
-
-| | |           
-|---|---|       
-|   **Service description** |   KDC Proxy Server service runs on edge servers to proxy Kerberos protocol messages to domain controllers on the corporate network.
-|   **Service name**    |   KPSSVC
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance    
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SharedAccess
+| **Description**    | Provides network address translation, addressing, name resolution and/or intrusion prevention services for a home or small office network.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | Required for clients used as WiFi hotspots, and also on both ends of Miracast projection. ICS can be blocked with GPO setting, "Prohibit use of Internet Connection Sharing on your DNS domain network"
+|||
 
 
+## IP Helper
 
-## KtmRm for Distributed Transaction Coordinator            
-
-| | |           
-|---|---|       
-|   **Service description** |   Coordinates transactions between the Distributed Transaction Coordinator (MSDTC) and the Kernel Transaction Manager (KTM). If it is not needed, it is recommended that this service remain stopped. If it is needed, both MSDTC and KTM will start this service automatically. If this service is disabled, any MSDTC transaction interacting with a Kernel Resource Manager will fail and any services that explicitly depend on it will fail to start.
-|   **Service name**    |   KtmRm
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | iphlpsvc
+| **Description**    | Provides tunnel connectivity using IPv6 transition technologies (6to4, ISATAP, Port Proxy, and Teredo), and IP-HTTPS. If this service is stopped, the computer will not have the enhanced connectivity benefits that these technologies offer.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-##  Link-Layer Topology Discovery Mapper        
+##  IPsec Policy Agent
 
-| | |       
-|---|---|       
-|   **Service description** |   Creates a Network Map, consisting of PC and device topology (connectivity) information, and metadata describing each PC and device.  If this service is disabled, the Network Map will not function properly.
-|   **Service name**    |   lltdsvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   OK to disable if no dependencies on Network Map
-|||         
-
-
-
-## Local Session Manager                    
-
-| | |                   
-|---|---|   
-|   **Service description** |   Core Windows Service that manages local user sessions. Stopping or disabling this service will result in system instability.    
-|   **Service name**    |   LSM |
-|   **Installation**    |   Always installed    |
-|   **StartType**   |   Automatic   |
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||                 
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | PolicyAgent
+| **Description**    | Internet Protocol security (IPsec) supports network-level peer authentication, data origin authentication, data integrity, data confidentiality (encryption), and replay protection.  This service enforces IPsec policies created through the IP Security Policies snap-in or the command-line tool "netsh ipsec".  If you stop this service, you may experience network connectivity issues if your policy requires that connections use IPsec.  Also, remote management of Windows Firewall is not available when this service is stopped.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+##  KDC Proxy Server service (KPS)
 
-## Microsoft (R) Diagnostics Hub Standard Collector         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | KPSSVC
+| **Description**    | KDC Proxy Server service runs on edge servers to proxy Kerberos protocol messages to domain controllers on the corporate network.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
-| | |           
-|---|---|           
-|   **Service description** |   Core Windows Service that manages local user sessions. Stopping or disabling this service will result in system instability.
-|   **Service name**    |   LSM
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
 
+## KtmRm for Distributed Transaction Coordinator
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | KtmRm
+| **Description**    | Coordinates transactions between the Distributed Transaction Coordinator (MSDTC) and the Kernel Transaction Manager (KTM). If it is not needed, it is recommended that this service remain stopped. If it is needed, both MSDTC and KTM will start this service automatically. If this service is disabled, any MSDTC transaction interacting with a Kernel Resource Manager will fail and any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Link-Layer Topology Discovery Mapper
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | lltdsvc
+| **Description**    | Creates a Network Map, consisting of PC and device topology (connectivity) information, and metadata describing each PC and device.  If this service is disabled, the Network Map will not function properly.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | OK to disable if no dependencies on Network Map
+|||
+
+
+## Local Session Manager
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | LSM |
+| **Description**    | Core Windows Service that manages local user sessions. Stopping or disabling this service will result in system instability.
+| **Installation**   | Always installed    |
+| **Startup type**   | Automatic   |
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Microsoft (R) Diagnostics Hub Standard Collector
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | diagnosticshub.standardcollector.service
+| **Description**    | Diagnostics Hub Standard Collector Service. When running, this service collects real time ETW events and processes them.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
 ## Microsoft Account Sign-in Assistant
-| | |
-|---|---|
-|   **Service description** |   Enables user sign-in through Microsoft account identity services. If this service is stopped, users will not be able to log on to the computer with their Microsoft account.
-|   **Service name**    |   wlidsvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Microsoft Accounts are N/A on Windows Server
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | wlidsvc
+| **Description**    | Enables user sign-in through Microsoft account identity services. If this service is stopped, users will not be able to log on to the computer with their Microsoft account.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | Microsoft Accounts are N/A on Windows Server
 |||
 
 
-
-##  Microsoft App-V Client      
-
-| | |           
-|---|---|       
-|   **Service description** |   Manages App-V users and virtual applications
-|   **Service name**    |   AppVClient
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   
-|||         
-
-
-
-## Microsoft iSCSI Initiator Service            
-
-| | |           
-|---|---|       
-|   **Service description** |   Manages Internet SCSI (iSCSI) sessions from this computer to remote iSCSI target devices. If this service is stopped, this computer will not be able to login or access iSCSI targets. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   MSiSCSI
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Our diagnostic data indicates this is used on client as well as server. No benefit to disabling this.
-|||         
-
-
-
-## Microsoft Passport           
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides process isolation for cryptographic keys used to authenticate to a user's associated identity providers. If this service is disabled, all uses and management of these keys will not be available, which includes machine logon and single-sign on for apps and websites. This service starts and stops automatically. It is recommended that you do not reconfigure this service.
-|   **Service name**    |   NgcSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Needed for PIN/Hello logons, which aren't supported on Server
-|||         
-
-
-
-## Microsoft Passport Container         
-
-| | |           
-|---|---|       
-|   **Service description** |   Manages local user identity keys used to authenticate user to identity providers as well as TPM virtual smart cards. If this service is disabled, local user identity keys and TPM virtual smart cards will not be accessible. It is recommended that you do not reconfigure this service.
-|   **Service name**    |   NgcCtnrSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Microsoft Software Shadow Copy Provider          
-
-| | |           
-|---|---|       
-|   **Service description** |   Manages software-based volume shadow copies taken by the Volume Shadow Copy service. If this service is stopped, software-based volume shadow copies cannot be managed. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   swprv
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Microsoft Storage Spaces SMP         
-
-| | |           
-|---|---|       
-|   **Service description** |   Host service for the Microsoft Storage Spaces management provider. If this service is stopped or disabled, Storage Spaces cannot be managed.
-|   **Service name**    |   smphost
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Storage management APIs fail without this service. Example: "Get-WmiObject -class MSFT_Disk -Namespace Root\Microsoft\Windows\Storage".
-|||         
-
-
-
-## Net.Tcp Port Sharing Service         
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides ability to share TCP ports over the net.tcp protocol.
-|   **Service name**    |   NetTcpPortSharing
-|   **Installation**    |   Always installed
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   
-|||         
-
-
-
-## Netlogon         
-
-| | |           
-|---|---|           
-|   **Service description** |   Maintains a secure channel between this computer and the domain controller for authenticating users and services. If this service is stopped, the computer may not authenticate users and services and the domain controller cannot register DNS records. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   Netlogon
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Network Connection Broker            
-
-| | |           
-|---|---|       
-|   **Service description** |   Brokers connections that allow Microsoft Store Apps to receive notifications from the internet.
-|   **Service name**    |   NcbService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-##  Network Connections         
-
-| | |           
-|---|---|   
-|   **Service description** |   Manages objects in the Network and Dial-Up Connections folder, in which you can view both local area network and remote connections.
-|   **Service name**    |   Netman
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Network Connectivity Assistant      
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides DirectAccess status notification for UI components
-|   **Service name**    |   NcaSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Network List Service        
-
-| | |           
-|---|---|   
-|   **Service description** |   Identifies the networks to which the computer has connected, collects and stores properties for these networks, and notifies applications when these properties change.
-|   **Service name**    |   netprofm
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Network Location Awareness           
-
-| | |           
-|---|---|       
-|   **Service description** |   Collects and stores configuration information for the network and notifies programs when this information is modified. If this service is stopped, configuration information might be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   NlaSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Network Setup Service       
-
-| | |           
-|---|---|       
-|   **Service description** |   The Network Setup Service manages the installation of network drivers and permits the configuration of low-level network settings.  If this service is stopped, any driver installations that are in-progress may be cancelled.
-|   **Service name**    |   NetSetupSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Network Store Interface Service      
-
-| | |           
-|---|---|   
-|   **Service description** |   This service delivers network notifications (e.g. interface addition/deleting etc) to user mode clients. Stopping this service will cause loss of network connectivity. If this service is disabled, any other services that explicitly depend on this service will fail to start.
-|   **Service name**    |   nsi
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Offline Files            
-
-| | |           
-|---|---|       
-|   **Service description** |   The Offline Files service performs maintenance activities on the Offline Files cache, responds to user logon and logoff events, implements the internals of the public API, and dispatches interesting events to those interested in Offline Files activities and changes in cache state.
-|   **Service name**    |   CscService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   
-|||         
-
-
-
-## Optimize drives          
-
-| | |           
-|---|---|   
-|   **Service description** |   Helps the computer run more efficiently by optimizing files on storage drives.
-|   **Service name**    |   defragsvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Performance Counter DLL Host         
-
-| | |           
-|---|---|       
-|   **Service description** |   Enables remote users and 64-bit processes to query performance counters provided by 32-bit DLLs. If this service is stopped, only local users and 32-bit processes will be able to query performance counters provided by 32-bit DLLs.
-|   **Service name**    |   PerfHost
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance    
-|   **Comments**    |   
-|||         
-
-
-
-## Performance Logs & Alerts            
-
-| | |           
-|---|---|   
-|   **Service description** |   Performance Logs and Alerts Collects performance data from local or remote computers based on preconfigured schedule parameters, then writes the data to a log or triggers an alert. If this service is stopped, performance information will not be collected. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   pla
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Phone Service       
-
-| | |           
-|---|---|   
-|   **Service description** |   Manages the telephony state on the device
-|   **Service name**    |   PhoneSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Used by modern VoIP apps
-|||         
-
-
-
-##      Plug and Play       
-
-| | |           
-|---|---|   
-|   **Service description** |   Enables a computer to recognize and adapt to hardware changes with little or no user input. Stopping or disabling this service will result in system instability.
-|   **Service name**    |   PlugPlay
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Portable Device Enumerator Service           
-
-| | |           
-|---|---|       
-|   **Service description** |   Enforces group policy for removable mass-storage devices. Enables applications such as Windows Media Player and Image Import Wizard to transfer and synchronize content using removable mass-storage devices.
-|   **Service name**    |   WPDBusEnum
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Power            
-
-| | |           
-|---|---|       
-|   **Service description** |   Manages power policy and power policy notification delivery.
-|   **Service name**    |   Power
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Print Spooler            
-
-| | |           
-|---|---|   
-|   **Service description** |   This service spools print jobs and handles interaction with the printer.  If you turn off this service, you won't be able to print or see your printers.
-|   **Service name**    |   Spooler
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   OK to disable if not a print server or a DC
-|   **Comments**    |   On a domain controller, the installation of the DC role adds a thread to the spooler service that is responsible for performing print pruning – removing the stale print queue objects from the Active Directory.  If the spooler service is not running on at least one DC in each site, then the AD has no means to remove old queues that no longer exist. https://blogs.technet.microsoft.com/askperf/2008/11/18/disabling-unnecessary-services-a-word-to-the-wise/
-|||         
-
-
-
-##  Printer Extensions and Notifications        
-
-| | |           
-|---|---|       
-|   **Service description** |   This service opens custom printer dialog boxes and handles notifications from a remote print server or a printer. If you turn off this service, you won't be able to see printer extensions or notifications.
-|   **Service name**    |   PrintNotify
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable if not a print server
-|   **Comments**    |   
-|||         
-
-
-
-##  Problem Reports and Solutions Control Panel Support     
-
-| | |           
-|---|---|   
-|   **Service description** |   This service provides support for viewing, sending and deletion of system-level problem reports for the Problem Reports and Solutions control panel.
-|   **Service name**    |   wercplsupport
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Program Compatibility Assistant Service     
-
-| | |           
-|---|---|       
-|   **Service description** |   This service provides support for the Program Compatibility Assistant (PCA).  PCA monitors programs installed and run by the user and detects known compatibility problems. If this service is stopped, PCA will not function properly.
-|   **Service name**    |   PcaSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-##  Quality Windows Audio Video Experience      
-
-| | |           
-|---|---|   
-|   **Service description** |   Quality Windows Audio Video Experience (qWave) is a networking platform for Audio Video (AV) streaming applications on IP home networks. qWave enhances AV streaming performance and reliability by ensuring network quality-of-service (QoS) for AV applications. It provides mechanisms for admission control, run time monitoring and enforcement, application feedback, and traffic prioritization.
-|   **Service name**    |   QWAVE
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Client-side QoS service
-|||         
-
-
-
-##      Radio Management Service        
-
-| | |           
-|---|---|   
-|   **Service description** |   Radio Management and Airplane Mode Service
-|   **Service name**    |   RmSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Remote Access Auto Connection Manager            
-
-| | |           
-|---|---|   
-|   **Service description** |   Creates a connection to a remote network whenever a program references a remote DNS or NetBIOS name or address.
-|   **Service name**    |   RasAuto
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Remote Access Connection Manager         
-
-| | |           
-|---|---|   
-|   **Service description** |   Manages dial-up and virtual private network (VPN) connections from this computer to the Internet or other remote networks. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   RasMan
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Remote Desktop Configuration         
-
-| | |           
-|---|---|   
-|   **Service description** |   Remote Desktop Configuration service (RDCS) is responsible for all Remote Desktop Services and Remote Desktop related configuration and session maintenance activities that require SYSTEM context. These include per-session temporary folders, RD themes, and RD certificates.
-|   **Service name**    |   SessionEnv
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   
-|||         
-
-
-
-## Remote Desktop Services          
-
-| | |           
-|---|---|   
-|   **Service description** |   Allows users to connect interactively to a remote computer. Remote Desktop and Remote Desktop Session Host Server depend on this service.  To prevent remote use of this computer, clear the checkboxes on the Remote tab of the System properties control panel item.
-|   **Service name**    |   TermService
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   
-|||         
-
-
-
-##  Remote Desktop Services UserMode Port Redirector        
-
-| | |           
-|---|---|   
-|   **Service description** |   Allows the redirection of Printers/Drives/Ports for RDP connections
-|   **Service name**    |   UmRdpService
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Supports redirections on the server side of the connection.
-|||         
-
-
-
-## Remote Procedure Call (RPC)          
-
-| | |           
-|---|---|   
-|   **Service description** |   The RPCSS service is the Service Control Manager for COM and DCOM servers. It performs object activations requests, object exporter resolutions and distributed garbage collection for COM and DCOM servers. If this service is stopped or disabled, programs using COM or DCOM will not function properly. It is strongly recommended that you have the RPCSS service running.
-|   **Service name**    |   RpcSs
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Remote Procedure Call (RPC) Locator             
-
-| | |               
-|---|---|   
-|   **Service description** |   In Windows 2003 and earlier versions of Windows, the Remote Procedure Call (RPC) Locator service manages the RPC name service database. In Windows Vista and later versions of Windows, this service does not provide any functionality and is present for application compatibility.   |
-|   **Service name**    |   RpcLocator  |
-|   **Installation**    |   Only with Desktop Experience    |
-|   **StartType**   |   Manual  |
-|   **Recommendation**  | No guidance   |
-|   **Comments**    |       |
-|||             
-
-
-
-## Remote Registry          
-
-| | |           
-|---|---|   
-|   **Service description** |   Enables remote users to modify registry settings on this computer. If this service is stopped, the registry can be modified only by users on this computer. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   RemoteRegistry
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   
-|||         
-
-
-
-##  Resultant Set of Policy Provider            
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides a network service that processes requests to simulate application of Group Policy settings for a target user or computer in various situations and computes the Resultant Set of Policy settings.
-|   **Service name**    |   RSoPProv
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |No guidance    
-|   **Comments**    |   
-|||         
-
-
-
-## Routing and Remote Access            
-
-| | |           
-|---|---|   
-|   **Service description** |   Offers routing services to businesses in local area and wide area network environments.
-|   **Service name**    |   RemoteAccess
-|   **Installation**    |   Always installed
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   Already disabled
-|||         
-
-
-
-## RPC Endpoint Mapper          
-
-| | |           
-|---|---|   
-|   **Service description** |   Resolves RPC interfaces identifiers to transport endpoints. If this service is stopped or disabled, programs using Remote Procedure Call (RPC) services will not function properly.
-|   **Service name**    |   RpcEptMapper
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Secondary Logon     
-
-| | |           
-|---|---|       
-|   **Service description** |   Enables starting processes under alternate credentials. If this service is stopped, this type of logon access will be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   seclogon
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Secure Socket Tunneling Protocol Service            
-
-| | |               
-|---|---|       
-|   **Service description** |   Provides support for the Secure Socket Tunneling Protocol (SSTP) to connect to remote computers using VPN. If this service is disabled, users will not be able to use SSTP to access remote servers.    |
-|   **Service name**    |   SstpSvc |
-|   **Installation**    |   Always installed    |
-|   **StartType**   |   Manual  |
-|   **Recommendation**  |   Do not disable  |
-|   **Comments**    |   Disabling breaks RRAS   |
-|||             
-
-
-
-## Security Accounts Manager            
-
-| | |           
-|---|---|       
-|   **Service description** |   The startup of this service signals other services that the Security Accounts Manager (SAM) is ready to accept requests.  Disabling this service will prevent other services in the system from being notified when the SAM is ready, which may in turn cause those services to fail to start correctly. This service should not be disabled.
-|   **Service name**    |   SamSs
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | Do not disable
-|   **Comments**    |   
-|||         
-
-
-
-## Sensor Data Service  
-
-| | |           
-|---|---|   
-|   **Service description** |   Delivers data from a variety of sensors
-|   **Service name**    |   SensorDataService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Sensor Monitoring Service            
-
-| | |           
-|---|---|       
-|   **Service description** |   Monitors various sensors in order to expose data and adapt to system and user state.  If this service is stopped or disabled, the display brightness will not adapt to lighting conditions. Stopping this service may affect other system functionality and features as well.
-|   **Service name**    |   SensrSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
+##  Microsoft App-V Client
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | AppVClient
+| **Description**    | Manages App-V users and virtual applications
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       |
+|||
+
+
+## Microsoft iSCSI Initiator Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | MSiSCSI
+| **Description**    | Manages Internet SCSI (iSCSI) sessions from this computer to remote iSCSI target devices. If this service is stopped, this computer will not be able to login or access iSCSI targets. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Our diagnostic data indicates this is used on client as well as server. No benefit to disabling this.
+|||
+
+
+## Microsoft Passport
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | NgcSvc
+| **Description**    | Provides process isolation for cryptographic keys used to authenticate to a user's associated identity providers. If this service is disabled, all uses and management of these keys will not be available, which includes machine logon and single-sign on for apps and websites. This service starts and stops automatically. It is recommended that you do not reconfigure this service.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | Needed for PIN/Hello logons, which aren't supported on Server
+|||
+
+
+## Microsoft Passport Container
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | NgcCtnrSvc
+| **Description**    | Manages local user identity keys used to authenticate user to identity providers as well as TPM virtual smart cards. If this service is disabled, local user identity keys and TPM virtual smart cards will not be accessible. It is recommended that you do not reconfigure this service.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Microsoft Software Shadow Copy Provider
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | swprv
+| **Description**    | Manages software-based volume shadow copies taken by the Volume Shadow Copy service. If this service is stopped, software-based volume shadow copies cannot be managed. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Microsoft Storage Spaces SMP
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | smphost
+| **Description**    | Host service for the Microsoft Storage Spaces management provider. If this service is stopped or disabled, Storage Spaces cannot be managed.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Storage management APIs fail without this service. Example: "Get-WmiObject -class MSFT_Disk -Namespace Root\Microsoft\Windows\Storage".
+|||
+
+
+## Net.Tcp Port Sharing Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | NetTcpPortSharing
+| **Description**    | Provides ability to share TCP ports over the net.tcp protocol.
+| **Installation**   | Always installed
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       |
+|||
+
+
+## Netlogon
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Netlogon
+| **Description**    | Maintains a secure channel between this computer and the domain controller for authenticating users and services. If this service is stopped, the computer may not authenticate users and services and the domain controller cannot register DNS records. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Network Connection Broker
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | NcbService
+| **Description**    | Brokers connections that allow Microsoft Store Apps to receive notifications from the internet.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+##  Network Connections
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Netman
+| **Description**    | Manages objects in the Network and Dial-Up Connections folder, in which you can view both local area network and remote connections.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Network Connectivity Assistant
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | NcaSvc
+| **Description**    | Provides DirectAccess status notification for UI components
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Network List Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | netprofm
+| **Description**    | Identifies the networks to which the computer has connected, collects and stores properties for these networks, and notifies applications when these properties change.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Network Location Awareness
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | NlaSvc
+| **Description**    | Collects and stores configuration information for the network and notifies programs when this information is modified. If this service is stopped, configuration information might be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Network Setup Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | NetSetupSvc
+| **Description**    | The Network Setup Service manages the installation of network drivers and permits the configuration of low-level network settings.  If this service is stopped, any driver installations that are in-progress may be cancelled.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Network Store Interface Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | nsi
+| **Description**    | This service delivers network notifications (e.g. interface addition/deleting etc) to user mode clients. Stopping this service will cause loss of network connectivity. If this service is disabled, any other services that explicitly depend on this service will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Offline Files
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | CscService
+| **Description**    | The Offline Files service performs maintenance activities on the Offline Files cache, responds to user logon and logoff events, implements the internals of the public API, and dispatches interesting events to those interested in Offline Files activities and changes in cache state.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       |
+|||
+
+
+## Optimize drives
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | defragsvc
+| **Description**    | Helps the computer run more efficiently by optimizing files on storage drives.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Performance Counter DLL Host
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | PerfHost
+| **Description**    | Enables remote users and 64-bit processes to query performance counters provided by 32-bit DLLs. If this service is stopped, only local users and 32-bit processes will be able to query performance counters provided by 32-bit DLLs.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Performance Logs & Alerts
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | pla
+| **Description**    | Performance Logs and Alerts Collects performance data from local or remote computers based on preconfigured schedule parameters, then writes the data to a log or triggers an alert. If this service is stopped, performance information will not be collected. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Phone Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | PhoneSvc
+| **Description**    | Manages the telephony state on the device
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | Used by modern VoIP apps
+|||
+
+
+##      Plug and Play
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | PlugPlay
+| **Description**    | Enables a computer to recognize and adapt to hardware changes with little or no user input. Stopping or disabling this service will result in system instability.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Portable Device Enumerator Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WPDBusEnum
+| **Description**    | Enforces group policy for removable mass-storage devices. Enables applications such as Windows Media Player and Image Import Wizard to transfer and synchronize content using removable mass-storage devices.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Power
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Power
+| **Description**    | Manages power policy and power policy notification delivery.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Print Spooler
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Spooler
+| **Description**    | This service spools print jobs and handles interaction with the printer.  If you turn off this service, you won't be able to print or see your printers.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | OK to disable if not a print server or a DC
+| **Comments**       | On a domain controller, the installation of the DC role adds a thread to the spooler service that is responsible for performing print pruning – removing the stale print queue objects from the Active Directory.  If the spooler service is not running on at least one DC in each site, then the AD has no means to remove old queues that no longer exist. https://blogs.technet.microsoft.com/askperf/2008/11/18/disabling-unnecessary-services-a-word-to-the-wise/
+|||
+
+
+##  Printer Extensions and Notifications
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | PrintNotify
+| **Description**    | This service opens custom printer dialog boxes and handles notifications from a remote print server or a printer. If you turn off this service, you won't be able to see printer extensions or notifications.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable if not a print server
+| **Comments**       |
+|||
+
+
+##  Problem Reports and Solutions Control Panel Support
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | wercplsupport
+| **Description**    | This service provides support for viewing, sending and deletion of system-level problem reports for the Problem Reports and Solutions control panel.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Program Compatibility Assistant Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | PcaSvc
+| **Description**    | This service provides support for the Program Compatibility Assistant (PCA).  PCA monitors programs installed and run by the user and detects known compatibility problems. If this service is stopped, PCA will not function properly.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+##  Quality Windows Audio Video Experience
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | QWAVE
+| **Description**    | Quality Windows Audio Video Experience (qWave) is a networking platform for Audio Video (AV) streaming applications on IP home networks. qWave enhances AV streaming performance and reliability by ensuring network quality-of-service (QoS) for AV applications. It provides mechanisms for admission control, run time monitoring and enforcement, application feedback, and traffic prioritization.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | Client-side QoS service
+|||
+
+
+##      Radio Management Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RmSvc
+| **Description**    | Radio Management and Airplane Mode Service
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Remote Access Auto Connection Manager
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RasAuto
+| **Description**    | Creates a connection to a remote network whenever a program references a remote DNS or NetBIOS name or address.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Remote Access Connection Manager
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RasMan
+| **Description**    | Manages dial-up and virtual private network (VPN) connections from this computer to the Internet or other remote networks. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Remote Desktop Configuration
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SessionEnv
+| **Description**    | Remote Desktop Configuration service (RDCS) is responsible for all Remote Desktop Services and Remote Desktop related configuration and session maintenance activities that require SYSTEM context. These include per-session temporary folders, RD themes, and RD certificates.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       |
+|||
+
+
+## Remote Desktop Services
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | TermService
+| **Description**    | Allows users to connect interactively to a remote computer. Remote Desktop and Remote Desktop Session Host Server depend on this service.  To prevent remote use of this computer, clear the checkboxes on the Remote tab of the System properties control panel item.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       |
+|||
+
+
+##  Remote Desktop Services UserMode Port Redirector
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | UmRdpService
+| **Description**    | Allows the redirection of Printers/Drives/Ports for RDP connections
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Supports redirections on the server side of the connection.
+|||
+
+
+## Remote Procedure Call (RPC)
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RpcSs
+| **Description**    | The RPCSS service is the Service Control Manager for COM and DCOM servers. It performs object activations requests, object exporter resolutions and distributed garbage collection for COM and DCOM servers. If this service is stopped or disabled, programs using COM or DCOM will not function properly. It is strongly recommended that you have the RPCSS service running.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Remote Procedure Call (RPC) Locator
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RpcLocator  |
+| **Description**    | In Windows 2003 and earlier versions of Windows, the Remote Procedure Call (RPC) Locator service manages the RPC name service database. In Windows Vista and later versions of Windows, this service does not provide any functionality and is present for application compatibility.   |
+| **Installation**   | Only with Desktop Experience    |
+| **Startup type**   | Manual  |
+| **Recommendation** | No guidance   |
+| **Comments**       |     |
+|||
+
+
+## Remote Registry
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RemoteRegistry
+| **Description**    | Enables remote users to modify registry settings on this computer. If this service is stopped, the registry can be modified only by users on this computer. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | Do not disable
+| **Comments**       |
+|||
+
+
+##  Resultant Set of Policy Provider
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RSoPProv
+| **Description**    | Provides a network service that processes requests to simulate application of Group Policy settings for a target user or computer in various situations and computes the Resultant Set of Policy settings.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Routing and Remote Access
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RemoteAccess
+| **Description**    | Offers routing services to businesses in local area and wide area network environments.
+| **Installation**   | Always installed
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       | Already disabled
+|||
+
+
+## RPC Endpoint Mapper
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | RpcEptMapper
+| **Description**    | Resolves RPC interfaces identifiers to transport endpoints. If this service is stopped or disabled, programs using Remote Procedure Call (RPC) services will not function properly.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Secondary Logon
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | seclogon
+| **Description**    | Enables starting processes under alternate credentials. If this service is stopped, this type of logon access will be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Secure Socket Tunneling Protocol Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SstpSvc |
+| **Description**    | Provides support for the Secure Socket Tunneling Protocol (SSTP) to connect to remote computers using VPN. If this service is disabled, users will not be able to use SSTP to access remote servers.    |
+| **Installation**   | Always installed    |
+| **Startup type**   | Manual  |
+| **Recommendation** | Do not disable  |
+| **Comments**       | Disabling breaks RRAS   |
+|||
+
+
+## Security Accounts Manager
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SamSs
+| **Description**    | The startup of this service signals other services that the Security Accounts Manager (SAM) is ready to accept requests.  Disabling this service will prevent other services in the system from being notified when the SAM is ready, which may in turn cause those services to fail to start correctly. This service should not be disabled.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | Do not disable
+| **Comments**       |
+|||
+
+
+## Sensor Data Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SensorDataService
+| **Description**    | Delivers data from a variety of sensors
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Sensor Monitoring Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SensrSvc
+| **Description**    | Monitors various sensors in order to expose data and adapt to system and user state.  If this service is stopped or disabled, the display brightness will not adapt to lighting conditions. Stopping this service may affect other system functionality and features as well.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
 
 ## Sensor Service
 
-| | |
-|---|---|
-|   **Service description** |   A service for sensors that manages the functionality of different sensors. Manages Simple Device Orientation (SDO) and History for sensors. Loads the SDO sensor that reports device orientation changes.  If this service is stopped or disabled, the SDO sensor will not be loaded and so auto-rotation will not occur. History collection from Sensors will also be stopped.
-|   **Service name**    |   SensorService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SensorService
+| **Description**    | A service for sensors that manages the functionality of different sensors. Manages Simple Device Orientation (SDO) and History for sensors. Loads the SDO sensor that reports device orientation changes.  If this service is stopped or disabled, the SDO sensor will not be loaded and so auto-rotation will not occur. History collection from Sensors will also be stopped.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
 |||
 
-## Server           
+## Server
 
-| | |           
-|---|---|   
-|   **Service description** |   Supports file, print, and named-pipe sharing over the network for this computer. If this service is stopped, these functions will be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   LanmanServer
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Needed for remote management, IPC$, SMB file sharing
-|||         
-
-
-
-## Shell Hardware Detection             
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides notifications for AutoPlay hardware events.
-|   **Service name**    |   ShellHWDetection
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | LanmanServer
+| **Description**    | Supports file, print, and named-pipe sharing over the network for this computer. If this service is stopped, these functions will be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | Do not disable
+| **Comments**       | Needed for remote management, IPC$, SMB file sharing
+|||
 
 
+## Shell Hardware Detection
 
-## Smart Card           
-
-| | |           
-|---|---|   
-|   **Service description** |   Manages access to smart cards read by this computer. If this service is stopped, this computer will be unable to read smart cards. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   SCardSvr
-|   **Installation**    |   Always installed
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | ShellHWDetection
+| **Description**    | Provides notifications for AutoPlay hardware events.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
 
 
-## Smart Card Device Enumeration Service                    
+## Smart Card
 
-| | |               
-|---|---|       
-|   **Service description** |   Creates software device nodes for all smart card readers accessible to a given session. If this service is disabled, WinRT APIs will not be able to enumerate smart card readers.   |
-|   **Service name**    |   ScDeviceEnum    |
-|   **Installation**    |   Always installed    |
-|   **StartType**   |   Manual  |
-|   **Recommendation**  |   OK to disable   |
-|   **Comments**    |   Needed almost exclusively for WinRT apps    |
-|||             
-
-
-
-## Smart Card Removal Policy        
-
-| | |           
-|---|---|       
-|   **Service description** |   Allows the system to be configured to lock the user desktop upon smart card removal.
-|   **Service name**    |   SCPolicySvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SCardSvr
+| **Description**    | Manages access to smart cards read by this computer. If this service is stopped, this computer will be unable to read smart cards. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       |
+|||
 
 
+## Smart Card Device Enumeration Service
 
-## SNMP Trap            
-
-| | |           
-|---|---|       
-|   **Service description** |   Receives trap messages generated by local or remote Simple Network Management Protocol (SNMP) agents and forwards the messages to SNMP management programs running on this computer. If this service is stopped, SNMP-based programs on this computer will not receive SNMP trap messages. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   SNMPTRAP
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | ScDeviceEnum    |
+| **Description**    | Creates software device nodes for all smart card readers accessible to a given session. If this service is disabled, WinRT APIs will not be able to enumerate smart card readers.   |
+| **Installation**   | Always installed    |
+| **Startup type**   | Manual  |
+| **Recommendation** | OK to disable   |
+| **Comments**       | Needed almost exclusively for WinRT apps    |
+|||
 
 
-##  Software Protection             
+## Smart Card Removal Policy
 
-| | |           
-|---|---|       
-|   **Service description** |   Enables the download, installation and enforcement of digital licenses for Windows and Windows applications. If the service is disabled, the operating system and licensed applications may run in a notification mode. It is strongly recommended that you not disable the Software Protection service.
-|   **Service name**    |   sppsvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Special Administration Console Helper        
-
-| | |           
-|---|---|   
-|   **Service description** |   Allows administrators to remotely access a command prompt using Emergency Management Services.
-|   **Service name**    |   sacsvr
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SCPolicySvc
+| **Description**    | Allows the system to be configured to lock the user desktop upon smart card removal.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## SNMP Trap
 
-## Spot Verifier            
-
-| | |           
-|---|---|   
-|   **Service description** |   Verifies potential file system corruptions.
-|   **Service name**    |   svsvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SNMPTRAP
+| **Description**    | Receives trap messages generated by local or remote Simple Network Management Protocol (SNMP) agents and forwards the messages to SNMP management programs running on this computer. If this service is stopped, SNMP-based programs on this computer will not receive SNMP trap messages. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## SSDP Discovery           
+##  Software Protection
 
-| | |           
-|---|---|   
-|   **Service description** |   Discovers networked devices and services that use the SSDP discovery protocol, such as UPnP devices. Also announces SSDP devices and services running on the local computer. If this service is stopped, SSDP-based devices will not be discovered. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   SSDPSRV
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | sppsvc
+| **Description**    | Enables the download, installation and enforcement of digital licenses for Windows and Windows applications. If the service is disabled, the operating system and licensed applications may run in a notification mode. It is strongly recommended that you not disable the Software Protection service.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## Special Administration Console Helper
 
-## State Repository Service         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | sacsvr
+| **Description**    | Allows administrators to remotely access a command prompt using Emergency Management Services.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
-| | |           
-|---|---|   
-|   **Service description** |   Provides required infrastructure support for the application model.
-|   **Service name**    |   StateRepository
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
 
+## Spot Verifier
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | svsvc
+| **Description**    | Verifies potential file system corruptions.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## SSDP Discovery
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SSDPSRV
+| **Description**    | Discovers networked devices and services that use the SSDP discovery protocol, such as UPnP devices. Also announces SSDP devices and services running on the local computer. If this service is stopped, SSDP-based devices will not be discovered. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## State Repository Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | StateRepository
+| **Description**    | Provides required infrastructure support for the application model.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
 ##  Still Image Acquisition Events
 
-| | |           
-|---|---|   
-|   **Service description** |   Launches applications associated with still image acquisition events.
-|   **Service name**    |   WiaRpc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Storage Service          
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides enabling services for storage settings and external storage expansion
-|   **Service name**    |   StorSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Storage Tiers Management        
-
-| | |           
-|---|---|   
-|   **Service description** |   Optimizes the placement of data in storage tiers on all tiered storage spaces in the system.
-|   **Service name**    |   TieringEngineService
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Superfetch          
-
-| | |           
-|---|---|       
-|   **Service description** |   Maintains and improves system performance over time.
-|   **Service name**    |   SysMain
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Sync Host            
-
-| | |           
-|---|---|       
-|   **Service description** |   This service synchronizes mail, contacts, calendar and various other user data. Mail and other applications dependent on this functionality will not work properly when this service is not running.
-|   **Service name**    |   OneSyncSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   User service template
-|||         
-
-
-
-## System Event Notification Service            
-
-| | |           
-|---|---|       
-|   **Service description** |   Monitors system events and notifies subscribers to COM+ Event System of these events.
-|   **Service name**    |   SENS
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## System Events Broker             
-
-| | |           
-|---|---|       
-|   **Service description** |   Coordinates execution of background work for WinRT application. If this service is stopped or disabled, then background work might not be triggered.
-|   **Service name**    |   SystemEventsBroker
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   In spite of the fact that its description implies it is only for WinRT apps, it's needed for task scheduler, broker infrastructure service, and other internal components.
-|||         
-
-
-
-## Task Scheduler           
-
-| | |           
-|---|---|   
-|   **Service description** |   Enables a user to configure and schedule automated tasks on this computer. The service also hosts multiple Windows system-critical tasks. If this service is stopped or disabled, these tasks will not be run at their scheduled times. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   Schedule
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## TCP/IP NetBIOS Helper            
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides support for the NetBIOS over TCP/IP (NetBT) service and NetBIOS name resolution for clients on the network, therefore enabling users to share files, print, and log on to the network. If this service is stopped, these functions might be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   lmhosts
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Telephony           
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides Telephony API (TAPI) support for programs that control telephony devices on the local computer and, through the LAN, on servers that are also running the service.
-|   **Service name**    |   TapiSrv
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Disabling breaks RRAS
-|||         
-
-
-
-## Themes           
-
-| | |           
-|---|---|
-|   **Service description** |   Provides user experience theme management.
-|   **Service name**    |   Themes
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Can't set accessibility themes when this service is disabled
-|||         
-
-
-
-## Tile Data model server           
-
-| | |           
-|---|---|   
-|   **Service description** |   Tile Server for tile updates.
-|   **Service name**    |   tiledatamodelsvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Start menu breaks if this service is disabled
-|||         
-
-
-
-##  Time Broker     
-
-| | |           
-|---|---|       
-|   **Service description** |   Coordinates execution of background work for WinRT application. If this service is stopped or disabled, then background work might not be triggered.
-|   **Service name**    |   TimeBrokerSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   In spite of the fact that its description implies it is only for WinRT apps, it's needed for task scheduler, broker infrastructure service, and other internal components.
-|||         
-
-
-
-## Touch Keyboard and Handwriting Panel Service         
-
-| | |           
-|---|---|   
-|   **Service description** |   Enables Touch Keyboard and Handwriting Panel pen and ink functionality
-|   **Service name**    |   TabletInputService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Update Orchestrator Service for Windows Update           
-
-| | |           
-|---|---|       
-|   **Service description** |   Manages Windows Updates. If stopped, your devices will not be able to download and install latest updates.
-|   **Service name**    |   UsoSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Service description was missing in v1607; Windows Update (incl. WSUS) depends on this service.
-|||         
-
-
-
-## UPnP Device Host         
-
-| | |           
-|---|---|   
-|   **Service description** |   Allows UPnP devices to be hosted on this computer. If this service is stopped, any hosted UPnP devices will stop functioning and no additional hosted devices can be added. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   upnphost
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## User Access Logging Service          
-
-| | |           
-|---|---|   
-|   **Service description** |   This service logs unique client access requests, in the form of IP addresses and user names, of installed products and roles on the local server. This information can be queried, via Powershell, by administrators needing to quantify client demand of server software for offline Client Access License (CAL) management. If the service is disabled, client requests will not be logged and will not be retrievable via Powershell queries. Stopping the service will not affect query of historical data (see supporting documentation for steps to delete historical data). The local system administrator must consult his, or her, Windows Server license terms to determine the number of CALs that are required for the server software to be appropriately licensed; use of the UAL service and data does not alter this obligation.
-|   **Service name**    |   UALSVC
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  User Data Access        
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides apps access to structured user data, including contact info, calendars, messages, and other content. If you stop or disable this service, apps that use this data might not work correctly.
-|   **Service name**    |   UserDataSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   User service template
-|||         
-
-
-
-## User Data Storage            
-
-| | |           
-|---|---|       
-|   **Service description** |   Handles storage of structured user data, including contact info, calendars, messages, and other content. If you stop or disable this service, apps that use this data might not work correctly.
-|   **Service name**    |   UnistoreSvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   User service template
-|||         
-
-
-
-## User Experience Virtualization Service           
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides support for application and OS settings roaming
-|   **Service name**    |   UevAgentService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   
-|||         
-
-
-
-##  User Manager        
-
-| | |           
-|---|---|   
-|   **Service description** |   User Manager provides the runtime components required for multi-user interaction.  If this service is stopped, some applications may not operate correctly.
-|   **Service name**    |   UserManager
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## User Profile Service         
-
-| | |           
-|---|---|   
-|   **Service description** |   This service is responsible for loading and unloading user profiles. If this service is stopped or disabled, users will no longer be able to successfully sign in or sign out, apps might have problems getting to users' data, and components registered to receive profile event notifications won't receive them.
-|   **Service name**    |   ProfSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Virtual Disk             
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides management services for disks, volumes, file systems, and storage arrays.
-|   **Service name**    |   vds
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   No guidance
-|   **Comments**    |   
-|||         
-
-
-
-## Volume Shadow Copy           
-
-| | |           
-|---|---|   
-|   **Service description** |   Manages and implements Volume Shadow Copies used for backup and other purposes. If this service is stopped, shadow copies will be unavailable for backup and the backup may fail. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   VSS
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   No guidance
-|   **Comments**    |   
-|||         
-
-
-
-##  WalletService           
-
-| | |           
-|---|---|   
-|   **Service description** |   Hosts objects used by clients of the wallet
-|   **Service name**    |   WalletService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Audio            
-
-| | |           
-|---|---|       
-|   **Service description** |   Manages audio for Windows-based programs.  If this service is stopped, audio devices and effects will not function properly.  If this service is disabled, any services that explicitly depend on it will fail to start
-|   **Service name**    |   Audiosrv
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Audio Endpoint Builder           
-
-| | |           
-|---|---|
-|   **Service description** |   Manages audio devices for the Windows Audio service.  If this service is stopped, audio devices and effects will not function properly.  If this service is disabled, any services that explicitly depend on it will fail to start
-|   **Service name**    |   AudioEndpointBuilder
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Biometric Service            
-
-| | |           
-|---|---|   
-|   **Service description** |   The Windows biometric service gives client applications the ability to capture, compare, manipulate, and store biometric data without gaining direct access to any biometric hardware or samples. The service is hosted in a privileged SVCHOST process.
-|   **Service name**    |   WbioSrvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Windows Camera Frame Server         
-
-| | |           
-|---|---|       
-|   **Service description** |   Enables multiple clients to access video frames from camera devices.
-|   **Service name**    |   FrameServer
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Connection Manager           
-
-| | |           
-|---|---|   
-|   **Service description** |   Makes automatic connect/disconnect decisions based on the network connectivity options currently available to the PC and enables management of network connectivity based on Group Policy settings.
-|   **Service name**    |   Wcmsvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Defender Network Inspection Service          
-
-| | |           
-|---|---|       
-|   **Service description** |   Helps guard against intrusion attempts targeting known and newly discovered vulnerabilities in network protocols
-|   **Service name**    |   WdNisSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance    
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Defender Service         
-
-| | |           
-|---|---|       
-|   **Service description** |   Helps protect users from malware and other potentially unwanted software
-|   **Service name**    |   WinDefend
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Driver Foundation - User-mode Driver Framework           
-
-| | |           
-|---|---|   
-|   **Service description** |   Creates and manages user-mode driver processes. This service cannot be stopped.
-|   **Service name**    |   wudfsvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Encryption Provider Host Service     
-
-| | |           
-|---|---|   
-|   **Service description** |   Windows Encryption Provider Host Service brokers encryption related functionalities from third-party Encryption Providers to processes that need to evaluate and apply EAS policies. Stopping this will compromise EAS compliancy checks that have been established by the connected Mail Accounts
-|   **Service name**    |   WEPHOSTSVC
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Error Reporting Service          
-
-| | |           
-|---|---|       
-|   **Service description** |   Allows errors to be reported when programs stop working or responding and allows existing solutions to be delivered. Also allows logs to be generated for diagnostic and repair services. If this service is stopped, error reporting might not work correctly and results of diagnostic services and repairs might not be displayed.
-|   **Service name**    |   WerSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Collects and sends crash/hang data used by both MS and third party ISVs/IHVs. The data is used to diagnose crash-inducing bugs, which may include security bugs. Also needed for Corporate Error Reporting
-|||         
-
-
-
-## Windows Event Collector          
-
-| | |           
-|---|---|   
-|   **Service description** |   This service manages persistent subscriptions to events from remote sources that support WS-Management protocol. This includes Windows Vista event logs, hardware and IPMI-enabled event sources. The service stores forwarded events in a local Event Log. If this service is stopped or disabled event subscriptions cannot be created and forwarded events cannot be accepted.
-|   **Service name**    |   Wecsvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Collects ETW events (including security events) for manageability, diagnostics.  Lots of features and third-party tools rely on it, including security audit tools
-|||         
-
-
-
-## Windows Event Log            
-
-| | |           
-|---|---|       
-|   **Service description** |   This service manages events and event logs. It supports logging events, querying events, subscribing to events, archiving event logs, and managing event metadata. It can display events in both XML and plain text format. Stopping this service may compromise security and reliability of the system.
-|   **Service name**    |   EventLog
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Firewall         
-
-| | |           
-|---|---|   
-|   **Service description** |   Windows Firewall helps protect your computer by preventing unauthorized users from gaining access to your computer through the Internet or a network.
-|   **Service name**    |   MpsSvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Windows Font Cache Service      
-
-| | |           
-|---|---|   
-|   **Service description** |   Optimizes performance of applications by caching commonly used font data. Applications will start this service if it is not already running. It can be disabled, though doing so will degrade application performance.
-|   **Service name**    |   FontCache
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Image Acquisition (WIA)          
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides image acquisition services for scanners and cameras
-|   **Service name**    |   stisvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-##  Windows Insider Service     
-
-| | |           
-|---|---|   
-|   **Service description** |   wisvc
-|   **Service name**    |   wisvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Server doesn't support flighting, so it's a no-op on Server. Feature can be disabled via GP as well.
-|||         
-
-
-
-##  Windows Installer       
-
-| | |           
-|---|---|
-|   **Service description** |   Adds, modifies, and removes applications provided as a Windows Installer (*.msi, *.msp) package. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   msiserver
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows License Manager Service          
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides infrastructure support for the Microsoft Store.  This service is started on demand and if disabled then content acquired through the Microsoft Store will not function properly.
-|   **Service name**    |   LicenseManager
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Management Instrumentation       
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides a common interface and object model to access management information about operating system, devices, applications and services. If this service is stopped, most Windows-based software will not function properly. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   Winmgmt
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-##  Windows Mobile Hotspot Service          
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides the ability to share a cellular data connection with another device.
-|   **Service name**    |   icssvc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Modules Installer        
-
-| | |           
-|---|---|   
-|   **Service description** |   Enables installation, modification, and removal of Windows updates and optional components. If this service is disabled, install or uninstall of Windows updates might fail for this computer.
-|   **Service name**    |   TrustedInstaller
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Push Notifications System Service            
-
-| | |           
-|---|---|
-|   **Service description** |   This service runs in session 0 and hosts the notification platform and connection provider which handles the connection between the device and WNS server.
-|   **Service name**    |   WpnService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   Needed for live tiles and other features
-|||         
-
-
-
-## Windows Push Notifications User Service          
-
-| | |           
-|---|---|   
-|   **Service description** |   This service hosts Windows notification platform which provides support for local and push notifications. Supported notifications are tile, toast and raw.
-|   **Service name**    |   WpnUserService
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   OK to disable
-|   **Comments**    |   User service template
-|||         
-
-
-
-## Windows Remote Management (WS-Management)
-| | |
-|---|---|
-|   **Service description** |   Windows Remote Management (WinRM) service implements the WS-Management protocol for remote management. WS-Management is a standard web services protocol used for remote software and hardware management. The WinRM service listens on the network for WS-Management requests and processes them. The WinRM Service needs to be configured with a listener using winrm.cmd command line tool or through Group Policy in order for it to listen over the network. The WinRM service provides access to WMI data and enables event collection. Event collection and subscription to events require that the service is running. WinRM messages use HTTP and HTTPS as transports. The WinRM service does not depend on IIS but is preconfigured to share a port with IIS on the same machine.  The WinRM service reserves the /wsman URL prefix. To prevent conflicts with IIS, administrators should ensure that any websites hosted on IIS do not use the /wsman URL prefix.
-|   **Service name**    |   WinRM
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Needed for remote management
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WiaRpc
+| **Description**    | Launches applications associated with still image acquisition events.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
 |||
 
 
+## Storage Service
 
-##  Windows Search      
-
-| | |           
-|---|---|       
-|   **Service description** |   Provides content indexing, property caching, and search results for files, e-mail, and other content.
-|   **Service name**    |   WSearch
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Disabled
-|   **Recommendation**  |   Already disabled
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | StorSvc
+| **Description**    | Provides enabling services for storage settings and external storage expansion
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-##  Windows Time        
+##  Storage Tiers Management
 
-| | |           
-|---|---|   
-|   **Service description** |   Maintains date and time synchronization on all clients and servers in the network. If this service is stopped, date and time synchronization will be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   W32Time
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance
-|   **Comments**    |   
-|||         
-
-
-
-## Windows Update           
-
-| | |           
-|---|---|       
-|   **Service description** |   Enables the detection, download, and installation of updates for Windows and other programs. If this service is disabled, users of this computer will not be able to use Windows Update or its automatic updating feature, and programs will not be able to use the Windows Update Agent (WUA) API.
-|   **Service name**    |   wuauserv
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | TieringEngineService
+| **Description**    | Optimizes the placement of data in storage tiers on all tiered storage spaces in the system.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+##  Superfetch
 
-## WinHTTP Web Proxy Auto-Discovery Service         
-
-| | |           
-|---|---|   
-|   **Service description** |   WinHTTP implements the client HTTP stack and provides developers with a Win32 API and COM Automation component for sending HTTP requests and receiving responses. In addition, WinHTTP provides support for auto-discovering a proxy configuration via its implementation of the Web Proxy Auto-Discovery (WPAD) protocol.
-|   **Service name**    |   WinHttpAutoProxySvc
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Do not disable
-|   **Comments**    |   Anything that uses the network stack can have a functional dependency on this service. Many organizations rely on this to configure their internal networks' HTTP proxy routing.  Without it, internally-originating HTTP connections to the Internet will all fail.
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SysMain
+| **Description**    | Maintains and improves system performance over time.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Wired AutoConfig         
+## Sync Host
 
-| | |           
-|---|---|       
-|   **Service description** |   The Wired AutoConfig (DOT3SVC) service is responsible for performing IEEE 802.1X authentication on Ethernet interfaces. If your current wired network deployment enforces 802.1X authentication, the DOT3SVC service should be configured to run for establishing Layer 2 connectivity and/or providing access to network resources. Wired networks that do not enforce 802.1X authentication are unaffected by the DOT3SVC service.
-|   **Service name**    |   dot3svc
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance   
-|   **Comments**    |   
-|||         
-
-
-
-## WMI Performance Adapter          
-
-| | |           
-|---|---|   
-|   **Service description** |   Provides performance library information from Windows Management Instrumentation (WMI) providers to clients on the network. This service only runs when Performance Data Helper is activated.
-|   **Service name**    |   wmiApSrv
-|   **Installation**    |   Always installed
-|   **StartType**   |   Manual
-|   **Recommendation**  | No guidance       
-|   **Comments**    |   
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | OneSyncSvc
+| **Description**    | This service synchronizes mail, contacts, calendar and various other user data. Mail and other applications dependent on this functionality will not work properly when this service is not running.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | OK to disable
+| **Comments**       | User service template
+|||
 
 
+## System Event Notification Service
 
-## Workstation          
-
-| | |           
-|---|---|   
-|   **Service description** |   Creates and maintains client network connections to remote servers using the SMB protocol. If this service is stopped, these connections will be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
-|   **Service name**    |   LanmanWorkstation
-|   **Installation**    |   Always installed
-|   **StartType**   |   Automatic
-|   **Recommendation**  | No guidance       
-|   **Comments**    |   
-|||         
-
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SENS
+| **Description**    | Monitors system events and notifies subscribers to COM+ Event System of these events.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
-## Xbox Live Auth Manager           
+## System Events Broker
 
-| | |           
-|---|---|   
-|   **Service description** |   Provides authentication and authorization services for interacting with Xbox Live. If this service is stopped, some applications may not operate correctly.
-|   **Service name**    |   XblAuthManager
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Should be disabled
-|   **Comments**    |   
-|||         
-
-
-
-## Xbox Live Game Save          
-
-| | |           
-|---|---|   
-|   **Service description** |   This service syncs save data for Xbox Live save enabled games.  If this service is stopped, game save data will not upload to or download from Xbox Live.
-|   **Service name**    |   XblGameSave
-|   **Installation**    |   Only with Desktop Experience
-|   **StartType**   |   Manual
-|   **Recommendation**  |   Should be disabled
-|   **Comments**    |   This service syncs save data for Xbox Live save enabled games.  If this service is stopped, game save data will not upload to or download from Xbox Live.
-|||         
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | SystemEventsBroker
+| **Description**    | Coordinates execution of background work for WinRT application. If this service is stopped or disabled, then background work might not be triggered.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | Do not disable
+| **Comments**       | In spite of the fact that its description implies it is only for WinRT apps, it's needed for task scheduler, broker infrastructure service, and other internal components.
+|||
 
 
+## Task Scheduler
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Schedule
+| **Description**    | Enables a user to configure and schedule automated tasks on this computer. The service also hosts multiple Windows system-critical tasks. If this service is stopped or disabled, these tasks will not be run at their scheduled times. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
 
 
+## TCP/IP NetBIOS Helper
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | lmhosts
+| **Description**    | Provides support for the NetBIOS over TCP/IP (NetBT) service and NetBIOS name resolution for clients on the network, therefore enabling users to share files, print, and log on to the network. If this service is stopped, these functions might be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Telephony
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | TapiSrv
+| **Description**    | Provides Telephony API (TAPI) support for programs that control telephony devices on the local computer and, through the LAN, on servers that are also running the service.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Disabling breaks RRAS
+|||
+
+
+## Themes
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Themes
+| **Description**    | Provides user experience theme management.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | Do not disable
+| **Comments**       | Can't set accessibility themes when this service is disabled
+|||
+
+
+## Tile Data model server
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | tiledatamodelsvc
+| **Description**    | Tile Server for tile updates.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | Do not disable
+| **Comments**       | Start menu breaks if this service is disabled
+|||
+
+
+##  Time Broker
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | TimeBrokerSvc
+| **Description**    | Coordinates execution of background work for WinRT application. If this service is stopped or disabled, then background work might not be triggered.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | In spite of the fact that its description implies it is only for WinRT apps, it's needed for task scheduler, broker infrastructure service, and other internal components.
+|||
+
+
+## Touch Keyboard and Handwriting Panel Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | TabletInputService
+| **Description**    | Enables Touch Keyboard and Handwriting Panel pen and ink functionality
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Update Orchestrator Service for Windows Update
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | UsoSvc
+| **Description**    | Manages Windows Updates. If stopped, your devices will not be able to download and install latest updates.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Service description was missing in v1607; Windows Update (incl. WSUS) depends on this service.
+|||
+
+
+## UPnP Device Host
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | upnphost
+| **Description**    | Allows UPnP devices to be hosted on this computer. If this service is stopped, any hosted UPnP devices will stop functioning and no additional hosted devices can be added. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## User Access Logging Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | UALSVC
+| **Description**    | This service logs unique client access requests, in the form of IP addresses and user names, of installed products and roles on the local server. This information can be queried, via Powershell, by administrators needing to quantify client demand of server software for offline Client Access License (CAL) management. If the service is disabled, client requests will not be logged and will not be retrievable via Powershell queries. Stopping the service will not affect query of historical data (see supporting documentation for steps to delete historical data). The local system administrator must consult his, or her, Windows Server license terms to determine the number of CALs that are required for the server software to be appropriately licensed; use of the UAL service and data does not alter this obligation.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  User Data Access
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | UserDataSvc
+| **Description**    | Provides apps access to structured user data, including contact info, calendars, messages, and other content. If you stop or disable this service, apps that use this data might not work correctly.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | User service template
+|||
+
+
+## User Data Storage
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | UnistoreSvc
+| **Description**    | Handles storage of structured user data, including contact info, calendars, messages, and other content. If you stop or disable this service, apps that use this data might not work correctly.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | User service template
+|||
+
+
+## User Experience Virtualization Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | UevAgentService
+| **Description**    | Provides support for application and OS settings roaming
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       |
+|||
+
+
+##  User Manager
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | UserManager
+| **Description**    | User Manager provides the runtime components required for multi-user interaction.  If this service is stopped, some applications may not operate correctly.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## User Profile Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | ProfSvc
+| **Description**    | This service is responsible for loading and unloading user profiles. If this service is stopped or disabled, users will no longer be able to successfully sign in or sign out, apps might have problems getting to users' data, and components registered to receive profile event notifications won't receive them.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Virtual Disk
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | vds
+| **Description**    | Provides management services for disks, volumes, file systems, and storage arrays.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Volume Shadow Copy
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | VSS
+| **Description**    | Manages and implements Volume Shadow Copies used for backup and other purposes. If this service is stopped, shadow copies will be unavailable for backup and the backup may fail. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  WalletService
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WalletService
+| **Description**    | Hosts objects used by clients of the wallet
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Windows Audio
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Audiosrv
+| **Description**    | Manages audio for Windows-based programs.  If this service is stopped, audio devices and effects will not function properly.  If this service is disabled, any services that explicitly depend on it will fail to start
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Windows Audio Endpoint Builder
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | AudioEndpointBuilder
+| **Description**    | Manages audio devices for the Windows Audio service.  If this service is stopped, audio devices and effects will not function properly.  If this service is disabled, any services that explicitly depend on it will fail to start
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Windows Biometric Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WbioSrvc
+| **Description**    | The Windows biometric service gives client applications the ability to capture, compare, manipulate, and store biometric data without gaining direct access to any biometric hardware or samples. The service is hosted in a privileged SVCHOST process.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Windows Camera Frame Server
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | FrameServer
+| **Description**    | Enables multiple clients to access video frames from camera devices.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Windows Connection Manager
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Wcmsvc
+| **Description**    | Makes automatic connect/disconnect decisions based on the network connectivity options currently available to the PC and enables management of network connectivity based on Group Policy settings.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Defender Network Inspection Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WdNisSvc
+| **Description**    | Helps guard against intrusion attempts targeting known and newly discovered vulnerabilities in network protocols
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Defender Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WinDefend
+| **Description**    | Helps protect users from malware and other potentially unwanted software
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Driver Foundation - User-mode Driver Framework
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | wudfsvc
+| **Description**    | Creates and manages user-mode driver processes. This service cannot be stopped.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Encryption Provider Host Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WEPHOSTSVC
+| **Description**    | Windows Encryption Provider Host Service brokers encryption related functionalities from third-party Encryption Providers to processes that need to evaluate and apply EAS policies. Stopping this will compromise EAS compliancy checks that have been established by the connected Mail Accounts
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Error Reporting Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WerSvc
+| **Description**    | Allows errors to be reported when programs stop working or responding and allows existing solutions to be delivered. Also allows logs to be generated for diagnostic and repair services. If this service is stopped, error reporting might not work correctly and results of diagnostic services and repairs might not be displayed.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Collects and sends crash/hang data used by both MS and third party ISVs/IHVs. The data is used to diagnose crash-inducing bugs, which may include security bugs. Also needed for Corporate Error Reporting
+|||
+
+
+## Windows Event Collector
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Wecsvc
+| **Description**    | This service manages persistent subscriptions to events from remote sources that support WS-Management protocol. This includes Windows Vista event logs, hardware and IPMI-enabled event sources. The service stores forwarded events in a local Event Log. If this service is stopped or disabled event subscriptions cannot be created and forwarded events cannot be accepted.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Collects ETW events (including security events) for manageability, diagnostics.  Lots of features and third-party tools rely on it, including security audit tools
+|||
+
+
+## Windows Event Log
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | EventLog
+| **Description**    | This service manages events and event logs. It supports logging events, querying events, subscribing to events, archiving event logs, and managing event metadata. It can display events in both XML and plain text format. Stopping this service may compromise security and reliability of the system.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Firewall
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | MpsSvc
+| **Description**    | Windows Firewall helps protect your computer by preventing unauthorized users from gaining access to your computer through the Internet or a network.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Windows Font Cache Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | FontCache
+| **Description**    | Optimizes performance of applications by caching commonly used font data. Applications will start this service if it is not already running. It can be disabled, though doing so will degrade application performance.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Image Acquisition (WIA)
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | stisvc
+| **Description**    | Provides image acquisition services for scanners and cameras
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+##  Windows Insider Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | wisvc
+| **Description**    | wisvc
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | Server doesn't support flighting, so it's a no-op on Server. Feature can be disabled via GP as well.
+|||
+
+
+##  Windows Installer
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | msiserver
+| **Description**    | Adds, modifies, and removes applications provided as a Windows Installer (*.msi, *.msp) package. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows License Manager Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | LicenseManager
+| **Description**    | Provides infrastructure support for the Microsoft Store.  This service is started on demand and if disabled then content acquired through the Microsoft Store will not function properly.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Management Instrumentation
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | Winmgmt
+| **Description**    | Provides a common interface and object model to access management information about operating system, devices, applications and services. If this service is stopped, most Windows-based software will not function properly. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+##  Windows Mobile Hotspot Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | icssvc
+| **Description**    | Provides the ability to share a cellular data connection with another device.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       |
+|||
+
+
+## Windows Modules Installer
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | TrustedInstaller
+| **Description**    | Enables installation, modification, and removal of Windows updates and optional components. If this service is disabled, install or uninstall of Windows updates might fail for this computer.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Push Notifications System Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WpnService
+| **Description**    | This service runs in session 0 and hosts the notification platform and connection provider which handles the connection between the device and WNS server.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Automatic
+| **Recommendation** | OK to disable
+| **Comments**       | Needed for live tiles and other features
+|||
+
+
+## Windows Push Notifications User Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WpnUserService
+| **Description**    | This service hosts Windows notification platform which provides support for local and push notifications. Supported notifications are tile, toast and raw.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | OK to disable
+| **Comments**       | User service template
+|||
+
+
+## Windows Remote Management (WS-Management)
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WinRM
+| **Description**    | Windows Remote Management (WinRM) service implements the WS-Management protocol for remote management. WS-Management is a standard web services protocol used for remote software and hardware management. The WinRM service listens on the network for WS-Management requests and processes them. The WinRM Service needs to be configured with a listener using winrm.cmd command line tool or through Group Policy in order for it to listen over the network. The WinRM service provides access to WMI data and enables event collection. Event collection and subscription to events require that the service is running. WinRM messages use HTTP and HTTPS as transports. The WinRM service does not depend on IIS but is preconfigured to share a port with IIS on the same machine.  The WinRM service reserves the /wsman URL prefix. To prevent conflicts with IIS, administrators should ensure that any websites hosted on IIS do not use the /wsman URL prefix.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | Do not disable
+| **Comments**       | Needed for remote management
+|||
+
+
+##  Windows Search
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WSearch
+| **Description**    | Provides content indexing, property caching, and search results for files, e-mail, and other content.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Disabled
+| **Recommendation** | Already disabled
+| **Comments**       |
+|||
+
+
+##  Windows Time
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | W32Time
+| **Description**    | Maintains date and time synchronization on all clients and servers in the network. If this service is stopped, date and time synchronization will be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Windows Update
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | wuauserv
+| **Description**    | Enables the detection, download, and installation of updates for Windows and other programs. If this service is disabled, users of this computer will not be able to use Windows Update or its automatic updating feature, and programs will not be able to use the Windows Update Agent (WUA) API.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## WinHTTP Web Proxy Auto-Discovery Service
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | WinHttpAutoProxySvc
+| **Description**    | WinHTTP implements the client HTTP stack and provides developers with a Win32 API and COM Automation component for sending HTTP requests and receiving responses. In addition, WinHTTP provides support for auto-discovering a proxy configuration via its implementation of the Web Proxy Auto-Discovery (WPAD) protocol.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | Do not disable
+| **Comments**       | Anything that uses the network stack can have a functional dependency on this service. Many organizations rely on this to configure their internal networks' HTTP proxy routing.  Without it, internally-originating HTTP connections to the Internet will all fail.
+|||
+
+
+## Wired AutoConfig
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | dot3svc
+| **Description**    | The Wired AutoConfig (DOT3SVC) service is responsible for performing IEEE 802.1X authentication on Ethernet interfaces. If your current wired network deployment enforces 802.1X authentication, the DOT3SVC service should be configured to run for establishing Layer 2 connectivity and/or providing access to network resources. Wired networks that do not enforce 802.1X authentication are unaffected by the DOT3SVC service.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## WMI Performance Adapter
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | wmiApSrv
+| **Description**    | Provides performance library information from Windows Management Instrumentation (WMI) providers to clients on the network. This service only runs when Performance Data Helper is activated.
+| **Installation**   | Always installed
+| **Startup type**   | Manual
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Workstation
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | LanmanWorkstation
+| **Description**    | Creates and maintains client network connections to remote servers using the SMB protocol. If this service is stopped, these connections will be unavailable. If this service is disabled, any services that explicitly depend on it will fail to start.
+| **Installation**   | Always installed
+| **Startup type**   | Automatic
+| **Recommendation** | No guidance
+| **Comments**       |
+|||
+
+
+## Xbox Live Auth Manager
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | XblAuthManager
+| **Description**    | Provides authentication and authorization services for interacting with Xbox Live. If this service is stopped, some applications may not operate correctly.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | Should be disabled
+| **Comments**       |
+|||
+
+
+## Xbox Live Game Save
+
+|                    |        |
+| ------------------ | ------ |
+| **Service name**   | XblGameSave
+| **Description**    | This service syncs save data for Xbox Live save enabled games.  If this service is stopped, game save data will not upload to or download from Xbox Live.
+| **Installation**   | Only with Desktop Experience
+| **Startup type**   | Manual
+| **Recommendation** | Should be disabled
+| **Comments**       | This service syncs save data for Xbox Live save enabled games.  If this service is stopped, game save data will not upload to or download from Xbox Live.
+|||


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4164 (**Microsoft (R) Diagnostics Hub Standard Collector**), the service description text for this particular service on this page is copy-pasted from the preceding service "Local Session manager".

Thanks to @rlappsupport for reporting this documentation issue.

**Changes proposed:**
- Replace the current service description text with the correct one:
  "Diagnostics Hub Standard Collector Service. When running, this service collects real time ETW events and processes them."
-  Correct its name to "diagnosticshub.standardcollector.service"
- Correct its Startup type to "Manual" according to factual standard
- Rename row names in accordance with actual services.msc names (Service name, Description, Startup type)
- Swap order for the "Description" and the "Service name" rows
- Whitespace & Layout changes:
    - Remove all redundant end-of-line (EOL) whitespace (blanks)
    - Remove redundant blank lines at end-of-file (EOF)
    - Reduce blank line spacing to max 2 blank lines (from 3 or 4)
    - Standardize table layout spacing and borders of first column
    - Standardize cell layout for the blank header row (readability)

I realize that this PR contains a lot of changes and that it may take more time than usual for MS Docs team members to review it. My motivation for making so many changes is for this documentation to be as useful and valuable as possible, for both myself and others, using Microsoft Windows Server 2016 in current production scenarios.

**Ticket closure or reference:**

Closes #4164