### PR TITLE
Windows Server upgrade Overview: grammar details

### DIFF
--- a/WindowsServerDocs/upgrade/upgrade-overview.md
+++ b/WindowsServerDocs/upgrade/upgrade-overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview about Windows Server upgrades | Microsoft Docs
-description: General Windows Server upgrade information, along with what to think about before you do the actual upgrade. 
+title: Overview of Windows Server upgrades | Microsoft Docs
+description: General Windows Server upgrade information, along with what to think through before you do the actual upgrade.
 ms.prod: windows-server
 ms.technology: server-general
 ms.topic: upgrade
@@ -9,18 +9,18 @@ ms.author: robhind
 ms.date: 09/10/2019
 ---
 
-# Overview about Windows Server upgrades
+# Overview of Windows Server upgrades
 
-The process of upgrading to a newer version of Windows Server can vary greatly depending on which operating system you are starting with and the pathway you take. We use the following terms to distinguish among different actions, any of which could be involved in a new Windows Server deployment.
+The process of upgrading to a newer version of Windows Server can vary greatly, depending on which operating system you are starting with and the pathway you take. We use the following terms to distinguish between different actions, any of which could be involved in a new Windows Server deployment.
 
 - **Upgrade.** Also known as an "in-place upgrade". You move from an older version of the operating system to a newer version, while staying on the same physical hardware. **This is the method we will be covering in this section.**
 
-    >[!Important]
-    >In-place upgrades might also be supported by public or private cloud companies; however, you must check with your cloud provider for the details. Additionally, you'll be unable to perform an in-place upgrade on any Windows Server that's configured to **Boot from VHD**. An In-Place Upgrade from Windows Storage Server Editions to Windows Server 2019 is not supported. You can perform either a **Migration** or **Installation** instead.
+    > [!Important]
+    > In-place upgrades might also be supported by public or private cloud companies; however, you must check with your cloud provider for the details. Additionally, you'll be unable to perform an in-place upgrade on any Windows Server configured to **Boot from VHD**. An In-Place Upgrade from Windows Storage Server Editions to Windows Server 2019 is not supported. You can perform either a **Migration** or **Installation** instead.
 
 - **Installation.** Also known as a "clean installation". You move from an older version of the operating system to a newer version, deleting the older operating system.
 
-- **Migration.** You move from an older version of the operating system to a newer version of the operating system by transferring to a different set of hardware or virtual machine.
+- **Migration.** You move from an older version of the operating system to a newer version of the operating system, by transferring to a different set of hardware or virtual machine.
 
 - **Cluster OS Rolling Upgrade.** You upgrade the operating system of your cluster nodes without stopping the Hyper-V or the Scale-Out File Server workloads. This feature allows you to avoid downtime which could impact Service Level Agreements. For more information, see [Cluster operating system rolling upgrade](../failover-clustering/cluster-operating-system-rolling-upgrade.md)
 
@@ -34,6 +34,6 @@ However, we realize that's not always possible. You can use the following diagra
 
 ![Available in-place upgrade paths](media/upgrade-paths.png)
 
-Windows Server can be typically be upgraded through at least one, and sometimes even two, versions. For example, Windows Server 2012 R2 and Windows Server 2016 can both be upgraded in-place to Windows Server 2019.
+Windows Server can typically be upgraded through at least one, and sometimes even two, versions. For example, Windows Server 2012 R2 and Windows Server 2016 can both be upgraded in-place to Windows Server 2019.
 
 You can also upgrade from an evaluation version of the operating system to a retail version, from an older retail version to a newer version, or, in some cases, from a volume-licensed edition of the operating system to an ordinary retail edition. For more information about upgrade options other than in-place upgrade, see [Upgrade and conversion options for Windows Server](../get-started/supported-upgrade-paths.md).


### PR DESCRIPTION
**Description:**

As suggested in issue ticket #4265 (**Suggested change to Title**), the current title text "Overview about Windows Server upgrades" is not entirely written as in normal, everyday English usage. "Overview about" is not a normal English phrase, compared to "Overview of".

There are also a few similar grammar details to be corrected in this document to make it easier to read, understand and translate.

Thanks to @cliffhobbs (Cliff @ FAQShop.com) for reporting the title grammar detail.

**Changes proposed:**
- "Overview about" -> "Overview of", in the title & metadata
- "think about" -> "think through" in the metadata section
- Remove a redundant "that's" from "on any Windows Server configured to"
- Remove an incorrect duplicate "be" from "can be typically be upgraded"
- Whitespace adjustments:
    - remove end-of-line (EOL) blank spaces
    - add MarkDown indent marker compatibility spacing in the [Important] note

**Ticket closure or reference:**

Closes #4265