### PR TITLE
Cluster Sets: grammar and whitespace edits

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/Cluster-Sets.md
+++ b/WindowsServerDocs/storage/storage-spaces/Cluster-Sets.md
@@ -10,6 +10,7 @@ ms.date: 01/30/2019
 description: This article describes the Cluster sets scenario
 ms.localizationpriority: medium
 ---
+
 # Cluster sets
 
 > Applies to: Windows Server 2019
@@ -20,13 +21,13 @@ While preserving existing Failover Cluster management experiences on member clus
 
 ## Technology introduction
 
-Cluster sets technology is developed to meet specific customer requests operating Software Defined Datacenter (SDDC) clouds at scale. Cluster sets value proposition may be summarized as the following:  
+Cluster sets technology is developed to meet specific customer requests operating Software Defined Datacenter (SDDC) clouds at scale. Cluster sets value proposition may be summarized as the following:
 
 - Significantly increase the supported SDDC cloud scale for running highly available virtual machines by combining multiple smaller clusters into a single large fabric, even while keeping the software fault boundary to a single cluster
 - Manage entire Failover Cluster lifecycle including onboarding and retiring clusters, without impacting tenant virtual machine availability, via fluidly migrating virtual machines across this large fabric
 - Easily change the compute-to-storage ratio in your hyper-converged I
 - Benefit from [Azure-like Fault Domains and Availability sets](htttps://docs.microsoft.com/azure/virtual-machines/windows/manage-availability) across clusters in initial virtual machine placement and subsequent virtual machine migration
-- Mix-and-match different generations of CPU hardware into the same cluster set fabric, even while keeping individual fault domains homogenous for maximum efficiency.  Please note that the recommendation of same hardware is still present within each individual cluster as well as the entire cluster set.
+- Mix-and-match different generations of CPU hardware into the same cluster set fabric, even while keeping individual fault domains homogeneous for maximum efficiency. Please note that the recommendation of same hardware is still present within each individual cluster as well as the entire cluster set.
 
 From a high level view, this is what cluster sets can look like.
 
@@ -36,7 +37,7 @@ The following provides a quick summary of each of the elements in the above imag
 
 **Management cluster**
 
-Management cluster in a cluster set is a Failover Cluster that hosts the highly-available management plane of the entire cluster set and the unified storage namespace (Cluster Set Namespace) referral Scale-Out File Server (SOFS). A management cluster is logically decoupled from member clusters that run the virtual machine workloads. This makes the cluster set management plane resilient to any localized cluster-wide failures, e.g. loss of power of a member cluster.   
+Management cluster in a cluster set is a Failover Cluster that hosts the highly-available management plane of the entire cluster set and the unified storage namespace (Cluster Set Namespace) referral Scale-Out File Server (SOFS). A management cluster is logically decoupled from member clusters that run the virtual machine workloads. This makes the cluster set management plane resilient to any localized cluster-wide failures, e.g. loss of power of a member cluster.
 
 **Member cluster**
 
@@ -52,11 +53,11 @@ In a cluster set, the communication between the member clusters is loosely coupl
 
 **Cluster set worker**
 
-In a Cluster Set deployment, the CS-Master interacts with a new cluster resource on the member Clusters called "Cluster Set Worker" (CS-Worker). CS-Worker acts as the only liaison on the cluster to orchestrate the local cluster interactions as requested by the CS-Master. Examples of such interactions include virtual machine placement and cluster-local resource inventorying. There is only one CS-Worker instance for each of the member clusters in a cluster set. 
+In a Cluster Set deployment, the CS-Master interacts with a new cluster resource on the member Clusters called "Cluster Set Worker" (CS-Worker). CS-Worker acts as the only liaison on the cluster to orchestrate the local cluster interactions as requested by the CS-Master. Examples of such interactions include virtual machine placement and cluster-local resource inventorying. There is only one CS-Worker instance for each of the member clusters in a cluster set.
 
 **Fault domain**
 
-A fault domain is the grouping of software and hardware artifacts that the administrator determines could fail together when a failure does occur.  While an administrator could designate one or more clusters together as a fault domain, each node could participate in a fault domain in an availability set. Cluster sets by design leaves the decision of fault domain boundary determination to the administrator who is well-versed with data center topology considerations – e.g. PDU, networking – that member clusters share. 
+A fault domain is the grouping of software and hardware artifacts that the administrator determines could fail together when a failure does occur. While an administrator could designate one or more clusters together as a fault domain, each node could participate in a fault domain in an availability set. Cluster sets by design leaves the decision of fault domain boundary determination to the administrator who is well-versed with data center topology considerations – e.g. PDU, networking – that member clusters share.
 
 **Availability set**
 
@@ -64,16 +65,16 @@ An availability set helps the administrator configure desired redundancy of clus
 
 ## Why use cluster sets
 
-Cluster sets provides the benefit of scale without sacrificing resiliency.  
+Cluster sets provides the benefit of scale without sacrificing resiliency.
 
-Cluster sets allows for clustering multiple clusters together to create a large fabric, while each cluster remains independent for resiliency.  For example, you have a several 4-node HCI clusters running virtual machines.  Each cluster provides the resiliency needed for itself.  If the storage or memory starts to fill up, scaling up is your next step.  With scaling up, there are some options and considerations.
+Cluster sets allows for clustering multiple clusters together to create a large fabric, while each cluster remains independent for resiliency. For example, you have a several 4-node HCI clusters running virtual machines. Each cluster provides the resiliency needed for itself. If the storage or memory starts to fill up, scaling up is your next step. With scaling up, there are some options and considerations.
 
-1. Add more storage to the current cluster.  With Storage Spaces Direct, this may be tricky as the exact same model/firmware drives may not be available.  The consideration of rebuild times also need to be taken into account.
-2. Add more memory.  What if you are maxed out on the memory the machines can handle?  What if all available memory slots are full?
-3. Add additional compute nodes with drives into the current cluster.  This takes us back to Option 1 needing to be considered.
+1. Add more storage to the current cluster. With Storage Spaces Direct, this may be tricky as the exact same model/firmware drives may not be available. The consideration of rebuild times also need to be taken into account.
+2. Add more memory. What if you are maxed out on the memory the machines can handle?  What if all available memory slots are full?
+3. Add additional compute nodes with drives into the current cluster. This takes us back to Option 1 needing to be considered.
 4. Purchase a whole new cluster
 
-This is where cluster sets provides the benefit of scaling.  If I add my clusters into a cluster set, I can take advantage of storage or memory that may be available on another cluster without any additional purchases.  From a resiliency perspective, adding additional nodes to a Storage Spaces Direct is not going to provide additional votes for quorum.  As mentioned [here](drive-symmetry-considerations.md), a Storage Spaces Direct Cluster can survive the loss of 2 nodes before going down.  If you have a 4-node HCI cluster, 3 nodes go down will take the entire cluster down.  If you have an 8-node cluster, 3 nodes go down will take the entire cluster down.  With Cluster sets that has two 4-node HCI clusters in the set, 2 nodes in one HCI go down and 1 node in the other HCI go down, both clusters remain up.  Is it better to create one large 16-node Storage Spaces Direct cluster or break it down into four 4-node clusters and use cluster sets?  Having four 4-node clusters with cluster sets gives the same scale, but better resiliency in that multiple compute nodes can go down (unexpectedly or for maintenance) and production remains.
+This is where cluster sets provides the benefit of scaling. If I add my clusters into a cluster set, I can take advantage of storage or memory that may be available on another cluster without any additional purchases. From a resiliency perspective, adding additional nodes to a Storage Spaces Direct is not going to provide additional votes for quorum. As mentioned [here](drive-symmetry-considerations.md), a Storage Spaces Direct Cluster can survive the loss of 2 nodes before going down. If you have a 4-node HCI cluster, 3 nodes go down will take the entire cluster down. If you have an 8-node cluster, 3 nodes go down will take the entire cluster down. With Cluster sets that has two 4-node HCI clusters in the set, 2 nodes in one HCI go down and 1 node in the other HCI go down, both clusters remain up. Is it better to create one large 16-node Storage Spaces Direct cluster or break it down into four 4-node clusters and use cluster sets?  Having four 4-node clusters with cluster sets gives the same scale, but better resiliency in that multiple compute nodes can go down (unexpectedly or for maintenance) and production remains.
 
 ## Considerations for deploying cluster sets
 
@@ -87,15 +88,15 @@ When considering if cluster sets is something you need to use, consider these qu
 
 If your answer is yes, then cluster sets is what you need.
 
-There are a few other items to consider where a larger SDDC might change your overall data center strategies.  SQL Server is a good example.  Does moving SQL Server virtual machines between clusters require licensing SQL to run on additional nodes?  
+There are a few other items to consider where a larger SDDC might change your overall data center strategies. SQL Server is a good example. Does moving SQL Server virtual machines between clusters require licensing SQL to run on additional nodes?
 
 ## Scale-out file server and cluster sets
 
-In Windows Server 2019, there is a new scale-out file server role called Infrastructure Scale-Out File Server (SOFS). 
+In Windows Server 2019, there is a new scale-out file server role called Infrastructure Scale-Out File Server (SOFS).
 
 The following considerations apply to an Infrastructure SOFS role:
 
-1. There can be at most only one Infrastructure SOFS cluster role on a Failover Cluster. Infrastructure SOFS role is created by specifying the "**-Infrastructure**" switch parameter to the **Add-ClusterScaleOutFileServerRole** cmdlet.  For example:
+1. There can be at most only one Infrastructure SOFS cluster role on a Failover Cluster. Infrastructure SOFS role is created by specifying the "**-Infrastructure**" switch parameter to the **Add-ClusterScaleOutFileServerRole** cmdlet. For example:
 
     ```PowerShell
     Add-ClusterScaleoutFileServerRole -Name "my_infra_sofs_name" -Infrastructure
@@ -107,9 +108,9 @@ The following considerations apply to an Infrastructure SOFS role:
 
 Once a cluster set is created, the cluster set namespace relies on an Infrastructure SOFS on each of the member clusters, and additionally an Infrastructure SOFS in the management cluster.
 
-At the time a member cluster is added to a cluster set, the administrator specifies the name of an Infrastructure SOFS on that cluster if one already exists. If the Infrastructure SOFS does not exist, a new Infrastructure SOFS role on the new member cluster is created by this operation. If an Infrastructure SOFS role already exists on the member cluster, the Add operation implicitly renames it to the specified name as needed. Any existing singleton SMB servers, or non-Infrastructure SOFS roles on the member clusters are left unutilized by the cluster set. 
+At the time a member cluster is added to a cluster set, the administrator specifies the name of an Infrastructure SOFS on that cluster if one already exists. If the Infrastructure SOFS does not exist, a new Infrastructure SOFS role on the new member cluster is created by this operation. If an Infrastructure SOFS role already exists on the member cluster, the Add operation implicitly renames it to the specified name as needed. Any existing singleton SMB servers, or non-Infrastructure SOFS roles on the member clusters are left unutilized by the cluster set.
 
-At the time the cluster set is created, the administrator has the option to use an already-existing AD computer object as the namespace root on the management cluster. Cluster set creation operations create the Infrastructure SOFS cluster role on the management cluster or renames the existing Infrastructure SOFS role just as previously described for member clusters. The Infrastructure SOFS on the management cluster is used as the cluster set namespace referral (Cluster Set Namespace) SOFS. It simply means that each SMB Share on the cluster set namespace SOFS is a referral share – of type 'SimpleReferral' - newly introduced in Windows Server 2019.  This referral allows SMB clients access to the target SMB share hosted on the member cluster SOFS. The cluster set namespace referral SOFS is a light-weight referral mechanism and as such, does not participate in the I/O path. The SMB referrals are cached perpetually on the each of the client nodes and the cluster sets namespace dynamically updates automatically these referrals as needed
+At the time the cluster set is created, the administrator has the option to use an already-existing AD computer object as the namespace root on the management cluster. Cluster set creation operations create the Infrastructure SOFS cluster role on the management cluster or renames the existing Infrastructure SOFS role just as previously described for member clusters. The Infrastructure SOFS on the management cluster is used as the cluster set namespace referral (Cluster Set Namespace) SOFS. It simply means that each SMB Share on the cluster set namespace SOFS is a referral share – of type 'SimpleReferral' - newly introduced in Windows Server 2019. This referral allows SMB clients access to the target SMB share hosted on the member cluster SOFS. The cluster set namespace referral SOFS is a light-weight referral mechanism and as such, does not participate in the I/O path. The SMB referrals are cached perpetually on the each of the client nodes and the cluster sets namespace dynamically updates automatically these referrals as needed
 
 ## Creating a Cluster Set
 
@@ -120,25 +121,25 @@ When creating a cluster set, you following prerequisites are recommended:
 1. Configure a management client running Windows Server 2019.
 2. Install the Failover Cluster tools on this management server.
 3. Create cluster members (at least two clusters with at least two Cluster Shared Volumes on each cluster)
-4. Create a management cluster (physical or guest) that straddles the member clusters.  This approach ensures that the Cluster sets management plane continues to be available despite possible member cluster failures.
+4. Create a management cluster (physical or guest) that straddles the member clusters. This approach ensures that the Cluster sets management plane continues to be available despite possible member cluster failures.
 
 ### Steps
 
-1. Create a new cluster set from three clusters as defined in the prerequisites.  The below chart gives an example of clusters to create.  The name of the cluster set in this example will be **CSMASTER**.
+1. Create a new cluster set from three clusters as defined in the prerequisites. The below chart gives an example of clusters to create. The name of the cluster set in this example will be **CSMASTER**.
 
-   | Cluster Name               | Infrastructure SOFS Name to be used later | 
-   |----------------------------|-------------------------------------------|
-   | SET-CLUSTER                | SOFS-CLUSTERSET                           |
-   | CLUSTER1                   | SOFS-CLUSTER1                             |
-   | CLUSTER2                   | SOFS-CLUSTER2                             |
+   | Cluster Name | Infrastructure SOFS Name to be used later |
+   |--------------|-------------------------------------------|
+   | SET-CLUSTER  | SOFS-CLUSTERSET                           |
+   | CLUSTER1     | SOFS-CLUSTER1                             |
+   | CLUSTER2     | SOFS-CLUSTER2                             |
 
-2. Once all cluster have been created, use the following commands to create the cluster set master.
+2. Once all the clusters have been created, use the following command to create the cluster set master:
 
     ```PowerShell
     New-ClusterSet -Name CSMASTER -NamespaceRoot SOFS-CLUSTERSET -CimSession SET-CLUSTER
     ```
 
-3. To add a Cluster Server to the cluster set, the below would be used.
+3. Use the command set below to add a Cluster Server to the cluster set:
 
     ```PowerShell
     Add-ClusterSetMember -ClusterName CLUSTER1 -CimSession CSMASTER -InfraSOFSName SOFS-CLUSTER1
@@ -148,7 +149,7 @@ When creating a cluster set, you following prerequisites are recommended:
    > [!NOTE]
    > If you are using a static IP Address scheme, you must include *-StaticAddress x.x.x.x* on the **New-ClusterSet** command.
 
-4. Once you have created the cluster set out of cluster members, you can list the nodes set and its properties.  To enumerate all the member clusters in the cluster set:
+4. Once you have created the cluster set out of cluster members, you can list the nodes set and its properties. To enumerate all the member clusters in the cluster set:
 
     ```PowerShell
     Get-ClusterSetMember -CimSession CSMASTER
@@ -169,30 +170,30 @@ When creating a cluster set, you following prerequisites are recommended:
 7. To list all the resource groups across the cluster set:
 
     ```PowerShell
-    Get-ClusterSet -CimSession CSMASTER | Get-Cluster | Get-ClusterGroup 
+    Get-ClusterSet -CimSession CSMASTER | Get-Cluster | Get-ClusterGroup
     ```
 
-8. To verify the cluster set creation process created one SMB share (identified as Volume1 or whatever the CSV folder is labeled with the ScopeName being the name of the Infrastructure File Server and the path as both) on the Infrastructure SOFS for each cluster member's CSV volume:
+8. To verify that the cluster set creation process created one SMB share (identified as Volume1, or whatever the CSV folder is labeled with, the ScopeName being the Infrastructure File Server name and the path as both) on the Infrastructure SOFS for each cluster member's CSV volume:
 
     ```PowerShell
     Get-SmbShare -CimSession CSMASTER
     ```
 
-8. Cluster sets has debug logs that can be collected for review.  Both the cluster set and cluster debug logs can be gathered for all members and the management cluster.
+9. Cluster set debug logs can be collected for review. Both the cluster set and cluster debug logs can be gathered for all members and the management cluster:
 
     ```PowerShell
     Get-ClusterSetLog -ClusterSetCimSession CSMASTER -IncludeClusterLog -IncludeManagementClusterLog -DestinationFolderPath <path>
     ```
 
-9. Configure Kerberos [constrained delegation](https://techcommunity.microsoft.com/t5/virtualization/live-migration-via-constrained-delegation-with-kerberos-in/ba-p/382334) between all cluster set members.
+10. Configure Kerberos [constrained delegation](https://techcommunity.microsoft.com/t5/virtualization/live-migration-via-constrained-delegation-with-kerberos-in/ba-p/382334) between all cluster set members.
 
-10. Configure the cross-cluster virtual machine live migration authentication type to Kerberos on each node in the Cluster Set.
+11. Configure the cross-cluster virtual machine live migration authentication type to Kerberos on each node in the Cluster Set.
 
     ```PowerShell
     foreach($h in $hosts){ Set-VMHost -VirtualMachineMigrationAuthenticationType Kerberos -ComputerName $h }
     ```
 
-11. Add the management cluster to the local administrators group on each node in the cluster set.
+12. Add the management cluster to the local administrators group on each node in the cluster set.
 
     ```PowerShell
     foreach($h in $hosts){ Invoke-Command -ComputerName $h -ScriptBlock {Net localgroup administrators /add <management_cluster_name>$} }
@@ -200,15 +201,15 @@ When creating a cluster set, you following prerequisites are recommended:
 
 ## Creating new virtual machines and adding to cluster sets
 
-After creating the cluster set, the next step is to create new virtual machines.  Normally, when it is time to create virtual machines and add them to a cluster, you need to do some checks on the clusters to see which it may be best to run on.  These checks could include:
+After creating the cluster set, the next step is to create new virtual machines. Normally, when it is time to create virtual machines and add them to a cluster, you need to do some checks on the clusters to see which it may be best to run on. These checks could include:
 
 - How much memory is available on the cluster nodes?
 - How much disk space is available on the cluster nodes?
 - Does the virtual machine require specific storage requirements (i.e. I want my SQL Server virtual machines to go to a cluster running faster drives; or, my infrastructure virtual machine is not as critical and can run on slower drives).
 
-Once this questions are answered, you create the virtual machine on the cluster you need it to be.  One of the benefits of cluster sets is that cluster sets do those checks for you and place the virtual machine on the most optimal node.
+Once this questions are answered, you create the virtual machine on the cluster you need it to be. One of the benefits of cluster sets is that cluster sets do those checks for you and place the virtual machine on the most optimal node.
 
-The below commands will both identify the optimal cluster and deploy the virtual machine to it.  In the below example, a new virtual machine is created specifying that at least 4 gigabytes of memory is available for the virtual machine and that it will need to utilize 1 virtual processor.
+The below commands will both identify the optimal cluster and deploy the virtual machine to it. In the below example, a new virtual machine is created specifying that at least 4 gigabytes of memory is available for the virtual machine and that it will need to utilize 1 virtual processor.
 
 - ensure that 4gb is available for the virtual machine
 - set the virtual processor used at 1
@@ -229,20 +230,20 @@ Start-VM CSVM1 -ComputerName $targetnode.name | Out-Null
 Get-VM CSVM1 -ComputerName $targetnode.name | fl State, ComputerName
 ```
 
-When it completes, you will be given the information about the virtual machine and where it was placed.  In the above example, it would show as:
+When it completes, you will be given the information about the virtual machine and where it was placed. In the above example, it would show as:
 
 ```
 State         : Running
 ComputerName  : 1-S2D2
 ```
 
-If you were to not have enough memory, cpu, or disk space to add the virtual machine, you will receive the error:
+If you were to have not enough memory, CPU capacity, or disk space to add the virtual machine, you will receive the following error:
 
 ```
-Get-ClusterSetOptimalNodeForVM : A cluster node is not available for this operation.  
+Get-ClusterSetOptimalNodeForVM : A cluster node is not available for this operation.
 ```
 
-Once the virtual machine has been created, it will be displayed in Hyper-V manager on the specific node specified.  To add it as a cluster set virtual machine and into the cluster, the command is below.  
+Once the virtual machine has been created, it will be displayed in Hyper-V manager on the specific node specified. To add it as a cluster set virtual machine, and add it to the cluster, use the command below:
 
 ```PowerShell
 Register-ClusterSetVM -CimSession CSMASTER -MemberName $targetnode.Member -VMName CSVM1
@@ -253,20 +254,20 @@ When it completes, the output will be:
 ```
 Id  VMName  State  MemberName  PSComputerName
 --  ------  -----  ----------  --------------
-1  CSVM1      On  CLUSTER1    CSMASTER
+ 1  CSVM1     On   CLUSTER1    CSMASTER
 ```
 
-If you have added a cluster with existing virtual machines, the virtual machines will also need to be registered with Cluster sets so register all the virtual machines at once, the command to use is:
+If you have added a cluster with existing virtual machines, the virtual machines will also need to be registered with Cluster sets. To register all those virtual machines at once, the command to use is:
 
 ```PowerShell
 Get-ClusterSetMember -Name CLUSTER3 -CimSession CSMASTER | Register-ClusterSetVM -RegisterAll -CimSession CSMASTER
 ```
 
-However, the process is not complete as the path to the virtual machine needs to be added to the cluster set namespace.
+However, the process is not yet complete, as the path to the virtual machine needs to be added to the cluster set namespace.
 
-So for example, an existing cluster is added and it has pre-configured virtual machines the reside on the local Cluster Shared Volume (CSV), the path for the VHDX would be something similar to "C:\ClusterStorage\Volume1\MYVM\Virtual Hard Disks\MYVM.vhdx.  A storage migration would need to be accomplished as CSV paths are by design local to a single member cluster. Thus, will not be accessible to the virtual machine once they are live migrated across member clusters. 
+For example: An existing cluster is added and it has pre-configured virtual machines which reside on the local Cluster Shared Volume (CSV). The path for the VHDX would be something similar to "C:\ClusterStorage\Volume1\MYVM\Virtual Hard Disks\MYVM.vhdx". A storage migration would need to be accomplished, as CSV paths are by design local to a single member cluster and will therefore not be accessible to the virtual machine once they are live migrated across member clusters.
 
-In this example, CLUSTER3 was added to the cluster set using Add-ClusterSetMember with the Infrastructure Scale-Out File Server as SOFS-CLUSTER3.  To move the virtual machine configuration and storage, the command is:
+In this example, CLUSTER3 was added to the cluster set using Add-ClusterSetMember with the Infrastructure Scale-Out File Server as SOFS-CLUSTER3. To move the virtual machine configuration and storage, the command is:
 
 ```PowerShell
 Move-VMStorage -DestinationStoragePath \\SOFS-CLUSTER3\Volume1 -Name MYVM
@@ -275,13 +276,13 @@ Move-VMStorage -DestinationStoragePath \\SOFS-CLUSTER3\Volume1 -Name MYVM
 Once it completes, you will receive a warning:
 
 ```
-WARNING: There were issues updating the virtual machine configuration that may prevent the virtual machine from running.  For more information view the report file below.
+WARNING: There were issues updating the virtual machine configuration that may prevent the virtual machine from running. For more information view the report file below.
 WARNING: Report file location: C:\Windows\Cluster\Reports\Update-ClusterVirtualMachineConfiguration '' on date at time.htm.
 ```
 
-This warning can be ignored as the warning is "No changes in the virtual machine role storage configuration were detected".  The reason for the warning as the actual physical location does not change; only the configuration paths. 
+This warning can be ignored as the warning is "No changes in the virtual machine role storage configuration were detected". The reason for the warning as the actual physical location does not change; only the configuration paths.
 
-For more information on Move-VMStorage, please review this [link](https://docs.microsoft.com/powershell/module/hyper-v/move-vmstorage?view=win10-ps). 
+For more information on Move-VMStorage, please review this [link](https://docs.microsoft.com/powershell/module/hyper-v/move-vmstorage?view=win10-ps).
 
 Live migrating a virtual machine between different cluster set clusters is not the same as in the past. In non-cluster set scenarios, the steps would be:
 
@@ -289,27 +290,27 @@ Live migrating a virtual machine between different cluster set clusters is not t
 2. live migrate the virtual machine to a member node of a different cluster.
 3. add the virtual machine into the cluster as a new virtual machine role.
 
-With Cluster sets these steps are not necessary and only one command is needed.  First, you should set all networks to be available for the migration with the command:
+With Cluster sets these steps are not necessary and only one command is needed. First, you should set all networks to be available for the migration with the command:
 
 ```PowerShell
 Set-VMHost -UseAnyNetworkForMigration $true
 ```
 
-For example, I want to move a Cluster Set virtual machine from CLUSTER1 to NODE2-CL3 on CLUSTER3.  The single command would be:
+For example, I want to move a Cluster Set virtual machine from CLUSTER1 to NODE2-CL3 on CLUSTER3. The single command would be:
 
 ```PowerShell
 Move-ClusterSetVM -CimSession CSMASTER -VMName CSVM1 -Node NODE2-CL3
 ```
 
-Please note that this does not move the virtual machine storage or configuration files.  This is not necessary as the path to the virtual machine remains as \\\\SOFS-CLUSTER1\VOLUME1.  Once a virtual machine has been registered with cluster sets has the Infrastructure File Server share path, the drives and virtual machine do not require being on the same machine as the virtual machine.
+Please note that this does not move the virtual machine storage or configuration files. This is not necessary as the path to the virtual machine remains as \\\\SOFS-CLUSTER1\VOLUME1. Once a virtual machine has been registered with cluster sets has the Infrastructure File Server share path, the drives and virtual machine do not require being on the same machine as the virtual machine.
 
 ## Creating Availability sets Fault Domains
 
-As described in the introduction, Azure-like fault domains and availability sets can be configured in a cluster set.  This is beneficial for initial virtual machine placements and migrations between clusters.  
+As described in the introduction, Azure-like fault domains and availability sets can be configured in a cluster set. This is beneficial for initial virtual machine placements and migrations between clusters.
 
-In the example below, there are four clusters participating in the cluster set.  Within the set, a logical fault domain will be created with two of the clusters and a fault domain created with the other two clusters.  These two fault domains will comprise the Availabiilty Set. 
+In the example below, there are four clusters participating in the cluster set. Within the set, a logical fault domain will be created with two of the clusters and a fault domain created with the other two clusters. These two fault domains will comprise the Availabiilty Set.
 
-In the example below, CLUSTER1 and CLUSTER2 will be in a fault domain called **FD1** while CLUSTER3 and CLUSTER4 will be in a fault domain called **FD2**.  The availability set will be called **CSMASTER-AS** and be comprised of the two fault domains.
+In the example below, CLUSTER1 and CLUSTER2 will be in a fault domain called **FD1** while CLUSTER3 and CLUSTER4 will be in a fault domain called **FD2**. The availability set will be called **CSMASTER-AS** and be comprised of the two fault domains.
 
 To create the fault domains, the commands are:
 
@@ -345,7 +346,7 @@ To validate it has been created, then use:
 Get-ClusterSetAvailabilitySet -AvailabilitySetName CSMASTER-AS -CimSession CSMASTER
 ```
 
-When creating new virtual machines, you would then need to use the -AvailabilitySet parameter as part of determining the optimal node.  So it would then look something like this:
+When creating new virtual machines, you would then need to use the -AvailabilitySet parameter as part of determining the optimal node. So it would then look something like this:
 
 ```PowerShell
 # Identify the optimal node to create a new virtual machine
@@ -359,7 +360,7 @@ $cred = new-object -typename System.Management.Automation.PSCredential ("<domain
 
 Removing a cluster from cluster sets due to various life cycles. There are times when a cluster needs to be removed from a cluster set. As a best practice, all cluster set virtual machines should be moved out of the cluster. This can be accomplished using the **Move-ClusterSetVM** and **Move-VMStorage** commands.
 
-However, if the virtual machines will not be moved as well, cluster sets runs a series of actions to provide an intuitive outcome to the administrator.  When the cluster is removed from the set, all remaining cluster set virtual machines hosted on the cluster being removed will simply become highly available virtual machines bound to that cluster, assuming they have access to their storage.  Cluster sets will also automatically update its inventory by:
+However, if the virtual machines will not be moved as well, cluster sets runs a series of actions to provide an intuitive outcome to the administrator. When the cluster is removed from the set, all remaining cluster set virtual machines hosted on the cluster being removed will simply become highly available virtual machines bound to that cluster, assuming they have access to their storage. Cluster sets will also automatically update its inventory by:
 
 - No longer tracking the health of the now-removed cluster and the virtual machines running on it
 - Removes from cluster set namespace and all references to shares hosted on the now-removed cluster
@@ -373,7 +374,7 @@ Remove-ClusterSetMember -ClusterName CLUSTER1 -CimSession CSMASTER
 ## Frequently asked questions (FAQ)
 
 **Question:** In my cluster set, am I limited to only using hyper-converged clusters? <br>
-**Answer:** No.  You can mix Storage Spaces Direct with traditional clusters.
+**Answer:** No. You can mix Storage Spaces Direct with traditional clusters.
 
 **Question:** Can I manage my Cluster Set via System Center Virtual Machine Manager? <br>
 **Answer:** System Center Virtual Machine Manager does not currently support Cluster sets <br><br> **Question:** Can Windows Server 2012 R2 or 2016 clusters co-exist in the same cluster set? <br>
@@ -387,10 +388,10 @@ Remove-ClusterSetMember -ClusterName CLUSTER1 -CimSession CSMASTER
 **Answer:** PowerShell or WMI in this release.
 
 **Question:** How will the cross-cluster live migration work with processors of different generations?  <br>
-**Answer:** Cluster sets does not work around processor differences and supersede what Hyper-V currently supports.  Therefore, processor compatibility mode must be used with quick migrations.  The recommendation for Cluster sets is to use the same processor hardware within each individual Cluster as well as the entire Cluster Set for live migrations between clusters to occur.
+**Answer:** Cluster sets does not work around processor differences and supersede what Hyper-V currently supports. Therefore, processor compatibility mode must be used with quick migrations. The recommendation for Cluster sets is to use the same processor hardware within each individual Cluster as well as the entire Cluster Set for live migrations between clusters to occur.
 
 **Question:** Can my cluster set virtual machines automatically failover on a cluster failure?  <br>
-**Answer:** In this release, cluster set virtual machines can only be manually live-migrated across clusters; but cannot automatically failover. 
+**Answer:** In this release, cluster set virtual machines can only be manually live-migrated across clusters; but cannot automatically failover.
 
 **Question:** How do we ensure storage is resilient to cluster failures? <br>
 **Answer:** Use cross-cluster Storage Replica (SR) solution across member clusters to realize the storage resiliency to cluster failures.
@@ -399,9 +400,9 @@ Remove-ClusterSetMember -ClusterName CLUSTER1 -CimSession CSMASTER
 **Answer:** In this release, such a cluster set namespace referral change does not occur with SR failover. Please let Microsoft know if this scenario is critical to you and how you plan to use it.
 
 **Question:** Is it possible to failover virtual machines across fault domains in a disaster recovery situation (say the entire fault domain went down)? <br>
-**Answer:** No, note that cross-cluster failover within a logical fault domain is not yet supported. 
+**Answer:** No, note that cross-cluster failover within a logical fault domain is not yet supported.
 
-**Question:** Can my cluster set span clusters in multiple sites (or DNS domains)? <br> 
+**Question:** Can my cluster set span clusters in multiple sites (or DNS domains)? <br>
 **Answer:** This is an untested scenario and not immediately planned for production support. Please let Microsoft know if this scenario is critical to you and how you plan to use it.
 
 **Question:** Does cluster set work with IPv6? <br>
@@ -418,9 +419,9 @@ Remove-ClusterSetMember -ClusterName CLUSTER1 -CimSession CSMASTER
 
 **Question:** Is the cluster set namespace highly available? <br>
 **Answer:** Yes, the cluster set namespace is provided via a Continuously Available (CA) referral SOFS namespace server running on the management cluster. Microsoft recommends having enough number of virtual machines from member clusters to make it resilient to localized cluster-wide failures. However, to account for unforeseen catastrophic failures – e.g. all virtual machines in the management cluster going down at the same time – the referral information is additionally persistently cached in each cluster set node, even across reboots.
- 
+
 **Question:** Does the cluster set namespace-based storage access slow down storage performance in a cluster set? <br>
-**Answer:** No. Cluster set namespace offers an overlay referral namespace within a cluster set – conceptually like Distributed File System Namespaces (DFSN). And unlike DFSN, all cluster set namespace referral metadata is auto-populated and auto-updated on all nodes without any administrator intervention, so there is almost no performance overhead in the storage access path. 
+**Answer:** No. Cluster set namespace offers an overlay referral namespace within a cluster set – conceptually like Distributed File System Namespaces (DFSN). And unlike DFSN, all cluster set namespace referral metadata is auto-populated and auto-updated on all nodes without any administrator intervention, so there is almost no performance overhead in the storage access path.
 
 **Question:** How can I backup cluster set metadata? <br>
-**Answer:** This guidance is the same as that of Failover Cluster. The System State Backup will backup the cluster state as well.  Through Windows Server Backup, you can do restores of just a node's cluster database (which should never be needed because of a bunch of self-healing logic we have) or do an authoritative restore to roll back the entire cluster database across all nodes. In the case of cluster sets, Microsoft recommends doing such an authoritative restore first on the member cluster and then the management cluster if needed.
+**Answer:** This guidance is the same as that of Failover Cluster. The System State Backup will backup the cluster state as well. Through Windows Server Backup, you can do restores of just a node's cluster database (which should never be needed because of a bunch of self-healing logic we have) or do an authoritative restore to roll back the entire cluster database across all nodes. In the case of cluster sets, Microsoft recommends doing such an authoritative restore first on the member cluster and then the management cluster if needed.


### PR DESCRIPTION
**Description:**

As documented in issue ticket #4255 (Grammar issues), there are a few sentences in need of grammar improvement. 
There is also some whitespace redundancy in this document page, needing some adjustments.

**Changes proposed:**
- Typo "homogenous" -> homogeneous
- Numbering update, correcting the 12 steps in the "Steps" section
- "Once all cluster have been" -> Once all the clusters have been
- "To add a Cluster Server to the cluster set, the below would be used." -> Use the command set below to add a Cluster Server to the cluster set:
- "To verify the cluster set creation process created one SMB share" -> To verify that the cluster set creation process created one SMB share
- "Cluster sets has debug logs that can be collected for review." -> Cluster set debug logs can be collected for review.
- "If you were to not have enough memory, cpu, or disk space [ ... ]" -> If you were to have not enough memory, CPU capacity, or disk space
- "the process is not complete" -> the process is not yet complete,

(omitting a couple of grammar corrections, due to quite long sentences)

- Whitespace corrections:
    - Remove all end-of-line blank space (Trim Trailing Space)
    - Reduce blank space between sentences, down from 2 to 1
    - Add 1 blank line between the metadata section and the page title
    - Reduce the width of the table column "Cluster Name" by 14 redundant blank spaces, all rows

**Ticket closure and/or reference:**

Closes #4255
Ref. #4132