### PR TITLE
Update manage-hyper-v-scheduler-types.md

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/manage/manage-hyper-v-scheduler-types.md
+++ b/WindowsServerDocs/virtualization/hyper-v/manage/manage-hyper-v-scheduler-types.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding and using Hyper-V hypervisor scheduler types
+title: Understanding and using Hyper-V Hypervisor Scheduler Types
 description: Provides information for Hyper-V host administrators on the use of Hyper-V's scheduler modes
 author: allenma
 ms.author: allenma
@@ -11,9 +11,9 @@ ms.localizationpriority: low
 ms.assetid: 6cb13f84-cb50-4e60-a685-54f67c9146be
 ---
 
-# Managing Hyper-V hypervisor scheduler types
+# Managing Hyper-V Hypervisor Scheduler Types
 
->Applies To: Windows 10, Windows Server 2016, Windows Server, version 1709, Windows Server, version 1803,Windows Server 2019
+>Applies To: Windows 10, Windows Server 2016, Windows Server, version 1709, Windows Server, version 1803, Windows Server 2019
 
 This article describes new modes of virtual processor scheduling logic first introduced in Windows Server 2016. These modes, or scheduler types, determine how the Hyper-V hypervisor allocates and manages work across guest virtual processors. A Hyper-V host administrator can select hypervisor scheduler types that are best suited for the guest virtual machines (VMs) and configure the VMs to take advantage of the scheduling logic.
 
@@ -43,7 +43,7 @@ Before considering hypervisor scheduler types, it's also helpful to understand t
 
 * The root partition is itself a virtual machine partition, although it has unique properties and much greater privileges than guest virtual machines. The root partition provides the management services that control all guest virtual machines, provides virtual device support for guests, and manages all device I/O for guest virtual machines. Microsoft strongly recommends not running any application workloads in the root partition.
 
-* Each virtual processor (VP) of the root partition is mapped 1:1 to an underlying logical processor (LP). A host VP will always run on the same underlying LP – there is no migration of the root partition's VPs.
+* Each virtual processor (VP) of the root partition is mapped 1:1 to an underlying logical processor (LP). A host VP always runs on the same underlying LP – there is no migration of the root partition's VPs.
 
 * By default, the LPs on which host VPs run can also run guest VPs.
 
@@ -68,7 +68,7 @@ The classic scheduler type is the most appropriate for the vast majority of trad
 The hypervisor core scheduler is a new alternative to the classic scheduler logic, introduced in Windows Server 2016 and Windows 10 version 1607. The core scheduler offers a strong security boundary for guest workload isolation, and reduced performance variability for workloads inside of VMs that are running on an SMT-enabled virtualization host. The core scheduler allows running both SMT and non-SMT virtual machines simultaneously on the same SMT-enabled virtualization host.
 
 The core scheduler utilizes the virtualization host's SMT topology, and optionally exposes SMT pairs to guest virtual machines, and schedules groups of guest virtual processors from the same virtual machine onto groups of SMT logical processors. This is done symmetrically so that if LPs are in groups of two, VPs are scheduled in groups of two, and a core is never shared between VMs.
-When the VP is scheduled for a virtual machine without SMT enabled, that VP will consume the entire core when it runs.
+When the VP is scheduled for a virtual machine without SMT enabled, that VP consumes the entire core when it runs.
 
 The overall result of the core scheduler is that:
 
@@ -82,11 +82,11 @@ The overall result of the core scheduler is that:
 
 * A strong security boundary for guest workload isolation - Guest VPs are constrained to run on underlying physical core pairs, reducing vulnerability to side-channel snooping attacks.
 
-The core scheduler will be used by default starting in Windows Server 2019. On Windows Server 2016, the core scheduler is optional and must be explicitly enabled by the Hyper-V host administrator, and the classic scheduler is the default.
+The core scheduler is used by default starting in Windows Server 2019. On Windows Server 2016, the core scheduler is optional and must be explicitly enabled by the Hyper-V host administrator, and the classic scheduler is the default.
 
 #### Core scheduler behavior with host SMT disabled
 
-If the hypervisor is configured to use the core scheduler type but the SMT capability is disabled or not present on the virtualization host, then the hypervisor will use the classic scheduler behavior, regardless of the hypervisor scheduler type setting.
+If the hypervisor is configured to use the core scheduler type but the SMT capability is disabled or not present on the virtualization host, then the hypervisor uses the classic scheduler behavior, regardless of the hypervisor scheduler type setting.
 
 ### The root scheduler
 
@@ -108,7 +108,7 @@ The root scheduler is not recommended for use with Hyper-V on servers at this ti
 
 ## Enabling SMT in guest virtual machines
 
-Once the virtualization host's hypervisor is configured to use the core scheduler type, guest virtual machines may be configured to utilize SMT if desired. Exposing the fact that VPs are hyperthreaded to a guest virtual machine allows the scheduler in the guest operating system and workloads running in the VM to detect and utilize the SMT topology in their own work scheduling. On Windows Server 2016, guest SMT is not configured by default and must be explicitly enabled by the Hyper-V host administrator. Starting with Windows Server 2019, new VMs created on the host will inherit the host's SMT topology by default.  That is, a version 9.0 VM created on a host with 2 SMT threads per core would also see 2 SMT threads per core.
+Once the virtualization host's hypervisor is configured to use the core scheduler type, guest virtual machines may be configured to utilize SMT if desired. Exposing the fact that VPs are hyperthreaded to a guest virtual machine allows the scheduler in the guest operating system and workloads running in the VM to detect and utilize the SMT topology in their own work scheduling. On Windows Server 2016, guest SMT is not configured by default and must be explicitly enabled by the Hyper-V host administrator. Starting with Windows Server 2019, new VMs created on the host inherits the host's SMT topology by default.  That is, a version 9.0 VM created on a host with 2 SMT threads per core would also see 2 SMT threads per core.
 
 PowerShell must be used to enable SMT in a guest virtual machine; there is no user interface provided in Hyper-V Manager.
 To enable SMT in a guest virtual machine, open a PowerShell window with sufficient permissions, and type:
@@ -117,8 +117,8 @@ To enable SMT in a guest virtual machine, open a PowerShell window with sufficie
 Set-VMProcessor -VMName <VMName> -HwThreadCountPerCore <n>
 ```
 
-Where <n> is the number of SMT threads per core the guest VM will see.  
-Note that <n> = 0 will set the HwThreadCountPerCore value to match the host's SMT thread count per core value.
+Where <n> is the number of SMT threads per core the guest VM sees.  
+Note that <n> = 0 sets the HwThreadCountPerCore value to match the host's SMT thread count per core value.
 
 >[!NOTE] 
 >Setting HwThreadCountPerCore = 0 is supported beginning with Windows Server 2019.
@@ -136,7 +136,7 @@ Windows Server 2016 Hyper-V uses the classic hypervisor scheduler model by defau
 
 ## Windows Server 2019 Hyper-V defaults to using the core scheduler
 
-To help ensure Hyper-V hosts are deployed in the optimal security configuration, Windows Server 2019 Hyper-V will now use the core hypervisor scheduler model by default. The host administrator may optionally configure the host to use the legacy classic scheduler. Administrators should carefully read, understand and consider the impacts each scheduler type has on the security and performance of virtualization hosts prior to overriding the scheduler type default settings.  See [Understanding Hyper-V scheduler type selection](https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/understanding-hyper-v-scheduler-type-selection) for more information.
+To help ensure Hyper-V hosts are deployed in the optimal security configuration, Windows Server 2019 Hyper-V now uses the core hypervisor scheduler model by default. The host administrator may optionally configure the host to use the legacy classic scheduler. Administrators should carefully read, understand and consider the impacts each scheduler type has on the security and performance of virtualization hosts prior to overriding the scheduler type default settings.  See [Understanding Hyper-V scheduler type selection](https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/understanding-hyper-v-scheduler-type-selection) for more information.
 
 ### Required updates
 

--- a/WindowsServerDocs/virtualization/hyper-v/manage/manage-hyper-v-scheduler-types.md
+++ b/WindowsServerDocs/virtualization/hyper-v/manage/manage-hyper-v-scheduler-types.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding and using Hyper-V Hypervisor Scheduler Types
+title: Understanding and using Hyper-V hypervisor scheduler types
 description: Provides information for Hyper-V host administrators on the use of Hyper-V's scheduler modes
 author: allenma
 ms.author: allenma


### PR DESCRIPTION
Two changes:
1. Capitalised the title properly.
2 Removed future tense in this article to aid in readability.