### PR TITLE
Improve sc.exe documentations

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/sc-config.md
+++ b/WindowsServerDocs/administration/windows-commands/sc-config.md
@@ -1,5 +1,5 @@
 ---
-title: Sc config
+title: Sc.exe config
 description: Reference topic for **** - 
 
 ms.prod: windows-server
@@ -15,7 +15,7 @@ manager: dongill
 ms.date: 06/05/2018
 ---
 
-# Sc config
+# Sc.exe config
 
 
 
@@ -26,7 +26,7 @@ Modifies the value of a service's entries in the registry and in the Service Con
 ## Syntax
 
 ```
-sc [<ServerName>] config [<ServiceName>] [type= {own | share | kernel | filesys | rec | adapt | interact type= {own | share}}] [start= {boot | system | auto | demand | disabled | delayed-auto}] [error= {normal | severe | critical | ignore}] [binpath= <BinaryPathName>] [group= <LoadOrderGroup>] [tag= {yes | no}] [depend= <dependencies>] [obj= {<AccountName> | <ObjectName>}] [displayname= <DisplayName>] [password= <Password>]
+sc.exe [<ServerName>] config [<ServiceName>] [type= {own | share | kernel | filesys | rec | adapt | interact type= {own | share}}] [start= {boot | system | auto | demand | disabled | delayed-auto}] [error= {normal | severe | critical | ignore}] [binpath= <BinaryPathName>] [group= <LoadOrderGroup>] [tag= {yes | no}] [depend= <dependencies>] [obj= {<AccountName> | <ObjectName>}] [displayname= <DisplayName>] [password= <Password>]
 ```
 
 ### Parameters
@@ -56,7 +56,7 @@ sc [<ServerName>] config [<ServiceName>] [type= {own | share | kernel | filesys 
 
 To specify a binary path for the NEWSERVICE service, type:
 ```
-sc config NewService binpath= ntsd -d c:\windows\system32\NewServ.exe
+sc.exe config NewService binpath= ntsd -d c:\windows\system32\NewServ.exe
 ```
 
 ## Additional References

--- a/WindowsServerDocs/administration/windows-commands/sc-config.md
+++ b/WindowsServerDocs/administration/windows-commands/sc-config.md
@@ -1,12 +1,8 @@
 ---
 title: Sc.exe config
-description: Reference topic for **** - 
-
+description: Learn how to change service configurations using the sc.exe utility 
 ms.prod: windows-server
-
-
 ms.technology: manage-windows-commands
-
 ms.topic: article
 ms.assetid: ad4d68a6-efe5-452b-8501-7f1f1c552a4a
 author: coreyp-at-msft
@@ -17,11 +13,7 @@ ms.date: 06/05/2018
 
 # Sc.exe config
 
-
-
 Modifies the value of a service's entries in the registry and in the Service Control Manager database.
-
-
 
 ## Syntax
 

--- a/WindowsServerDocs/administration/windows-commands/sc-create.md
+++ b/WindowsServerDocs/administration/windows-commands/sc-create.md
@@ -1,5 +1,5 @@
 ---
-title: Sc create
+title: Sc.exe create
 description: Reference topic for **** - 
 
 ms.prod: windows-server
@@ -15,18 +15,14 @@ manager: dongill
 ms.date: 10/16/2017
 ---
 
-# Sc create
-
-
+# Sc.exe create
 
 Creates a subkey and entries for a service in the registry and in the Service Control Manager database.
-
-
 
 ## Syntax
 
 ```
-sc [<ServerName>] create [<ServiceName>] [type= {own | share | kernel | filesys | rec | interact type= {own | share}}] [start= {boot | system | auto | demand | disabled | delayed-auto }] [error= {normal | severe | critical | ignore}] [binpath= <BinaryPathName>] [group= <LoadOrderGroup>] [tag= {yes | no}] [depend= <dependencies>] [obj= {<AccountName> | <ObjectName>}] [displayname= <DisplayName>] [password= <Password>]
+sc.exe [<ServerName>] create [<ServiceName>] [type= {own | share | kernel | filesys | rec | interact type= {own | share}}] [start= {boot | system | auto | demand | disabled | delayed-auto }] [error= {normal | severe | critical | ignore}] [binpath= <BinaryPathName>] [group= <LoadOrderGroup>] [tag= {yes | no}] [depend= <dependencies>] [obj= {<AccountName> | <ObjectName>}] [displayname= <DisplayName>] [password= <Password>]
 ```
 
 ### Parameters
@@ -54,10 +50,10 @@ sc [<ServerName>] create [<ServiceName>] [type= {own | share | kernel | filesys 
 
 ## Examples
 
-The following examples show how you can use the **sc create** command:
+The following examples show how you can use the **sc.exe create** command:
 ```
-sc \\myserver create NewService binpath= c:\windows\system32\NewServ.exe
-sc create NewService binpath= c:\windows\system32\NewServ.exe type= share start= auto depend= +TDI NetBIOS
+sc.exe \\myserver create NewService binpath= c:\windows\system32\NewServ.exe
+sc.exe create NewService binpath= c:\windows\system32\NewServ.exe type= share start= auto depend= +TDI NetBIOS
 ```
 
 ## Additional References

--- a/WindowsServerDocs/administration/windows-commands/sc-create.md
+++ b/WindowsServerDocs/administration/windows-commands/sc-create.md
@@ -1,12 +1,8 @@
 ---
 title: Sc.exe create
-description: Reference topic for **** - 
-
+description: Learn how register new services with Windows Service Manager using the sc.exe utility
 ms.prod: windows-server
-
-
 ms.technology: manage-windows-commands
-
 ms.topic: article
 ms.assetid: 59416460-0661-4fef-85cc-73e9d8f4beb4
 author: coreyp-at-msft

--- a/WindowsServerDocs/administration/windows-commands/sc-delete.md
+++ b/WindowsServerDocs/administration/windows-commands/sc-delete.md
@@ -1,12 +1,8 @@
 ---
 title: Sc.exe delete
-description: Reference topic for **** - 
-
+description: Learn how unregister services using the sc.exe utility
 ms.prod: windows-server
-
-
 ms.technology: manage-windows-commands
-
 ms.topic: article
 ms.assetid: 2fe94fb3-e4d1-47b5-b999-39995ecbb644
 author: coreyp-at-msft
@@ -16,8 +12,6 @@ ms.date: 10/16/2017
 ---
 
 # Sc.exe delete
-
-
 
 Deletes a service subkey from the registry. If the service is running or if another process has an open handle to the service, the service is marked for deletion.
 
@@ -39,7 +33,7 @@ sc.exe [<ServerName>] delete [<ServiceName>]
 
 ## Remarks
 
-Use **Add or Remove Programs** on **Control Panel** to delete DHCP, DNS, or any other built-in operating system services. Note that **Add or Remove Programs** will not only remove the registry subkey for the service, but it will also uninstall the service and delete any shortcuts to it.
+It is not recommended to use sc.exe to delete built-in operating system services such as DHCP, DNS, or Internet Information Services. To install, remove, or reconfigure operating system roles, services and components, see [Install or Uninstall Roles, Role Services, or Features](/WindowsServerDocs/administration/server-manager/install-or-uninstall-roles-role-services-or-features.md)
 
 ## Examples
 

--- a/WindowsServerDocs/administration/windows-commands/sc-delete.md
+++ b/WindowsServerDocs/administration/windows-commands/sc-delete.md
@@ -1,5 +1,5 @@
 ---
-title: Sc delete
+title: Sc.exe delete
 description: Reference topic for **** - 
 
 ms.prod: windows-server
@@ -15,7 +15,7 @@ manager: dongill
 ms.date: 10/16/2017
 ---
 
-# Sc delete
+# Sc.exe delete
 
 
 
@@ -26,7 +26,7 @@ For examples of how to use this command, see [Examples](#examples).
 ## Syntax
 
 ```
-sc [<ServerName>] delete [<ServiceName>]
+sc.exe [<ServerName>] delete [<ServiceName>]
 ```
 
 ### Parameters
@@ -45,7 +45,7 @@ Use **Add or Remove Programs** on **Control Panel** to delete DHCP, DNS, or any 
 
 To delete the service subkey **NewServ** from the registry on the local computer, type:
 ```
-sc delete newserv
+sc.exe delete newserv
 ```
 
 ## Additional References

--- a/WindowsServerDocs/administration/windows-commands/sc-query.md
+++ b/WindowsServerDocs/administration/windows-commands/sc-query.md
@@ -1,6 +1,6 @@
 ---
 title: Sc.exe query
-description: Reference topic for **** - 
+description: Learn how to obtain information about services, drivers, type of services, or type of drivers using the sc.exe utility
 ms.prod: windows-server
 ms.technology: manage-windows-commands
 ms.topic: article
@@ -14,8 +14,6 @@ ms.date: 10/16/2017
 # Sc.exe query
 
 Obtains and displays information about the specified service, driver, type of service, or type of driver.
-
-
 
 ## Syntax
 

--- a/WindowsServerDocs/administration/windows-commands/sc-query.md
+++ b/WindowsServerDocs/administration/windows-commands/sc-query.md
@@ -1,12 +1,8 @@
 ---
-title: Sc query
+title: Sc.exe query
 description: Reference topic for **** - 
-
 ms.prod: windows-server
-
-
 ms.technology: manage-windows-commands
-
 ms.topic: article
 ms.assetid: ac365f89-4b20-4de6-a582-b204c5e7d0eb
 author: coreyp-at-msft
@@ -15,9 +11,7 @@ manager: dongill
 ms.date: 10/16/2017
 ---
 
-# Sc query
-
-
+# Sc.exe query
 
 Obtains and displays information about the specified service, driver, type of service, or type of driver.
 
@@ -26,7 +20,7 @@ Obtains and displays information about the specified service, driver, type of se
 ## Syntax
 
 ```
-sc [<ServerName>] query [<ServiceName>] [type= {driver | service | all}] [type= {own | share | interact | kernel | filesys | rec | adapt}] [state= {active | inactive | all}] [bufsize= <BufferSize>] [ri= <ResumeIndex>] [group= <GroupName>]
+sc.exe [<ServerName>] query [<ServiceName>] [type= {driver | service | all}] [type= {own | share | interact | kernel | filesys | rec | adapt}] [state= {active | inactive | all}] [bufsize= <BufferSize>] [ri= <ResumeIndex>] [group= <GroupName>]
 ```
 
 ### Parameters
@@ -54,43 +48,43 @@ sc [<ServerName>] query [<ServiceName>] [type= {driver | service | all}] [type= 
   ```  
   To display the remaining **query** information, rerun **query**, setting **bufsize=** to be the number of bytes and setting **ri=** to the specified index. For example, the remaining output would be displayed by typing the following at the command prompt:  
   ```
-  sc query bufsize= 1822 ri= 79
+  sc.exe query bufsize= 1822 ri= 79
   ```
 
 ## Examples
 
 To display information for active services only, type either of the following commands:
 ```
-sc query
-sc query type= service
+sc.exe query
+sc.exe query type= service
 ```
 To display information for active services, and to specify a buffer size of 2,000 bytes, type:
 ```
-sc query type= all bufsize= 2000
+sc.exe query type= all bufsize= 2000
 ```
 To display information for the WUAUSERV service, type:
 ```
-sc query wuauserv
+sc.exe query wuauserv
 ```
 To display information for all services (active and inactive), type:
 ```
-sc query state= all
+sc.exe query state= all
 ```
 To display information for all services (active and inactive), beginning at line 56, type:
 ```
-sc query state= all ri= 56
+sc.exe query state= all ri= 56
 ```
 To display information for interactive services, type:
 ```
-sc query type= service type= interact
+sc.exe query type= service type= interact
 ```
 To display information for drivers only, type:
 ```
-sc query type= driver
+sc.exe query type= driver
 ```
 To display information for drivers in the Network Driver Interface Specification (NDIS) group, type:
 ```
-sc query type= driver group= ndis
+sc.exe query type= driver group= ndis
 ```
 
 ## Additional References


### PR DESCRIPTION
This pull request changes four pages:

- sc-config.md
- sc-create.md
- sc-delete.md
- sc-query.md

Changes include:

- Change all invocations containing `sc` to `sc.exe` because, in PowerShell, the former is an alias for `Set-Content`. This change has been discussed in #3952. This PR is the result of that discussion.
- Fill in the missing "Description" field with meaningful sentences. Instead of "Reference topic for \*\*\*\* - " it now says, e.g. "Learn how to change service configurations using the sc.exe utility."
- Change an incorrect remark about using the "Add or Remove Programs" module of Control Panel. Since Windows Server 2003 (released 17 years ago), this module is no longer in charge of configuring server roles. This change applies to `sc-delete.md` only.
