### PR TITLE
Security/TLS: Link updates, whitespace & typo fix

### DIFF
--- a/WindowsServerDocs/security/tls/manage-tls.md
+++ b/WindowsServerDocs/security/tls/manage-tls.md
@@ -12,25 +12,25 @@ ms.date: 05/16/2018
 
 # Manage Transport Layer Security (TLS)
 
->Applies to: Windows Server (Semi-Annual Channel), Windows Server 2016, Windows 10
+> Applies to: Windows Server (Semi-Annual Channel), Windows Server 2016, Windows 10
 
 ## Configuring TLS Cipher Suite Order
 
-Different Windows versions support different TLS cipher suites and priority order. See [Cipher Suites in TLS/SSL (Schannel SSP)](https://msdn.microsoft.com/library/windows/desktop/aa374757.aspx) for the default order supported by the Microsoft Schannel Provider in different Windows versions.
+Different Windows versions support different TLS cipher suites and priority order. See [Cipher Suites in TLS/SSL (Schannel SSP)](https://docs.microsoft.com/windows/win32/secauthn/cipher-suites-in-schannel) for the default order supported by the Microsoft Schannel Provider in different Windows versions.
 
-> [!NOTE] 
-> You can also modify the list of cipher suites by using CNG functions, see [Prioritizing Schannel Cipher Suites](https://msdn.microsoft.com/library/windows/desktop/bb870930.aspx) for details.
+> [!NOTE]
+> You can also modify the list of cipher suites by using CNG functions, see [Prioritizing Schannel Cipher Suites](https://docs.microsoft.com/windows/win32/secauthn/prioritizing-schannel-cipher-suites) for details.
 
 Changes to the TLS cipher suite order will take effect on the next boot. Until restart or shutdown, the existing order will be in effect.
 
-> [!WARNING] 
-> Updating the registry settings for the default priority ordering is not supported and may be reset with servicing updates. 
+> [!WARNING]
+> Updating the registry settings for the default priority ordering is not supported and may be reset with servicing updates.
 
 ### Configuring TLS Cipher Suite Order by using Group Policy
 
 You can use the SSL Cipher Suite Order Group Policy settings to configure the default TLS cipher suite order.
 
-1. From the Group Policy Management Console, go to **Computer Configuration** > **Administrative Templates** > **Networks** > **SSL Configuration Settings**.
+1. From the Group Policy Management Console, go to **Computer Configuration** > **Administrative Templates** > **Network** > **SSL Configuration Settings**.
 2. Double-click **SSL Cipher Suite Order**, and then click the **Enabled** option.
 3. Right-click **SSL Cipher Suites** box and select **Select all** from the pop-up menu.
 
@@ -40,8 +40,8 @@ You can use the SSL Cipher Suite Order Group Policy settings to configure the de
 5. Paste the text into a text editor such as notepad.exe and update with the new cipher suite order list.
 
    > [!NOTE]
-   > The TLS cipher suite order list must be in strict comma delimited format. Each cipher suite string will end with a comma (,) to the right side of it. 
-   > 
+   > The TLS cipher suite order list must be in strict comma delimited format. Each cipher suite string will end with a comma (,) to the right side of it.
+   >
    > Additionally, the list of cipher suites is limited to 1,023 characters.
 
 6. Replace the list in the **SSL Cipher Suites** with the updated ordered list.
@@ -49,13 +49,13 @@ You can use the SSL Cipher Suite Order Group Policy settings to configure the de
 
 ### Configuring TLS Cipher Suite Order by using MDM
 
-The Windows 10 Policy CSP supports configuration of the TLS Cipher Suites. See [Cryptography/TLSCipherSuites](https://msdn.microsoft.com/windows/hardware/commercialize/customize/mdm/policy-configuration-service-provider#cryptography-tlsciphersuites) for more information.
+The Windows 10 Policy CSP supports configuration of the TLS Cipher Suites. See [Cryptography/TLSCipherSuites](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-cryptography#cryptography-tlsciphersuites) for more information.
 
 ### Configuring TLS Cipher Suite Order by using TLS PowerShell Cmdlets
 
-The TLS PowerShell module supports getting the ordered list of TLS cipher suites, disabling a cipher suite, and enabling a cipher suite. See [TLS Module](https://technet.microsoft.com/itpro/powershell/windows/tls/tls) for more information.
+The TLS PowerShell module supports getting the ordered list of TLS cipher suites, disabling a cipher suite, and enabling a cipher suite. See [TLS Module](https://docs.microsoft.com/powershell/module/tls/?view=win10-ps) for more information.
 
-## Configuring TLS ECC Curve Order 
+## Configuring TLS ECC Curve Order
 
 Beginning with Windows 10 & Windows Server 2016, ECC curve order can be configured independent of the cipher suite order. If the TLS cipher suite order list has elliptic curve suffixes, they will be overridden by the new elliptic curve priority order, when enabled. This allow organizations to use a Group Policy object to configure different versions of Windows with the same cipher suites order.
 
@@ -64,9 +64,9 @@ Beginning with Windows 10 & Windows Server 2016, ECC curve order can be configur
 
 ### Managing Windows ECC curves using CertUtil
 
-Beginning with Windows 10 and Windows Server 2016, Windows provides elliptic curve parameter management through the command line utility certutil.exe. 
-Elliptic curve parameters are stored in the bcryptprimitives.dll. Using certutil.exe, administrators can add and remove curve parameters to and from Windows, respectively. Certutil.exe stores the curve parameters securely in the registry. 
-Windows can begin using the curve parameters by the name associated with the curve.    
+Beginning with Windows 10 and Windows Server 2016, Windows provides elliptic curve parameter management through the command line utility certutil.exe.
+Elliptic curve parameters are stored in the bcryptprimitives.dll. Using certutil.exe, administrators can add and remove curve parameters to and from Windows, respectively. Certutil.exe stores the curve parameters securely in the registry.
+Windows can begin using the curve parameters by the name associated with the curve.
 
 #### Displaying Registered Curves
 
@@ -82,8 +82,8 @@ certutil.exe –displayEccCurve
 
 #### Adding a New Curve
 
-Organizations can create and use curve parameters researched by other trusted entities.  
-Administrators wanting to use these new curves in Windows must add the curve.  
+Organizations can create and use curve parameters researched by other trusted entities.
+Administrators wanting to use these new curves in Windows must add the curve.
 Use the following certutil.exe command to add a curve to current computer:
 
 ```powershell
@@ -93,7 +93,7 @@ Certutil —addEccCurue curveName curveParameters [curveOID] [curveType]
 - The **curveName** argument represents the name of the curve under which the curve parameters were added.
 - The **curveParameters** argument represents the filename of a certificate that contains the parameters of the curves you want to add.
 - The **curveOid** argument represents a filename of a certificate that contains the OID of the curve parameters you want to add (optional).
-- The **curveType** argument represents a decimal value of the named curve from the [EC Named Curve Registry](http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8) (optional).
+- The **curveType** argument represents a decimal value of the named curve from the [EC Named Curve Registry](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8) (optional).
 
 ![Certutil add curves](../media/Transport-Layer-Security-protocol/certutil-add-curves.png)
 
@@ -111,14 +111,14 @@ Windows cannot use a named curve after an administrator removes the curve from c
 
 ## Managing Windows ECC curves using Group Policy
 
-Organizations can distribute curve parameters to enterprise, domain-joined, computer using Group Policy and the Group Policy Preferences Registry extension.  
+Organizations can distribute curve parameters to enterprise, domain-joined, computer using Group Policy and the Group Policy Preferences Registry extension.
 The process for distributing a curve is:
 
-1.    On Windows 10 and Windows Server 2016, use **certutil.exe** to add a new registered named curve to Windows.
-2.    From that same computer, Open the Group Policy Management Console (GPMC), create a new Group Policy object, and edit it.
-3.    Navigate to **Computer Configuration|Preferences|Windows Settings|Registry**.  Right-click **Registry**. Hover over **New** and select **Collection Item**. Rename the collection item to match the name of the curve. You'll create one Registry Collection item for each registry key under *HKEY_LOCAL_MACHINE\CurrentControlSet\Control\Cryptography\ECCParameters*.
-4.    Configure the newly created Group Policy Preference Registry Collection by adding a new **Registry Item** for each registry value listed under *HKEY_LOCAL_MACHINE\CurrentControlSet\Control\Cryptography\ECCParameters\[curveName]*.
-5.    Deploy the Group Policy object containing Group Policy Registry Collection item to Windows 10 and Windows Server 2016 computers that should receive the new named curves.
+1. On Windows 10 and Windows Server 2016, use **certutil.exe** to add a new registered named curve to Windows.
+2. From that same computer, Open the Group Policy Management Console (GPMC), create a new Group Policy object, and edit it.
+3. Navigate to **Computer Configuration|Preferences|Windows Settings|Registry**.  Right-click **Registry**. Hover over **New** and select **Collection Item**. Rename the collection item to match the name of the curve. You'll create one Registry Collection item for each registry key under *HKEY_LOCAL_MACHINE\CurrentControlSet\Control\Cryptography\ECCParameters*.
+4. Configure the newly created Group Policy Preference Registry Collection by adding a new **Registry Item** for each registry value listed under *HKEY_LOCAL_MACHINE\CurrentControlSet\Control\Cryptography\ECCParameters\[curveName]*.
+5. Deploy the Group Policy object containing Group Policy Registry Collection item to Windows 10 and Windows Server 2016 computers that should receive the new named curves.
 
     ![GPP distribute curves](../media/Transport-Layer-Security-protocol/gpp-distribute-curves.png)
 
@@ -126,12 +126,11 @@ The process for distributing a curve is:
 
 ## Managing TLS ECC order
 
-Beginning with Windows 10 and Windows Server 2016, ECC Curve Order group policy settings can be used configure the default TLS ECC Curve Order. 
-Using Generic ECC and this setting, organizations can add their own trusted named curves (that are approved for use with TLS) to the operating system and then add those named curves to the curve priority Group Policy setting to ensure they are used in future TLS handshakes. 
-New curve priority lists become active on the next reboot after receiving the policy settings.     
+Beginning with Windows 10 and Windows Server 2016, ECC Curve Order group policy settings can be used configure the default TLS ECC Curve Order.
+Using Generic ECC and this setting, organizations can add their own trusted named curves (that are approved for use with TLS) to the operating system and then add those named curves to the curve priority Group Policy setting to ensure they are used in future TLS handshakes.
+New curve priority lists become active on the next reboot after receiving the policy settings.
 
 ![GPP distribute curves](../media/Transport-Layer-Security-protocol/gp-managing-tls-curve-priority-order.png)
 
 *Figure 4 Managing TLS curve priority using Group Policy*
-
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4289 (**Wrong GPO Path**), there is an unwanted '**s**' at the end of the GPO directory name "Network".

Thanks to @matziq for reporting this typo.

There is also a fair amount of old MSDN & Technet links, with a permanent redirect to docs.microsoft.com, in need of updating.

**Changes proposed:**
- Typo correction, "Networks" -> Network
- All  MSDN & Technet URLs updated to current targets
- Remove end-of-line blanks a.k.a. "Trim Trailing Space"
- HTTP to HTTPS (http://www.iana.org -> https://www.iana.org)
- Reduce redundant spacing in numbered list, from 4 down to 1
- Add MarkDown indent marker compatibility spacing in "Applies to:"
- Remove 1 blank line at EOF

**Ticket closure or reference:**

Closes #4289