### PR TITLE
Windows Commands: MD corrections for NFS table

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/services-for-network-file-system-command-reference.md
+++ b/WindowsServerDocs/administration/windows-commands/services-for-network-file-system-command-reference.md
@@ -13,15 +13,19 @@ ms.author: coreyp
 manager: dongill
 ms.date: 10/16/2017
 ---
+
 # Services for Network File System Command Reference
+
 Services for Network File System (NFS) provides a file sharing solution that enables you to transfer files between computers running Windows Server 2008 and UNIX operating systems using the NFS protocol.
-The following is a list of NFS command-line tools.
-|Command|Description|
-|-------|-----------|
-|[mapadmin](mapadmin.md)|Manage User Name Mapping for Microsoft Services for Network File System.|
-|[Mount](mount.md)|Mount Network File System (NFS) network shares.|
-|[Nfsadmin](nfsadmin.md)|Manage Server for NFS and Client for NFS.|
-|[Nfsshare](nfsshare.md)|Control Network File System (NFS) shares.|
-|[Nfsstat](nfsstat.md)|Display or reset counts of calls made to Server for NFS.|
-|[Rpcinfo](rpcinfo.md)|List programs on remote computers.|
-|[Showmount](showmount.md)|Display mounted directories.|
+The following is a list of NFS command-line tools:
+
+
+| Command | Description |
+| ------- | ----------- |
+| [mapadmin](mapadmin.md) | Manage User Name Mapping for Microsoft Services for Network File System. |
+| [Mount](mount.md) | Mount Network File System (NFS) network shares. |
+| [Nfsadmin](nfsadmin.md) | Manage Server for NFS and Client for NFS. |
+| [Nfsshare](nfsshare.md) | Control Network File System (NFS) shares. |
+| [Nfsstat](nfsstat.md) | Display or reset counts of calls made to Server for NFS. |
+| [Rpcinfo](rpcinfo.md) | List programs on remote computers. |
+| [Showmount](showmount.md)|Display mounted directories. |


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4316 (**Table not clearly displayed**), the MarkDown table is unreadable because the MarkDown rules for spacing around the table has not been followed, making the table part of the preceding text section, without the required space to be converted properly to HTML on the docs.microsoft.com page.

Thanks to @k10blogger (Siddharth Kaul) for reporting this issue.

**Changes proposed:**

- Add 2 blank lines before the table (at least 1 is required)
- Add a blank line before & after the page title (recommended)
- Add 1 blank space between each table cell divider (pipe character)
- Add a NewLine (line break) at EOF (end-of-file)

**Ticket closure or reference:**

Closes #4316