### PR TITLE
TLSExtensions xmlns Incorrectly Contains "HTTPS"

### DIFF
--- a/WindowsServerDocs/remote/remote-access/vpn/vpn-create-oma-dm-based-vpnv2-profiles.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/vpn-create-oma-dm-based-vpnv2-profiles.md
@@ -43,7 +43,7 @@ Windows 10 client computer has already been configured with a VPN connection usi
 3. Locate the section that ends with **\</AcceptServerName>\</EapType>** and insert the following string between these two values to provide the VPN client with the logic to select the AAD Conditional Access Certificate:
 
     ```XML
-    <TLSExtensions xmlns="https://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV2"><FilteringInfo xmlns="https://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV3"><EKUMapping><EKUMap><EKUName>AAD Conditional Access</EKUName><EKUOID>1.3.6.1.4.1.311.87</EKUOID></EKUMap></EKUMapping><ClientAuthEKUList Enabled="true"><EKUMapInList><EKUName>AAD Conditional Access</EKUName></EKUMapInList></ClientAuthEKUList></FilteringInfo></TLSExtensions>
+    <TLSExtensions xmlns="http://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV2"><FilteringInfo xmlns="http://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV3"><EKUMapping><EKUMap><EKUName>AAD Conditional Access</EKUName><EKUOID>1.3.6.1.4.1.311.87</EKUOID></EKUMap></EKUMapping><ClientAuthEKUList Enabled="true"><EKUMapInList><EKUName>AAD Conditional Access</EKUName></EKUMapInList></ClientAuthEKUList></FilteringInfo></TLSExtensions>
     ```
 
 4. Select the **Conditional Access** blade and toogle **Conditional access for this VPN connection** to **Enabled**.


### PR DESCRIPTION
While attempting to test SSO with always-on VPN I kept running into issues with the profile failing to be installed through both Intune and PowerShell. I compared a working manual configuration against the example code showed on this page and the only difference was the URI in the TLSExtensions. They should be "http://..." instead of "https://..."

The examples from https://docs.microsoft.com/en-us/windows/client-management/mdm/vpnv2-csp also show "http" instead of "https".