### PR TITLE
remove parsetcglogs parameter

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/tpmtool.md
+++ b/WindowsServerDocs/administration/windows-commands/tpmtool.md
@@ -30,7 +30,6 @@ tpmtool /parameter [<arguments>]
 |getdeviceinformation|Displays the basic information of the TPM. The meaning of the information flag values can be found [here](https://docs.microsoft.com/windows/desktop/SecProv/win32-tpm-isreadyinformation#parameters).|
 |gatherlogs [output directory path]|Collects TPM logs and places them in the specified directory. If that directory does not exist, it is created. By default, they are placed in the current directory. The possible files generated are: </br>- TpmEvents.evtx</br>- TpmInformation.txt</br>- SRTMBoot.dat</br>- SRTMResume.dat</br>- DRTMBoot.dat</br>- DRTMResume.dat</br>|
 |drivertracing [start / stop]|Start / stop collecting TPM driver traces. The trace log, TPMTRACE.etl, will be generated and placed in the current directory.|
-|parsetcglogs [-validate (-v)]|Displays the parsed TCG log, also known as the Windows Boot Configuration Log (WBCL). The most up-to-date event descriptions can be found on the [TCG website](https://trustedcomputinggroup.org/resource/pc-client-specific-platform-firmware-profile-specification/), under **Event Descriptions**. If the `-validate` flag set, validates that the Platform Configuration Register (PCR) values on the TPM match values in the log.|
 |/?|Displays help at the command prompt.|
 
 ## <a name=tpmtool_examples></a>Examples
@@ -52,14 +51,6 @@ To collect TPM driver traces, type:
 tpmtool drivertracing start
 # Run scenario
 tpmtool drivertracing stop
-```
-To parse the TCG log:
-```
-tpmtool parsetcglogs
-```
-To parse the TCG log and validate the PCRs:
-```
-tpmtool parsetcglogs -validate
 ```
 
 ## Decoding Error Codes


### PR DESCRIPTION
The parsetcglogs parameter is no longer supported (starting with Iron release).