### PR TITLE
Escaped md table pipe char

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/echo.md
+++ b/WindowsServerDocs/administration/windows-commands/echo.md
@@ -26,7 +26,7 @@ echo [on | off]
 
 | Parameter | Description |
 | --------- | ----------- |
-| [on \ | off] | Turns on or off the command echoing feature. Command echoing is on by default. |
+| [on \| off] | Turns on or off the command echoing feature. Command echoing is on by default. |
 | `<message>` | Specifies the text to display on the screen. |
 | /? | Displays help at the command prompt. |
 


### PR DESCRIPTION
Escaped the pipe char in the Parameters table so it rendered the markdown correctly.