### PR TITLE
Windows Commands/tracert: typo, link & whitespace

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/tracert.md
+++ b/WindowsServerDocs/administration/windows-commands/tracert.md
@@ -10,6 +10,7 @@ ms.author: coreyp
 manager: dongill
 ms.date: 10/16/2017
 ---
+
 # tracert
 
 > Applies to: Windows Server (Semi-Annual Channel), Windows Server 2019, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012
@@ -17,10 +18,13 @@ ms.date: 10/16/2017
 Determines the path taken to a destination by sending Internet Control Message Protocol (ICMP) echo Request or ICMPv6 messages to the destination with incrementally increasing time to Live (TTL) field values. The path displayed is the list of near/side router interfaces of the routers in the path between a source host and a destination. The near/side interface is the interface of the router that is closest to the sending host in the path. Used without parameters, tracert displays help.
 
 ## Syntax
+
 ```
 tracert [/d] [/h <MaximumHops>] [/j <Hostlist>] [/w <timeout>] [/R] [/S <Srcaddr>] [/4][/6] <TargetName>
 ```
+
 #### Parameters
+
 |Parameter|Description|
 |-------|--------|
 |/d|Prevents **tracert** from attempting to resolve the IP addresses of intermediate routers to their names. This can speed up the display of **tracert** results.|
@@ -35,11 +39,13 @@ tracert [/d] [/h <MaximumHops>] [/j <Hostlist>] [/w <timeout>] [/R] [/S <Srcaddr
 |/?|Displays help at the command prompt.|
 
 ## Remarks
--   This diagnostic tool determines the path taken to a destination by sending ICMP echo Request messages with varying time to Live (TTL) values to the destination. Each router along the path is required to decrement the TTL in an IP packet by at least 1 before forwarding it. Effectively, the TTL is a maximum link counter. When the TTL on a packet reaches 0, the router is expected to return an ICMP time Exceeded message to the source computer. tracert determines the path by sending the first echo Request message with a TTL of 1 and incrementing the TTL by 1 on each subsequent transmission until the target responds or the maximum number of hops is reached. The maximum number of hops is 30 by default and can be specified using the **/h** parameter. The path is determined by examining the ICMP time Exceeded messages returned by intermediate routers and the echo Reply message returned by the destination. However, some routers do not return time Exceeded messages for packets with expired TTL values and are invisile to the tracert command. In this case, a row of asterisks (*) is displayed for that hop.
--   To trace a path and provide network latency and packet loss for each router and link in the path, use the **pathping** command.
--   This command is available only if the Internet Protocol (TCP/IP) protocol is installed as a component in the properties of a network adapter in Network Connections.
+
+- This diagnostic tool determines the path taken to a destination by sending ICMP echo Request messages with varying time to Live (TTL) values to the destination. Each router along the path is required to decrement the TTL in an IP packet by at least 1 before forwarding it. Effectively, the TTL is a maximum link counter. When the TTL on a packet reaches 0, the router is expected to return an ICMP time Exceeded message to the source computer. tracert determines the path by sending the first echo Request message with a TTL of 1 and incrementing the TTL by 1 on each subsequent transmission until the target responds or the maximum number of hops is reached. The maximum number of hops is 30 by default and can be specified using the **/h** parameter. The path is determined by examining the ICMP time Exceeded messages returned by intermediate routers and the echo Reply message returned by the destination. However, some routers do not return time Exceeded messages for packets with expired TTL values and are invisible to the tracert command. In this case, a row of asterisks (*) is displayed for that hop.
+- To trace a path and provide network latency and packet loss for each router and link in the path, use the [**pathping**](pathping.md) command.
+- This command is available only if the Internet Protocol (TCP/IP) protocol is installed as a component in the properties of a network adapter in Network Connections.
 
 ## Examples
+
 To trace the path to the host named corp7.microsoft.com, type:
 ```
 tracert corp7.microsoft.com
@@ -52,5 +58,7 @@ To trace the path to the host named corp7.microsoft.com and use the loose source
 ```
 tracert /j 10.12.0.1 10.29.3.1 10.1.44.1 corp7.microsoft.com
 ```
+
 ## Additional References
+
 - [Command-Line Syntax Key](command-line-syntax-key.md)


### PR DESCRIPTION
**Description:**

As reported in issue ticket **Spelling Change for Invisile to Invisible** #4396 , 'invisible' is misspelled as "invisile" and needs correction.

Thanks to @crispymiller for reporting this issue.

**Changes proposed:**
- typo correction, invisile -> invisible
- Link the command **pathping** to its nearby page (same directory)
- Whitespace adjustments:
    - Normalize bullet list spacing from 3 spaces to 1 space (3 lines)
    - Add 1 blank line between metadata and the page title
    - Normalize MD heading formatting to 1 blank line before & after

**Ticket closure or reference:**

Closes #4396