### PR TITLE
Windows Commands/bcdboot: URL typo correction

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/bcdboot.md
+++ b/WindowsServerDocs/administration/windows-commands/bcdboot.md
@@ -31,7 +31,7 @@ bcdboot <source> [/l] [/s]
 
 ## Examples
 
-For information about where to find BCDboot and examples of how to use this command, see the [BCDboot Command-Line Options](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-8.1-and-8/hh824874(v=win.10)x) topic.
+For information about where to find BCDboot and examples of how to use this command, see the [BCDboot Command-Line Options](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-8.1-and-8/hh824874(v=win.10)) topic.
 
 ## Additional References
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4405 (**Link throws 404**), following the link pointing to the **BCDboot Command-Line Options** page gives a 404 error. This is because the link URL contains a misplaced letter X at the end.

Thanks to @TheBeardedLlama (Steven Moschidis) for reporting this issue.

**Changes proposed:**
- Remove the misplaced letter X from the link URL

**Additional notes:**

The BCDboot Command-Line Options page says: 
- We’re no longer updating this content regularly. Check the Microsoft Product Lifecycle for information about how this product, service, technology or API is supported.

Because of this, I would like to propose using the more updated page https://docs.microsoft.com/windows-hardware/manufacture/desktop/bcdboot-command-line-options-techref-di which has the exact same page title (BCDboot Command-Line Options) and is at least 3 years newer than the currently linked Windows 8 page. My only caveat is that I have not fully compared the page contents to see if there are any important differences between the pages. I don't know yet if any useful information on the Windows 8 page will be lost by replacing link to the old page with a link to the newer hardware page.

**Ticket closure or reference:**

Closes #4405