### PR TITLE
Storage/Folder Redirection: table row & URLs

### DIFF
--- a/WindowsServerDocs/storage/folder-redirection/deploy-folder-redirection.md
+++ b/WindowsServerDocs/storage/folder-redirection/deploy-folder-redirection.md
@@ -1,17 +1,17 @@
 ---
 title: Deploy Folder Redirection with Offline FilesDeploy Folder Redirection with Offline Files
 description: How to use Windows Server to deploy Folder Redirection with Offline Files to Windows client computers.
-ms.prod: windows-server 
-ms.topic: article 
-author: JasonGerend 
-ms.author: jgerend 
-ms.technology: storage 
+ms.prod: windows-server
+ms.topic: article
+author: JasonGerend
+ms.author: jgerend
+ms.technology: storage
 ms.date: 06/06/2019
 ms.localizationpriority: medium
 ---
 # Deploy Folder Redirection with Offline Files
 
->Applies to: Windows 10, Windows 7, Windows 8, Windows 8.1, Windows Vista, Windows Server 2019, Windows Server 2016, Windows Server 2012, Windows Server 2012 R2, Windows Server 2008 R2, Windows Server (Semi-annual Channel)
+> Applies to: Windows 10, Windows 7, Windows 8, Windows 8.1, Windows Vista, Windows Server 2019, Windows Server 2016, Windows Server 2012, Windows Server 2012 R2, Windows Server 2008 R2, Windows Server (Semi-annual Channel)
 
 This topic describes how to use Windows Server to deploy Folder Redirection with Offline Files to Windows client computers.
 
@@ -77,9 +77,9 @@ Here's how to create a file share on Windows Server 2019, Windows Server 2016, a
 7. On the **Permissions** page, select **Customize permissions…**. The Advanced Security Settings dialog box appears.
 8. Select **Disable inheritance**, and then select **Convert inherited permissions into explicit permission on this object**.
 9. Set the permissions as described Table 1 and shown in Figure 1, removing permissions for unlisted groups and accounts, and adding special permissions to the Folder Redirection Users group that you created in Step 1.
-    
+
     ![Setting the permissions for the redirected folders share](media/deploy-folder-redirection/setting-the-permissions-for-the-redirected-folders-share.png)
-    
+
     **Figure 1** Setting the permissions for the redirected folders share
 10. If you chose the **SMB Share - Advanced** profile, on the **Management Properties** page, select the **User Files** Folder Usage value.
 11. If you chose the **SMB Share - Advanced** profile, on the **Quota** page, optionally select a quota to apply to users of the share.
@@ -89,7 +89,6 @@ Here's how to create a file share on Windows Server 2019, Windows Server 2016, a
 
 | User Account  | Access  | Applies to  |
 | --------- | --------- | --------- |
-| User Account | Access | Applies to |
 | System     | Full control        |    This folder, subfolders and files     |
 | Administrators     | Full Control       | This folder only        |
 | Creator/Owner     |   Full Control      |   Subfolders and files only      |
@@ -111,11 +110,11 @@ Here's how to create a GPO for Folder Redirection:
 7. In the **Security Filtering** section, select **Add**.
 8. In the **Select User, Computer, or Group** dialog box, type the name of the security group you created in Step 1 (for example, **Folder Redirection Users**), and then select **OK**.
 9. Select the **Delegation** tab, select **Add**, type **Authenticated Users**, select **OK**, and then select **OK** again to accept the default Read permissions.
-    
+
     This step is necessary due to security changes made in [MS16-072](https://support.microsoft.com/help/3163622/ms16-072-security-update-for-group-policy-june-14-2016).
 
 > [!IMPORTANT]
-> Due to the security changes made in [MS16-072](https://support.microsoft.com/help/3163622/ms16-072-security-update-for-group-policy-june-14-2016), you now must give the Authenticated Users group delegated Read permissions to the Folder Redirection GPO - otherwise the GPO won't get applied to users, or if it's already applied, the GPO is removed, redirecting folders back to the local PC. For more info, see [Deploying Group Policy Security Update MS16-072](https://blogs.technet.microsoft.com/askds/2016/06/22/deploying-group-policy-security-update-ms16-072-kb3163622/).
+> Due to the security changes made in [MS16-072](https://support.microsoft.com/help/3163622/ms16-072-security-update-for-group-policy-june-14-2016), you now must give the Authenticated Users group delegated Read permissions to the Folder Redirection GPO - otherwise the GPO won't get applied to users, or if it's already applied, the GPO is removed, redirecting folders back to the local PC. For more info, see [Deploying Group Policy Security Update MS16-072](https://techcommunity.microsoft.com/t5/ask-the-directory-services-team/deploying-group-policy-security-update-ms16-072-kb3163622/ba-p/400434).
 
 ## Step 4: Configure folder redirection with Offline Files
 
@@ -159,7 +158,7 @@ Here's how to test Folder Redirection:
 
 1. Sign in to a primary computer (if you enabled primary computer support) with a user account for which you have enabled Folder Redirection.
 2. If the user has previously signed in to the computer, open an elevated command prompt, and then type the following command to ensure that the latest Group Policy settings are applied to the client computer:
-    
+
     ```PowerShell
     gpupdate /force
     ```
@@ -195,4 +194,4 @@ The following table summarizes some of the most important changes to this topic.
 * [Enable Advanced Offline Files Functionality](enable-always-offline.md)
 * [Microsoft's Support Statement Around Replicated User Profile Data](https://docs.microsoft.com/archive/blogs/askds/microsofts-support-statement-around-replicated-user-profile-data)
 * [Sideload Apps with DISM](<https://docs.microsoft.com/previous-versions/windows/it-pro/windows-8.1-and-8/hh852635(v=win.10)>)
-* [Troubleshooting packaging, deployment, and query of Windows Runtime-based apps](https://msdn.microsoft.com/library/windows/desktop/hh973484.aspx)
+* [Troubleshooting packaging, deployment, and query of Windows Runtime-based apps](https://docs.microsoft.com/windows/win32/appxpkg/troubleshooting)


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4414 (**Duplicated header for table under "Required permissions for the file share hosting redirected folders"**), there is a redundant table row duplicating the table header row.

Thanks to @DrDrrae for reporting this issue.

There are also 2 outdated links to MSDN and TechNet in need of updating.

**Changes proposed:**
- Remove the unneeded table row duplicating the table header
- Replace the MSDN URL with its docs.microsoft.com permanent redirect
- Replace the archived blogs.technet URL with its techcommunity URL
- Whitespace adjustments:
    - Remove redundant end-of-line blanks (9 lines)
    - Add MarkDown indent marker compatibility space (1 line)

**Ticket closure or reference:**

Closes #4414