### PR TITLE
Windows Commands/query: bullet list & technet link

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/query.md
+++ b/WindowsServerDocs/administration/windows-commands/query.md
@@ -14,6 +14,7 @@ ms.author: coreyp
 manager: dongill
 ms.date: 10/16/2017
 ---
+
 # query
 
 > Applies to: Windows Server (Semi-Annual Channel), Windows Server 2019, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012
@@ -21,9 +22,10 @@ ms.date: 10/16/2017
 Displays information about processes, sessions, and Remote Desktop Session Host (RD Session Host) servers.
 
 > [!NOTE]
-> In Windows Server 2008 R2, Terminal Services was renamed Remote Desktop Services. To find out what's new in the latest version, see [What s New in Remote Desktop Services in Windows Server 2012](https://technet.microsoft.com/library/hh831527) in the Windows Server TechNet Library.
+> In Windows Server 2008 R2, Terminal Services was renamed Remote Desktop Services. To find out what's new in the latest version, see [What's New in Remote Desktop Services in Windows Server](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn283323(v=ws.11)) in the Microsoft Docs Windows Server Library.
 
 ## Syntax
+
 ```
 query process
 query session
@@ -32,6 +34,7 @@ query user
 ```
 
 ### Parameters
+
 |Parameter|Description|
 |-------|--------|
 |[query process](query-process.md)|Displays information about processes that are running on an rd Session Host server.|
@@ -40,5 +43,6 @@ query user
 |[query user](query-user.md)|Displays information about user sessions on an rd Session Host server.|
 
 ## Additional References
+
 - [Command-Line Syntax Key](command-line-syntax-key.md)
-[Remote Desktop Services (Terminal Services) Command Reference](remote-desktop-services-terminal-services-command-reference.md)
+- [Remote Desktop Services (Terminal Services) Command Reference](remote-desktop-services-terminal-services-command-reference.md)


### PR DESCRIPTION
**Description:**

After noticing the now closed issue ticket #3004 (**Which Windows API will be used by this command "query session" "query user"**) and checking the linked page to see if there is anything obvious that might have answered the ticket question directly for jyxjjj (DESMG-ShenLin), I noticed a couple of small page issues in need of resolving:

- The "Additional References" section contains 2 links, but only 1 bullet point (missing list formatting)
- The TechNet URL is now permanently redirected to docs.microsoft.com and the redirect page is deprecated, pointing to the 2012 R2 page.

**Changes proposed:**
- Add the missing MarkDown bullet point to the last link
- Update the permanently redirected TechNet URL
- Use the 2012 R2 page URL instead of the deprecated 2012 page
- Replace the "TechNet" reference in the link description with "Microsoft Docs"
- Whitespace adjustments:
    - Add missing blank line after the MarkDown H2/H3 headings (3)
    - Add 1 blank line between the metadata and the page title

**Ticket closure or reference:**

Ref. #3004