### PR TITLE
Windows Commands/xcopy: Example 9 missing a verb

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/xcopy.md
+++ b/WindowsServerDocs/administration/windows-commands/xcopy.md
@@ -10,6 +10,7 @@ ms.author: coreyp
 manager: dongill
 ms.date: 01/05/2019
 ---
+
 # xcopy
 
 Copies files and directories, including subdirectories.
@@ -186,7 +187,7 @@ copyit c:\prgmcode b:
 
 The command interpreter substitutes **C:\Prgmcode** for *%1* and **B:** for *%2*, then uses **xcopy** with the **/e** and **/s** command-line options. If **xcopy** encounters an error, the batch program reads the exit code and goes to the label indicated in the appropriate **IF ERRORLEVEL** statement, then displays the appropriate message and exits from the batch program.
 
-**9.** This example all the non-empty directories, plus files whose name match the pattern given with the asterisk symbol.
+**9.** This example copies all the non-empty directories, plus files whose name match the pattern given with the asterisk symbol.
 
 ```
 xcopy .\toc*.yml ..\..\Copy-To\ /S /Y
@@ -198,14 +199,14 @@ rem  .\d2\toc.yml
 rem  3 File(s) copied
 ```
 
-In the preceding example, this particular source parameter value **.\\toc\*.yml** copy the same 3 files even if its two path characters **.\\** were removed. However, no files would be copied if the asterisk wildcard was removed from the source parameter, making it just **.\\toc.yml**.
+In the preceding example, this particular source parameter value **.\\toc\*.yml** copies the same 3 files even if its two path characters **.\\** were removed. However, no files would be copied if the asterisk wildcard was removed from the source parameter, making it just **.\\toc.yml**.
 
 ## Additional References
 
--   [Copy](copy.md)
--   [Move](move.md)
--   [Dir](dir.md)
--   [Attrib](attrib.md)
--   [Diskcopy](diskcopy.md)
--   [If](if.md)
+- [Copy](copy.md)
+- [Move](move.md)
+- [Dir](dir.md)
+- [Attrib](attrib.md)
+- [Diskcopy](diskcopy.md)
+- [If](if.md)
 - [Command-Line Syntax Key](command-line-syntax-key.md)


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4383 (**Grammar**), the description text for Example 9 is missing a verb to make complete sense.
There is also a minor grammatical error in the comment following the example.

Thanks to @S-List for noticing and reporting the issue.

**Changes proposed:**
- Add the missing verb "copies" to complete the sentence
- Change "copy" to "copies" (3rd person singular) in the comment below
- Whitespace changes:
    - Normalize MD bullet point list spacing to 1 (6 lines)
    - Add 1 blank line between the metadata section and the page title

**Additional notes:**
- Please notify me if "will copy" is preferred instead of "copies".

**Ticket closure or reference:**

Closes #4383