### PR TITLE
Windows Commands/Command Extensions: extra notes

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/assoc.md
+++ b/WindowsServerDocs/administration/windows-commands/assoc.md
@@ -8,7 +8,7 @@ ms.assetid: 237bedda-b24c-4fec-a39c-9b7eacf96417
 author: coreyp-at-msft
 ms.author: coreyp
 manager: dongill
-ms.date: 10/16/2017
+ms.date: 06/13/2020
 ---
 
 # assoc
@@ -16,7 +16,9 @@ ms.date: 10/16/2017
 Displays or modifies file name extension associations. If used without parameters, **assoc** displays a list of all the current file name extension associations.
 
 > [!NOTE]
-> This command is only supported within cmd.exe and is not available from PowerShell.
+> This command is only supported within cmd.exe and is not available from PowerShell.<br>
+> <br>
+> The command interpreter [cmd.exe](cmd.md) does not recognize this command if Command Extensions are disabled.
 
 ## Syntax
 

--- a/WindowsServerDocs/administration/windows-commands/cmd.md
+++ b/WindowsServerDocs/administration/windows-commands/cmd.md
@@ -32,7 +32,7 @@ cmd [/c|/k] [/s] [/q] [/d] [/a|/u] [/t:{<b><f> | <f>}] [/e:{on | off}] [/f:{on |
 | /d | Disables execution of AutoRun commands. |
 | /a | Formats internal command output to a pipe or a file as American National Standards Institute (ANSI). |
 | /u | Formats internal command output to a pipe or a file as Unicode. |
-| /t:{`<b><f> | <f>`} | Sets the background (*b*) and foreground (*f*) colors. |
+| /t:{\<b>\<f> \| \<f>} | Sets the background (*b*) and foreground (*f*) colors. |
 | /e:on | Enables command extensions. |
 | /e:off | Disables commands extensions. |
 | /f:on | Enables file and directory name completion. |

--- a/WindowsServerDocs/administration/windows-commands/cmd.md
+++ b/WindowsServerDocs/administration/windows-commands/cmd.md
@@ -1,6 +1,6 @@
 ---
 title: cmd
-description: Reference topic for the cmd command, which starts a new instance of the command interpreter, Cmd.exe. 
+description: Reference topic for the cmd command, which starts a new instance of the command interpreter, Cmd.exe.
 ms.prod: windows-server
 ms.technology: manage-windows-commands
 ms.topic: article
@@ -8,7 +8,7 @@ ms.assetid: 6ec588db-31a9-4a73-a970-65a2c6f4abbe
 author: coreyp-at-msft
 ms.author: coreyp
 manager: dongill
-ms.date: 10/16/2017
+ms.date: 06/13/2020
 ---
 
 # cmd
@@ -32,7 +32,7 @@ cmd [/c|/k] [/s] [/q] [/d] [/a|/u] [/t:{<b><f> | <f>}] [/e:{on | off}] [/f:{on |
 | /d | Disables execution of AutoRun commands. |
 | /a | Formats internal command output to a pipe or a file as American National Standards Institute (ANSI). |
 | /u | Formats internal command output to a pipe or a file as Unicode. |
-| /t:{`<b><f>` | `<f>`} | Sets the background (*b*) and foreground (*f*) colors. |
+| /t:{`<b><f> | <f>`} | Sets the background (*b*) and foreground (*f*) colors. |
 | /e:on | Enables command extensions. |
 | /e:off | Disables commands extensions. |
 | /f:on | Enables file and directory name completion. |
@@ -107,7 +107,8 @@ The following table lists valid hexadecimal digits that you can use as the value
     > [!CAUTION]
     > Incorrectly editing the registry may severely damage your system. Before making changes to the registry, you should back up any valued data on the computer.
 
-    When you enable command extensions, the following commands are affected:  
+    When you enable command extensions, the following commands are affected:
+
     - **assoc**
 
     - **call**
@@ -115,6 +116,8 @@ The following table lists valid hexadecimal digits that you can use as the value
     - **chdir (cd)**
 
     - **color**
+
+    - **date**
 
     - **del (erase)**
 
@@ -143,6 +146,10 @@ The following table lists valid hexadecimal digits that you can use as the value
     - **shift**
 
     - **start** (also includes changes to external command processes)
+
+    - **time**
+
+    Another way to enable or disable Command Extensions, specifically in batch scripts, is by using the script commands **setlocal** and **endlocal**.
 
 - If you enable delayed environment variable expansion, you can use the exclamation point character to substitute the value of an environment variable at run time.
 

--- a/WindowsServerDocs/administration/windows-commands/color.md
+++ b/WindowsServerDocs/administration/windows-commands/color.md
@@ -8,7 +8,7 @@ ms.assetid: f5b67131-d196-45ec-a3f9-b5d9f091fd86
 author: coreyp-at-msft
 ms.author: coreyp
 manager: dongill
-ms.date: 10/16/2017
+ms.date: 06/13/2020
 ---
 
 # color
@@ -62,6 +62,10 @@ The following table lists valid hexadecimal digits that you can use as the value
 
 - If `<b>` and `<f>` are the same color value, the ERRORLEVEL is set to `1`, and no change is made to either the foreground or the background color.
 
+- The command is not available from PowerShell, but the [BackgroundColor](https://docs.microsoft.com/dotnet/api/system.management.automation.host.pshostrawuserinterface.backgroundcolor) and [ForegroundColor](https://docs.microsoft.com/dotnet/api/system.management.automation.host.pshostrawuserinterface.foregroundcolor) properties of `$ExecutionContext.Host.UI.RawUI` can be set instead.
+
+- The command interpreter [cmd.exe](cmd.md) does not recognize this command if Command Extensions are disabled.
+
 ## Examples
 
 To change the Command Prompt window background color to gray and the foreground color to red, type:
@@ -77,7 +81,7 @@ color e
 ```
 
 > [!NOTE]
-> In this example, the background is set to the default color because only one hexadecimal digit is specified.
+> In this example, the background is set to the default color, because only one hexadecimal digit is specified.
 
 ## Additional References
 

--- a/WindowsServerDocs/administration/windows-commands/ftype.md
+++ b/WindowsServerDocs/administration/windows-commands/ftype.md
@@ -8,7 +8,7 @@ ms.assetid: 6fb53cee-9bed-44dd-af5d-bc7cec1dd114
 author: coreyp-at-msft
 ms.author: coreyp
 manager: dongill
-ms.date: 10/16/2017
+ms.date: 06/13/2020
 ---
 
 # ftype
@@ -16,8 +16,10 @@ ms.date: 10/16/2017
 Displays or modifies file types that are used in file name extension associations. If used without an assignment operator (=), this command displays the current open command string for the specified file type. If used without parameters, this command displays the file types that have open command strings defined.
 
 > [!NOTE]
-> This command is only supported within cmd.exe and is not available from PowerShell.
-> Though you can use `cmd /c ftype` as a workaround.
+> This command is only supported within cmd.exe and is not available from PowerShell.<br>
+> Though you can use `cmd /c ftype` as a workaround.<br>
+> <br>
+> The command interpreter [cmd.exe](cmd.md) does not recognize this command if Command Extensions are disabled.
 
 ## Syntax
 

--- a/WindowsServerDocs/administration/windows-commands/setlocal.md
+++ b/WindowsServerDocs/administration/windows-commands/setlocal.md
@@ -8,13 +8,12 @@ ms.assetid: e4e4b6d3-3f1a-4851-a782-25ee2470e16e
 author: coreyp-at-msft
 ms.author: coreyp
 manager: dongill
-ms.date: 10/16/2017
+ms.date: 06/13/2020
 ---
 
 # setlocal
 
 Starts localization of environment variables in a batch file. Localization continues until a matching **endlocal** command is encountered or the end of the batch file is reached.
-
 
 
 ## Syntax
@@ -25,33 +24,42 @@ setlocal [enableextensions | disableextensions] [enabledelayedexpansion | disabl
 
 ## Arguments
 
-|Argument|Description|
-|--------|-----------|
-|enableextensions|Enables the command extensions until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run.|
-|disableextensions|Disables the command extensions until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run.|
-|enabledelayedexpansion|Enables the delayed environment variable expansion until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run.|
-|disabledelayedexpansion|Disables the delayed environment variable expansion until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run.|
-|/?|Displays help at the command prompt.|
+| Argument | Description |
+| -------- | ----------- |
+| enableextensions | Enables the command extensions until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
+| disableextensions | Disables the command extensions until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
+| enabledelayedexpansion | Enables the delayed environment variable expansion until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
+| disabledelayedexpansion | Disables the delayed environment variable expansion until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
+| /?|Displays help at the command prompt. |
 
 ## Remarks
 
--   Using **setlocal**
+- Using **setlocal**
 
     When you use **setlocal** outside of a script or batch file, it has no effect.
--   Changing environmental variables
+
+- Changing environmental variables
 
     Use **setlocal** to change environment variables when you run a batch file. Environment changes made after you run **setlocal** are local to the batch file. The Cmd.exe program restores previous settings when it encounters an **endlocal** command or reaches the end of the batch file.
--   Nesting commands
+
+- Nesting commands
 
     You can have more than one **setlocal** or **endlocal** command in a batch program (that is, nested commands).
--   Testing for command extensions in batch files
 
-    The **setlocal** command sets the ERRORLEVEL variable. If you pass {**enableextensions** | **disableextensions**} or {**enabledelayedexpansion** | **disabledelayedexpansion**}, the ERRORLEVEL variable is set to **0** (zero). Otherwise, it is set to **1**. You can use this information in batch scripts to determine whether the extensions are available, as shown in the following example:  
+- Command Extensions
+
+    Command Extensions is a mode of the [cmd](cmd.md) command interpreter that changes the behavior of variable expansion and of many internal commands (internal to cmd.exe). These changes are described in the documentation of each command. The cmd documentation page contains a list of affected commands. The [assoc](assoc.md), [color](color.md), and [ftype](ftype.md) commands are not available at all if Command Extensions are disabled.
+
+- Testing for command extensions in batch files
+
+    The **setlocal** command sets the ERRORLEVEL variable. If you pass {**enableextensions** | **disableextensions**} or {**enabledelayedexpansion** | **disabledelayedexpansion**}, the ERRORLEVEL variable is set to **0** (zero). Otherwise, it is set to **1**. You can use this information in batch scripts to determine whether the extensions are available, as shown in the following example:
+
     ```
     setlocal enableextensions
     verify other 2>nul
     if errorlevel 1 echo Unable to enable extensions
-    ```  
+    ```
+
     Because **cmd** does not set the ERRORLEVEL variable when command extensions are disabled, the **verify** command initializes the ERRORLEVEL variable to a nonzero value when you use it with an invalid argument. Also, if you use the **setlocal** command with arguments {**enableextensions** | **disableextensions**} or {**enabledelayedexpansion** | **disabledelayedexpansion**} and it does not set the ERRORLEVEL variable to **1**, command extensions are not available.
 
 ## Examples
@@ -73,4 +81,5 @@ start notepad c:\superapp.out
 
 ## Additional References
 
+- [The command interpreter cmd.exe](cmd.md)
 - [Command-Line Syntax Key](command-line-syntax-key.md)


### PR DESCRIPTION
**Description:**

As requested in issue ticket #4305 (**Really?**), Command Extensions needs to be described better, at least enough to get a fair understanding of the concept and its usage.

Thanks to @RocketCityElectromagnetics for initiating the issue ticket.

Based on feedback from @KalleOlaviNiemitalo (Kalle Olavi Niemitalo), this PR contains his suggested changes from the same ticket.
***
**Changes proposed:**
- Set 06/13/2020 as the new (tentative) metadata date for the files
- Add a note about Command Extensions in the setlocal page
- Add link to "The command interpreter cmd.exe" in Additional References
- Add a note about setlocal and endlocal after the list in the cmd page
- Add the commands 'date' and 'time' to the list of affected commands
- Add a note in 'assoc', 'color' and 'ftype' about cmd not recognizing the command if Command Extensions are disabled
- Add a note in the 'color' page about PowerShell alternatives
***
- Whitespace and codestyle adjustments:
    - Remove redundant end-of-line blanks (if present in the file)
    - Add blank space to insides of table cell dividers in 'setlocal'
    - Add readability comma in the Note text in the 'color' page
    - Add HTML line breaks in the Note blobs with added text
    - Show all the /t: arguments by using the backslash escape character
    - Normalize bullet point spacing to 1 space (4 lines)
    - Normalize number of contiguous blank lines to 2 (setlocal, 1 line)
    - Add blank line before list of affected commands (cmd page)
    - Add missing NewLine (line break) at end-of-file (setlocal page)
***
**Ticket closure or reference:**

Closes #4305