### PR TITLE
Get Started/Troubleshoot KMS/DNS: typo correction

### DIFF
--- a/WindowsServerDocs/get-started/common-troubleshooting-procedures-kms-dns.md
+++ b/WindowsServerDocs/get-started/common-troubleshooting-procedures-kms-dns.md
@@ -237,7 +237,7 @@ As described in [Manually assign a KMS host to a KMS client](#manually-assign-a-
 - For domain-joined computers, the computer's domain as assigned by the DNS system (such as Active Directory Domain Services (AD DS) DNS).
 - For workgroup computers, the computer's domain as assigned by the Dynamic Host Configuration Protocol (DHCP). This domain name is defined by the option that has the code value of 15 as defined in Request for Comments (RFC) 2132.
 
-By default, a KMS host registers its SRV records in the DNS zone that corresponds to the domain of the KMS host computer. For example, assume that a KMS host joins the contoso.com domain. In this scenario, the KMS host registers its _vlmcs SRV record under the contoso.com DNS zone. Therefore, the record identifies the service as _VLMCS._TCP.CONTOSO.COM.
+By default, a KMS host registers its SRV records in the DNS zone that corresponds to the domain of the KMS host computer. For example, assume that a KMS host joins the contoso.com domain. In this scenario, the KMS host registers its `_vlmcs` SRV record under the contoso.com DNS zone. Therefore, the record identifies the service as `_VLMCS._TCP.CONTOSO.COM`.
 
 If the KMS host and KMS clients use different DNS zones, you must configure the KMS host to automatically publish its SRV records in multiple DNS domains. To do this, follow these steps:
 

--- a/WindowsServerDocs/get-started/common-troubleshooting-procedures-kms-dns.md
+++ b/WindowsServerDocs/get-started/common-troubleshooting-procedures-kms-dns.md
@@ -194,7 +194,7 @@ allow-update { any; };
 ```
 ## Manually assign a KMS host to a KMS client
 
-By default, the KMS clients use the automatic discovery process. According to this process, a KMS client queries DNS for a list of servers that have published _vlmcs SRV records within the membership zone of the client. DNS returns the list of KMS hosts in a random order. The client picks a KMS host and tries to establish a session on it. If this attempt works, the client caches the name of the KMS host and tries to use it for the next renewal attempt. If the session setup fails, the client randomly picks another KMS host. We highly recommend that you use the automatic discovery process.
+By default, the KMS clients use the automatic discovery process. According to this process, a KMS client queries DNS for a list of servers that have published `_vlmcs` SRV records within the membership zone of the client. DNS returns the list of KMS hosts in a random order. The client picks a KMS host and tries to establish a session on it. If this attempt works, the client caches the name of the KMS host and tries to use it for the next renewal attempt. If the session setup fails, the client randomly picks another KMS host. We highly recommend that you use the automatic discovery process.
 
 However, you can manually assign a KMS host to a particular KMS client. To do this, follow these steps.
 
@@ -233,7 +233,7 @@ However, you can manually assign a KMS host to a particular KMS client. To do th
 > [!IMPORTANT]
 > Follow the steps in this section carefully. Serious problems might occur if you modify the registry incorrectly. Before you modify it, [back up the registry for restoration](https://support.microsoft.com/help/322756) in case problems occur.
 
-As described in [Manually assign a KMS host to a KMS client](#manually-assign-a-kms-host-to-a-kms-client), KMS clients typically use the automatic discovery process to identify KMS hosts. This process requires that the _vlmcs SRV records must be available in the DNS zone of the KMS client computer. The DNS zone corresponds to either the primary DNS suffix of the computer or to one of the following:
+As described in [Manually assign a KMS host to a KMS client](#manually-assign-a-kms-host-to-a-kms-client), KMS clients typically use the automatic discovery process to identify KMS hosts. This process requires that the `_vlmcs` SRV records must be available in the DNS zone of the KMS client computer. The DNS zone corresponds to either the primary DNS suffix of the computer or to one of the following:
 - For domain-joined computers, the computer's domain as assigned by the DNS system (such as Active Directory Domain Services (AD DS) DNS).
 - For workgroup computers, the computer's domain as assigned by the Dynamic Host Configuration Protocol (DHCP). This domain name is defined by the option that has the code value of 15 as defined in Request for Comments (RFC) 2132.
 

--- a/WindowsServerDocs/get-started/common-troubleshooting-procedures-kms-dns.md
+++ b/WindowsServerDocs/get-started/common-troubleshooting-procedures-kms-dns.md
@@ -25,7 +25,7 @@ You may have to use some of these methods if one or more of the following condit
    - Windows 8
 - The activation wizard cannot connect to a KMS host computer.
 
-When you try to activate a client system, the activation wizard uses DNS to locate a corresponding computer that&#39;s running the KMS software. If the wizard queries DNS and does not find the DNS entry for the KMS host computer, the wizard reports an error.   
+When you try to activate a client system, the activation wizard uses DNS to locate a corresponding computer that&#39;s running the KMS software. If the wizard queries DNS and does not find the DNS entry for the KMS host computer, the wizard reports an error.
 
 <a id="list"></a>Review the following list to find an approach that fits your circumstances:
 
@@ -33,7 +33,7 @@ When you try to activate a client system, the activation wizard uses DNS to loca
 - If you have to install and configure a KMS host, use the [Configure a KMS host for the clients to activate against](#configure-a-kms-host-for-the-clients-to-activate-against) procedure.
 - If the client cannot locate your existing KMS host, use the following procedures to troubleshoot your routing configurations. These procedures are arranged from the simplest to the most complex.
   - [Verify basic IP connectivity to the DNS server](#verify-basic-ip-connectivity-to-the-dns-server)
-  - [Verify the KMS host configuration](#verify-the-configuration-of-the-kms-host)  
+  - [Verify the KMS host configuration](#verify-the-configuration-of-the-kms-host)
   - [Determine the type of routing issue](#determine-the-type-of-routing-issue)
   - [Verify the DNS configuration](#verify-the-dns-configuration)
   - [Manually create a KMS SRV record](#manually-create-a-kms-srv-record)
@@ -52,7 +52,7 @@ To change the product key to an MAK, follow these steps:
     slmgr -ipk xxxxx-xxxxx-xxxxx-xxxxx-xxxxx
    ```
    > [!NOTE]
-   > The **xxxxx-xxxxx-xxxxx-xxxxx-xxxxx** placeholder represents your MAK product key.  
+   > The **xxxxx-xxxxx-xxxxx-xxxxx-xxxxx** placeholder represents your MAK product key.
 
 [Return to the procedure list.](#list)
 
@@ -80,33 +80,33 @@ Verify basic IP connectivity to the DNS server by using the ping command. To do 
 
 ## Verify the configuration of the KMS host
 
-Check the registry of the KMS host server to determine whether it is registering with DNS. By default, a KMS host server dynamically registers a DNS SRV record one time every 24 hours. 
+Check the registry of the KMS host server to determine whether it is registering with DNS. By default, a KMS host server dynamically registers a DNS SRV record one time every 24 hours.
 > [!IMPORTANT]
-> Follow the steps in this section carefully. Serious problems might occur if you modify the registry incorrectly. Before you modify it, [back up the registry for restoration](https://support.microsoft.com/help/322756) in case problems occur.  
+> Follow the steps in this section carefully. Serious problems might occur if you modify the registry incorrectly. Before you modify it, [back up the registry for restoration](https://support.microsoft.com/help/322756) in case problems occur.
 
 To check this setting, follow these steps:
 1. Start Registry Editor. To do this, right-click **Start**, select **Run**, type **regedit**, and then press Enter.
 1. Locate the **HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SL** subkey, and check the value of the **DisableDnsPublishing** entry. This entry has the following possible values:
    - **0** or undefined (default): The KMS host server registers a SRV record once every 24 hours.
-   - **1**: The KMS host server does not automatically register SRV records. If your implementation does not support dynamic updates, see [Manually create a KMS SRV record](#manually-create-a-kms-srv-record).  
+   - **1**: The KMS host server does not automatically register SRV records. If your implementation does not support dynamic updates, see [Manually create a KMS SRV record](#manually-create-a-kms-srv-record).
 1. If the **DisableDnsPublishing** entry is missing, create it (the type is DWORD). If dynamic registration is acceptable, leave the value undefined or set it to **0**.
 
 [Return to the procedure list.](#list)
 
 ## Determine the type of routing issue
 
-You can use the following commands to determine whether this is a name resolution issue or an SRV record issue.  
+You can use the following commands to determine whether this is a name resolution issue or an SRV record issue.
 
-1. On a KMS client, open an elevated Command Prompt window.  
+1. On a KMS client, open an elevated Command Prompt window.
 1. At the command prompt, run the following commands:
    ```cmd
    cscript \windows\system32\slmgr.vbs -skms <KMS_FQDN>:<port>
    cscript \windows\system32\slmgr.vbs -ato
    ```
    > [!NOTE]
-   > In this command, <KMS_FQDN> represents the fully qualified domain name (FQDN) of the KMS host computer and \<port\> represents the TCP port that KMS uses.  
+   > In this command, <KMS_FQDN> represents the fully qualified domain name (FQDN) of the KMS host computer and \<port\> represents the TCP port that KMS uses.
 
-   If these commands resolve the problem, this is an SRV record issue. You can you can troubleshoot it by using one of the commands that are documented in the [Manually assign a KMS host to a KMS client](#manually-assign-a-kms-host-to-a-kms-client) procedure.  
+   If these commands resolve the problem, this is an SRV record issue. You can you can troubleshoot it by using one of the commands that are documented in the [Manually assign a KMS host to a KMS client](#manually-assign-a-kms-host-to-a-kms-client) procedure.
 
 1. If the problem persists, run the following commands:
    ```cmd
@@ -114,7 +114,7 @@ You can use the following commands to determine whether this is a name resolutio
    cscript \windows\system32\slmgr.vbs -ato
    ```
    > [!NOTE]
-   > In this command, \<IP Address\> represents the IP address of the KMS host computer and \<port\> represents the TCP port that KMS uses.  
+   > In this command, \<IP Address\> represents the IP address of the KMS host computer and \<port\> represents the TCP port that KMS uses.
 
    If these commands resolve the problem, this is most likely a name resolution issue. For additional troubleshooting information, see the [Verify the DNS configuration](#verify-the-dns-configuration) procedure.
 
@@ -124,7 +124,7 @@ You can use the following commands to determine whether this is a name resolutio
 
 ## Verify the DNS configuration
 
->[!NOTE]
+> [!NOTE]
 > Unless otherwise stated, follow these steps on a KMS client that has experienced the applicable error.
 
 1. Open an elevated Command Prompt window
@@ -137,7 +137,7 @@ You can use the following commands to determine whether this is a name resolutio
    - The IP address of the Primary DNS server that the KMS client computer uses
    - The IP address of the default gateway that the KMS client computer uses
    - The DNS suffix search list that the KMS client computer uses
-1. Verify that the KMS host SRV records are registered in DNS. To do this, follow these steps:  
+1. Verify that the KMS host SRV records are registered in DNS. To do this, follow these steps:
    1. Open an elevated Command Prompt window.
    1. At the command prompt, run the following command:
       ```cmd
@@ -153,7 +153,7 @@ You can use the following commands to determine whether this is a name resolutio
        > [!NOTE]
        > In this entry, contoso.com represents the domain of the KMS host.
       1. Verify the IP address, host name, port, and domain of the KMS host.
-      1. If these **_vlmcs** entries exist, and if they contain the expected KMS host names, go to [Manually assign a KMS host to a KMS client](#manually-assign-a-kms-host-to-a-kms-client).  
+      1. If these **_vlmcs** entries exist, and if they contain the expected KMS host names, go to [Manually assign a KMS host to a KMS client](#manually-assign-a-kms-host-to-a-kms-client).
       > [!NOTE]
       > If the [**nslookup**](https://docs.microsoft.com/windows-server/administration/windows-commands/nslookup) command finds the KMS host, it does not mean that the DNS client can find the KMS host. If the **nslookup** command finds the KMS host, but you still cannot activate by using the KMS host, check the other DNS settings, such as the primary DNS suffix and the search list of the DNS suffix.
 1. Verify that the search list of the primary DNS suffix contains the DNS domain suffix that is associated with the KMS host. If the search list does not include this information, go to the [Configure the KMS host to publish in multiple DNS domains](#configure-the-kms-host-to-publish-in-multiple-dns-domains) procedure.
@@ -194,7 +194,7 @@ allow-update { any; };
 ```
 ## Manually assign a KMS host to a KMS client
 
-By default, the KMS clients use the automatic discovery process. According to this process, a KMS client queries DNS for a list of servers that have published _vlmcs SRV records within the membership zone of the client. DNS returns the list of KMS hosts in a random order. The client picks a KMS host and tries to establish a session on it. If this attempt works, the client caches the name of the KMS host and tries to use it for the next renewal attempt. If the session setup fails, the client randomly picks another KMS host. We highly recommend that you use the automatic discovery process.  
+By default, the KMS clients use the automatic discovery process. According to this process, a KMS client queries DNS for a list of servers that have published _vlmcs SRV records within the membership zone of the client. DNS returns the list of KMS hosts in a random order. The client picks a KMS host and tries to establish a session on it. If this attempt works, the client caches the name of the KMS host and tries to use it for the next renewal attempt. If the session setup fails, the client randomly picks another KMS host. We highly recommend that you use the automatic discovery process.
 
 However, you can manually assign a KMS host to a particular KMS client. To do this, follow these steps.
 
@@ -222,11 +222,11 @@ However, you can manually assign a KMS host to a particular KMS client. To do th
      ```
      > [!NOTE]
      > These commands use the following placeholders:
-     >- **<KMS_FQDN>** represents the fully qualified domain name (FQDN) of the KMS host computer
-     >- **\<IPv4Address\>** represents the IP version 4 address of the KMS host computer
-     >- **\<IPv6Address\>** represents the IP version 6 address of the KMS host computer
-     >- **\<NETBIOSName\>** represents the NETBIOS name of the KMS host computer
-     >- **\<port\>** represents the TCP port that KMS uses.  
+     > - **<KMS_FQDN>** represents the fully qualified domain name (FQDN) of the KMS host computer
+     > - **\<IPv4Address\>** represents the IP version 4 address of the KMS host computer
+     > - **\<IPv6Address\>** represents the IP version 6 address of the KMS host computer
+     > - **\<NETBIOSName\>** represents the NETBIOS name of the KMS host computer
+     > - **\<port\>** represents the TCP port that KMS uses.
 
 ## Configure the KMS host to publish in multiple DNS domains
 
@@ -237,11 +237,11 @@ As described in [Manually assign a KMS host to a KMS client](#manually-assign-a-
 - For domain-joined computers, the computer's domain as assigned by the DNS system (such as Active Directory Domain Services (AD DS) DNS).
 - For workgroup computers, the computer's domain as assigned by the Dynamic Host Configuration Protocol (DHCP). This domain name is defined by the option that has the code value of 15 as defined in Request for Comments (RFC) 2132.
 
-By default, a KMS host registers its SRV records in the DNS zone that corresponds to the domain of the KMS host computer. For example, assume that a KMS host joins the contoso.com domain. In this scenario, the KMS host registers its _vmlcs SRV record under the contoso.com DNS zone. Therefore, the record identifies the service as _VLMCS._TCP.CONTOSO.COM.
+By default, a KMS host registers its SRV records in the DNS zone that corresponds to the domain of the KMS host computer. For example, assume that a KMS host joins the contoso.com domain. In this scenario, the KMS host registers its _vlmcs SRV record under the contoso.com DNS zone. Therefore, the record identifies the service as _VLMCS._TCP.CONTOSO.COM.
 
 If the KMS host and KMS clients use different DNS zones, you must configure the KMS host to automatically publish its SRV records in multiple DNS domains. To do this, follow these steps:
 
-1. On the KMS host, start Registry Editor. 
+1. On the KMS host, start Registry Editor.
 1. Locate and then select the **HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SL** subkey.
 1. In the **Details** pane, right-click a blank area, select **New**, and then select **Multi-String Value**.
 1. For the name of the new entry, enter **DnsDomainPublishList**.


### PR DESCRIPTION
**Description:**

As reported in issue ticket #4214 (**typo**), the term '_vlmcs' is mistyped as "_vmlcs" and should be corrected to match the other occurrences.

Thanks to @Regen379 for reporting this typo issue.

**Changes proposed:**
- Correct the typo "_vmlcs" to _vlmcs (see the doc for reference)

- Whitespace adjustments:
    - Remove redundant end-of-line blanks (15 lines)
    - Add MarkDown indent marker compatibility spacing (6 lines)

**Ticket closure or reference:**

Closes #4214