### PR TITLE
Fixed DNS instruction issues

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/deployment/how-to-connect-fed-azure-adfs.md
+++ b/WindowsServerDocs/identity/ad-fs/deployment/how-to-connect-fed-azure-adfs.md
@@ -205,8 +205,13 @@ In order to effectively balance the traffic, the ILB should be configured with l
 
 **6.5. Update DNS with ILB**
 
-Go to your DNS server and create a CNAME for the ILB. The CNAME should be for the federation service with the IP address pointing to the IP address of the ILB. For example if the ILB DIP address is 10.3.0.8, and the federation service installed is fs.contoso.com, then create a CNAME for fs.contoso.com pointing to 10.3.0.8.
-This will ensure that all communication regarding fs.contoso.com end up at the ILB and are appropriately routed.
+Using your internal DNS server, create an A record for the ILB. The A record should be for the federation service with the IP address pointing to the IP address of the ILB. For example, if the ILB IP address is 10.3.0.8 and the federation service installed is fs.contoso.com, then create an A record for fs.contoso.com pointing to 10.3.0.8.
+This will ensure that all data trasmitted to fs.contoso.com end up at the ILB and are appropriately routed. 
+
+> [!NOTE]
+>If your deployment is also using IPv6, be sure to create a corresponding AAAA record.
+>
+>
 
 ### 7. Configuring the Web Application Proxy server
 **7.1. Configuring the Web Application Proxy servers to reach AD FS servers**


### PR DESCRIPTION
instructions indicated a CNAME record should be created but specified an IP address. CNAME records for the adding an additional name a DNS name goes by, but A records are intended for IP addresses.

Also fixed minor grammar / syntax issues, and added a note specifying that if IPv6 was used, an additional AAAA record should be created.