### PR TITLE
ConfigurationVersion related info

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/deployment/upgrading-to-ad-fs-in-windows-server.md
+++ b/WindowsServerDocs/identity/ad-fs/deployment/upgrading-to-ad-fs-in-windows-server.md
@@ -139,6 +139,9 @@ Check the WAP configuration by running the Get-WebApplicationProxyConfiguration 
 ```PowerShell
 Get-WebApplicationProxyConfiguration
 ```
+> [!NOTE]
+> Skip the next step if the ConfigurationVersion is Windows Server 2016. This is the correct value for Web Application Proxy on Windows Server 2016 / 2019.
+
 To upgrade the ConfigurationVersion of the WAP servers, run the following Powershell command.
 
 ```PowerShell


### PR DESCRIPTION
Many administrators try to upgrade the ConfigurationVersion to Windows Server 2019, however such ConfigurationVersion does not exist. WAP 2016 / 2019 use Windows Server 2016 as ConfigurationVersion.  Double cheked in my test environment and in the source code. We need to avoid more confusion here and I suggest that you accept my update request.