### PR TITLE
Update deploy-two-node-clustered-file-server.md

### DIFF
--- a/WindowsServerDocs/failover-clustering/deploy-two-node-clustered-file-server.md
+++ b/WindowsServerDocs/failover-clustering/deploy-two-node-clustered-file-server.md
@@ -317,18 +317,20 @@ To configure a file server failover cluster, follow the below steps.
    > [!NOTE]
    > If you are using static IP Addresses, you will need to select the network to use and input the IP Address it will use for the cluster name.  If you are using DHCP for your IP Addresses, the IP Address will be configured automatically for you.
 
-6. Choose **Next**.
+9. Choose **Next**.
 
-7. In the **Select Storage** window, select the additional drive (not the witness) that will hold your shares and **Next**.
+10. In the **Select Storage** window, select the additional drive (not the witness) that will hold your shares and **Next**.
 
-8. On the **Confirmation** page, verify your configuration and select **Next**.
+11. On the **Confirmation** page, verify your configuration and select **Next**.
 
-9. On the **Summary** page, it will give you the configuration it has created.  You can select View Report to see the report of the file server role creation.
-    - If the role does not add or start correctly, the CNO (Cluster Name Object) may not have permission to create further objects in Active Directory. In this case the "Client Access Point" name selected in step 8.
+12. On the **Summary** page, it will give you the configuration it has created.  You can select View Report to see the report of the file server role creation.
 
-10. Under **Roles** in the console tree, you will see the new role you created listed as the name you created.  With it highlighted, under the **Actions** pane on the right, choose **Add a share**.
+   > [!NOTE]
+   > If the role does not add or start correctly, the CNO (Cluster Name Object) may not have permission to create objects in Active Directory. The File Server role requires a Computer object of the same name as the "Client Access Point" provided in Step 8.
 
-11. Run through the share wizard inputting the following:
+13. Under **Roles** in the console tree, you will see the new role you created listed as the name you created.  With it highlighted, under the **Actions** pane on the right, choose **Add a share**.
+
+14. Run through the share wizard inputting the following:
 
     - Type of share it will be
     - Location/path the folder shared will be
@@ -336,10 +338,10 @@ To configure a file server failover cluster, follow the below steps.
     - Additional settings such as Access-based enumeration, caching, encryption, etc
     - File level permissions if they will be other than the defaults
 
-12. On the **Confirmation** page, verify what you have configured and select **Create** to create the file server share.
+15. On the **Confirmation** page, verify what you have configured and select **Create** to create the file server share.
 
-13. On the **Results** page, select Close if it created the share.  If it could not create the share, it will give you the errors incurred.
+16. On the **Results** page, select Close if it created the share.  If it could not create the share, it will give you the errors incurred.
 
-14. Choose **Close**.
+17. Choose **Close**.
 
-15. Repeat this process for any additional shares.
+18. Repeat this process for any additional shares.

--- a/WindowsServerDocs/failover-clustering/deploy-two-node-clustered-file-server.md
+++ b/WindowsServerDocs/failover-clustering/deploy-two-node-clustered-file-server.md
@@ -319,7 +319,7 @@ To configure a file server failover cluster, follow the below steps.
 
 9. Choose **Next**.
 
-10. In the **Select Storage** window, select the additional drive (not the witness) that will hold your shares and **Next**.
+10. In the **Select Storage** window, select the additional drive (not the witness) that will hold your shares, and click **Next**.
 
 11. On the **Confirmation** page, verify your configuration and select **Next**.
 
@@ -335,10 +335,10 @@ To configure a file server failover cluster, follow the below steps.
     - Type of share it will be
     - Location/path the folder shared will be
     - The name of the share users will connect to
-    - Additional settings such as Access-based enumeration, caching, encryption, etc
+    - Additional settings such as Access-based enumeration, caching, encryption, etc.
     - File level permissions if they will be other than the defaults
 
-15. On the **Confirmation** page, verify what you have configured and select **Create** to create the file server share.
+15. On the **Confirmation** page, verify what you have configured, and select **Create** to create the file server share.
 
 16. On the **Results** page, select Close if it created the share.  If it could not create the share, it will give you the errors incurred.
 

--- a/WindowsServerDocs/failover-clustering/deploy-two-node-clustered-file-server.md
+++ b/WindowsServerDocs/failover-clustering/deploy-two-node-clustered-file-server.md
@@ -324,6 +324,7 @@ To configure a file server failover cluster, follow the below steps.
 8. On the **Confirmation** page, verify your configuration and select **Next**.
 
 9. On the **Summary** page, it will give you the configuration it has created.  You can select View Report to see the report of the file server role creation.
+    - If the role does not add or start correctly, the CNO (Cluster Name Object) may not have permission to create further objects in Active Directory. In this case the "Client Access Point" name selected in step 8.
 
 10. Under **Roles** in the console tree, you will see the new role you created listed as the name you created.  With it highlighted, under the **Actions** pane on the right, choose **Add a share**.
 


### PR DESCRIPTION
The file server role would not start because the object could not be created in AD. I should think most people will encounter this.