### PR TITLE
Corrected unnecessarily escaped character

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Add-sign-in-page-description.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Add-sign-in-page-description.md
@@ -1,6 +1,6 @@
 ---
 ms.assetid: 330c7b61-dde0-432f-9b74-d250ad9cc808
-title: Add sign\-in page description
+title: Add sign-in page description
 author: billmath
 ms.author: billmath
 manager: femila


### PR DESCRIPTION
Unnecessarily escaped hyphen was causing backslash to appear in article title.