### PR TITLE
Windows Commands/PowerShell: PS URL 404 correction

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/windows-commands.md
+++ b/WindowsServerDocs/administration/windows-commands/windows-commands.md
@@ -64,7 +64,7 @@ The information that is contained in this topic applies to:
 
 The Command shell was the first shell built into Windows to automate routine tasks, like user account management or nightly backups, with batch (.bat) files. With Windows Script Host you could run more sophisticated scripts in the Command shell. For more information, see [cscript](cscript.md) or [wscript](wscript.md). You can perform operations more efficiently by using scripts than you can by using the user interface. Scripts accept all Commands that are available at the command line.
 
-Windows has two command shells: The Command shell and [PowerShell](/powershell/scripting/powershell-scripting?view=powershell-6). Each shell is a software program that provides direct communication between you and the operating system or application, providing an environment to automate IT operations.
+Windows has two command shells: The Command shell and [PowerShell](/powershell/scripting/overview). Each shell is a software program that provides direct communication between you and the operating system or application, providing an environment to automate IT operations.
 
 PowerShell was designed to extend the capabilities of the Command shell to run PowerShell commands called cmdlets. Cmdlets are similar to Windows Commands but provide a more extensible scripting language. You can run Windows Commands and PowerShell cmdlets in Powershell, but the Command shell can only run Windows Commands and not PowerShell cmdlets.
 


### PR DESCRIPTION
As reported in issue ticket **Broken link** #4685, the first PowerShell link on this page
causes a 404 error due to earlier changes in the PowerShell docs hierarchy.

My proposed new link URL points to https://docs.microsoft.com/powershell/scripting/overview
as the most likely correct page for the link, even though there is a landing page one level up.

Closes #4685