### PR TITLE
Fixed critical typos in Powershell Examples

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/deploy-standalone-storage-spaces.md
+++ b/WindowsServerDocs/storage/storage-spaces/deploy-standalone-storage-spaces.md
@@ -96,19 +96,19 @@ The following Windows PowerShell cmdlet or cmdlets perform the same function as 
 The following example shows which physical disks are available in the primordial pool.
 
 ```PowerShell
-Get-StoragePool -IsPrimordial $true | Get-PhysicalDisk | Where-Object CanPool -eq $True
+Get-StoragePool -IsPrimordial $true | Get-PhysicalDisk -CanPool $True
 ```
 
 The following example creates a new storage pool named *StoragePool1* that uses all available disks.
 
 ```PowerShell
-New-StoragePool –FriendlyName StoragePool1 –StorageSubsystemFriendlyName “Storage Spaces*” –PhysicalDisks (Get-PhysicalDisk –CanPool $True)
+New-StoragePool –FriendlyName StoragePool1 –StorageSubsystemFriendlyName "Windows Storage*" –PhysicalDisks (Get-PhysicalDisk –CanPool $True)
 ```
 
 The following example creates a new storage pool, *StoragePool1*, that uses four of the available disks.
 
 ```PowerShell
-New-StoragePool –FriendlyName StoragePool1 –StorageSubsystemFriendlyName “Storage Spaces*” –PhysicalDisks (Get-PhysicalDisk PhysicalDisk1, PhysicalDisk2, PhysicalDisk3, PhysicalDisk4)
+New-StoragePool –FriendlyName StoragePool1 –StorageSubsystemFriendlyName "Windows Storage*" –PhysicalDisks (Get-PhysicalDisk PhysicalDisk1, PhysicalDisk2, PhysicalDisk3, PhysicalDisk4)
 ```
 
 The following example sequence of cmdlets shows how to add an available physical disk *PhysicalDisk5* as a hot spare to the storage pool *StoragePool1*.


### PR DESCRIPTION
1. friendlier version of this commandlet: Get-StoragePool -IsPrimordial $true | Get-PhysicalDisk -CanPool $True
2. examples uses wrong parenthesis “Storage Spaces*” instead of "Storage Spaces*" 

3. examples uses invalid StorageSubSystemFriendlyname "Storage Spaces*" instead of "Windows Storage"
reference: https://docs.microsoft.com/en-us/powershell/module/storage/new-storagepool?view=win10-ps

The given examples fail to work for two reasons


issue example:
 New-StoragePool -FriendlyName StoragePool1 -StorageSubsystemFriendlyName "Storage Spaces*" -PhysicalDisks $disk
New-StoragePool : No MSFT_StorageSubSystem objects found with property 'FriendlyName' matching 'Storage Spaces*'.  Verify the value of the property and retry.
At line:1 char:1
+ New-StoragePool –FriendlyName StoragePool1 –StorageSubsystemFriendlyN ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Storage Spaces*:String) [New-StoragePool], CimJobException
    + FullyQualifiedErrorId : CmdletizationQuery_NotFound_FriendlyName,New-StoragePool

PS C:\Windows\system32> New-StoragePool -FriendlyName StoragePool1 -StorageSubsystemFriendlyName "Windows Storage*" -PhysicalDisks $disk

FriendlyName OperationalStatus HealthStatus IsPrimordial IsReadOnly      Size AllocatedSize
------------ ----------------- ------------ ------------ ----------      ---- -------------
Storagepool1           OK                Healthy      False        False      252.75 GB        512 MB