### PR TITLE
ADFS/Operations: "End user experience" removed

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Configuring-Alternate-Login-ID.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Configuring-Alternate-Login-ID.md
@@ -13,30 +13,19 @@ ms.topic: article
 ## What is Alternate Login ID?
 In most scenarios, users use their UPN (User Principal Names) to login to their accounts. However, in some environments due to corporate policies or on-premises line-of-business application dependencies, the users may be using some other form of sign-in.
 
->[!NOTE]
->Microsoft's recommended best practices are to match UPN to primary SMTP address. This article addresses the small percentage of customers that cannot remediate UPN's to match.
+> [!NOTE]
+> Microsoft's recommended best practices are to match UPN to primary SMTP address. This article addresses the small percentage of customers that cannot remediate UPN's to match.
 
 For example, they can be using their email-id for sign-in and that can be different from their UPN. This is particularly a common occurrence in scenarios where their UPN is non-routable. Consider a user Jane Doe with UPN jdoe@contoso.local and email address jdoe@contoso.com. Jane might not be even aware of the UPN as she has always used her email id for signing-in. Use of any other sign-in method instead of UPN constitutes alternate ID. For more information on how the UPN is created see, [Azure AD UserPrincipalName population](/azure/active-directory/connect/active-directory-aadconnect-userprincipalname).
 
 Active Directory Federation Services (AD FS) enables federated applications using AD FS to sign-in using alternate ID. This enables administrators to specify an alternative to the default UPN to be used for sign-in. AD FS already supports using any form of user identifier that is accepted by Active Directory Domain Services (AD DS). When configured for alternate ID, AD FS allows users to sign in using the configured alternate ID value, say email-id. Using the alternate ID enables you to adopt SaaS providers, such as Office 365 without modifying your on-premises UPNs. It also enables you to support line-of-business service applications with consumer-provisioned identities.
 
 ## Alternate id in Azure AD
+
 An organization may have to use alternate ID in the following scenarios:
 1. The on-premises domain name is non-routable, ex. Contoso.local and as a result the default user principal name is non-routable (jdoe@contoso.local). Existing UPN cannot be changed due to local application dependencies or company policies. Azure AD and Office 365 require all domain suffixes associated with Azure AD directory to be fully internet routable.
 2. The on-premises UPN is not same as the user's email address and to sign-in to Office 365, users use email address and UPN cannot be used due to organizational constraints.
    In the above-mentioned scenarios, alternate ID with AD FS enables users to sign-in to Azure AD without modifying your on-premises UPNs.
-
-## End-User Experience with Alternate Login ID
-The end-user experience varies depending on the authentication method used with alternate login id.  Currently there three different ways in which using alternate login id can be achieved.  They are:
-
-- **Regular Authentication (Legacy)**- uses the basic authentication protocol.
-- **Modern Authentication** - brings Active Directory Authentication Library (ADAL)-based sign-in to applications. This enables sign-in features such as Multi-Factor Authentication (MFA), SAML-based third-party Identity Providers with Office client applications, smart card and certificate-based authentication.
-- **Hybrid Modern Authentication** - Provides all of the benefits of Modern Authentication and provides users the ability to access on-premises applications using authorization tokens obtained from the cloud.
-
->[!NOTE]
-> For the best possible experience, Microsoft highly recommends Hybrid Modern Authentication.
-
-
 
 ## Configure alternate logon ID
 Using Azure AD Connect
@@ -47,7 +36,7 @@ We recommend using Azure AD connect to configure alternate logon ID for your env
 
 When Azure AD Connect is provided details about AD FS environment, it automatically checks for the presence of the right KB on your AD FS and configures AD FS for alternate ID including all necessary right claim rules for Azure AD federation trust. There is no additional step required outside wizard to configure alternate ID.
 
->[!NOTE]
+> [!NOTE]
 > Microsoft recommends using Azure AD Connect to configure alternate logon ID.
 
 ### Manually configure alternate ID
@@ -82,14 +71,14 @@ Set-AdfsClaimsProviderTrust -TargetIdentifier "AD AUTHORITY" -AlternateLoginID $
 
 ## Hybrid Modern Authentication with Alternate-ID
 
->[!IMPORTANT]
->The following has only been tested against AD FS and not 3rd party identity providers.
+> [!IMPORTANT]
+> The following has only been tested against AD FS and not 3rd party identity providers.
 
 ### Exchange and Skype for Business
 If you are using alternate login id with Exchange and Skype for Business, the user experience varies depending on whether or not you are using HMA.
 
->[!NOTE]
->For the best end-user experience, Microsoft recommends using Hybrid Modern Authentication.
+> [!NOTE]
+> For the best end-user experience, Microsoft recommends using Hybrid Modern Authentication.
 
 or more information see, [Hybrid Modern Authentication Overview](https://support.office.com/article/Hybrid-Modern-Authentication-overview-and-prerequisites-for-using-it-with-on-premises-Skype-for-Business-and-Exchange-servers-ef753b32-7251-4c9e-b442-1a5aec14e58d)
 
@@ -108,10 +97,6 @@ The following are pre-requisites for achieving SSO with alternate ID.
    - SFB Mac desktop
 - Exchange Clients that are Modern Authentication capable and support AltID regkeys
     - Office Pro Plus 2016 only
-
-
-
-
 
 #### Supported Office version
 
@@ -171,36 +156,36 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings\Zo
 
 ## Additional Details & Considerations
 
--   The Alternate login ID feature is available for federated environments with AD FS deployed.  It is not supported in the following scenarios:
-    -   Non-routable domains (e.g. Contoso.local) that cannot be verified by Azure AD.
-    -   Managed environments that do not have AD FS deployed.
+- The Alternate login ID feature is available for federated environments with AD FS deployed.  It is not supported in the following scenarios:
+    - Non-routable domains (e.g. Contoso.local) that cannot be verified by Azure AD.
+    - Managed environments that do not have AD FS deployed.
 
 
--   When enabled, the alternate login ID feature is only available for username/password authentication across all the user name/password authentication protocols supported by AD FS (SAML-P, WS-Fed, WS-Trust, and OAuth).
+- When enabled, the alternate login ID feature is only available for username/password authentication across all the user name/password authentication protocols supported by AD FS (SAML-P, WS-Fed, WS-Trust, and OAuth).
 
 
--   When Windows Integrated Authentication (WIA) is performed (for example, when users try to access a corporate application on a domain-joined machine from intranet and AD FS administrator has configured the authentication policy to use WIA for intranet), UPN isused for authentication. If you have configured any claim rules for the relying parties for alternate login ID feature, you should make sure those rules are still valid in the WIA case.
+- When Windows Integrated Authentication (WIA) is performed (for example, when users try to access a corporate application on a domain-joined machine from intranet and AD FS administrator has configured the authentication policy to use WIA for intranet), UPN isused for authentication. If you have configured any claim rules for the relying parties for alternate login ID feature, you should make sure those rules are still valid in the WIA case.
 
--   When enabled, the alternate login ID feature requires at least one global catalog server to be reachable from the AD FS server for each user account forest that AD FS supports. Failure to reach a global catalog server in the user account forest results in AD FS falling back to use UPN. By default all the domain controllers are global catalog servers.
+- When enabled, the alternate login ID feature requires at least one global catalog server to be reachable from the AD FS server for each user account forest that AD FS supports. Failure to reach a global catalog server in the user account forest results in AD FS falling back to use UPN. By default all the domain controllers are global catalog servers.
 
--   When enabled, if the AD FS server finds more than one user object with the same alternate login ID value specified across all the configured user account forests, it fails the login.
+- When enabled, if the AD FS server finds more than one user object with the same alternate login ID value specified across all the configured user account forests, it fails the login.
 
--   When alternate login ID feature is enabled, AD FS tries to authenticate the end user with alternate login ID first and then fall back to use UPN if it cannot find an account that can be identified by the alternate login ID. You should make sure there are no clashes between the alternate login ID and the UPN if you want to still support the UPN login. For example, setting one's mail attribute with the other's UPN blocks the other user from signing in with his UPN.
+- When alternate login ID feature is enabled, AD FS tries to authenticate the end user with alternate login ID first and then fall back to use UPN if it cannot find an account that can be identified by the alternate login ID. You should make sure there are no clashes between the alternate login ID and the UPN if you want to still support the UPN login. For example, setting one's mail attribute with the other's UPN blocks the other user from signing in with his UPN.
 
--   If one of the forests that is configured by the administrator is down, AD FS continues to look up user account with alternate login ID in other forests that are configured. If AD FS server finds a unique user objects across the forests that it has searched, a user logs in successfully.
+- If one of the forests that is configured by the administrator is down, AD FS continues to look up user account with alternate login ID in other forests that are configured. If AD FS server finds a unique user objects across the forests that it has searched, a user logs in successfully.
 
--   You may additionally want to customize the AD FS sign-in page to give end users some hint about the alternate login ID. You can do it by either adding the customized sign-in page description (for more information, see [Customizing the AD FS Sign-in Pages](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn280950(v=ws.11)) or customizing "Sign in with organizational account" string above username field (for more information, see [Advanced Customization of AD FS Sign-in Pages](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn636121(v=ws.11)).
+- You may additionally want to customize the AD FS sign-in page to give end users some hint about the alternate login ID. You can do it by either adding the customized sign-in page description (for more information, see [Customizing the AD FS Sign-in Pages](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn280950(v=ws.11)) or customizing "Sign in with organizational account" string above username field (for more information, see [Advanced Customization of AD FS Sign-in Pages](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn636121(v=ws.11)).
 
--   The new claim type that contains the alternate login ID value is **http:schemas.microsoft.com/ws/2013/11/alternateloginid**
+- The new claim type that contains the alternate login ID value is **http:schemas.microsoft.com/ws/2013/11/alternateloginid**
 
 ## Events and Performance Counters
 The following performance counters have been added to measure the performance of AD FS servers when alternate login ID is enabled:
 
--   Alternate Login Id Authentications: number of authentications performed by using alternate login ID
+- Alternate Login Id Authentications: number of authentications performed by using alternate login ID
 
--   Alternate Login Id Authentications/Sec: number of authentications performed by using alternate login ID per second
+- Alternate Login Id Authentications/Sec: number of authentications performed by using alternate login ID per second
 
--   Average Search Latency for Alternate Login ID: average search latency across the forests that an administrator has configured for alternate login ID
+- Average Search Latency for Alternate Login ID: average search latency across the forests that an administrator has configured for alternate login ID
 
 The following are various error cases and corresponding impact on a user's sign-in experience with events logged by AD FS:
 


### PR DESCRIPTION
Taken from PR #4664 which is now closed due to branch removals.

PR comment text:

"This section provides no information of any use to the reader. It just arbitrarily lists some information and says nothing about the associated user experience."

While editing, I took the liberty to add some whitespace improvements as well:
- Added missing MarkDown indent marker compatibility spacing (1 blank)
- Corrected indent spacing in bullet point lists, from 3 or 4 spaces to 1 space
- Removed redundant and surplus blank lines in the document