### PR TITLE
WAC/Azure Extended Network: replace recursive URL

### DIFF
--- a/WindowsServerDocs/manage/windows-admin-center/azure/index.md
+++ b/WindowsServerDocs/manage/windows-admin-center/azure/index.md
@@ -83,7 +83,7 @@ For more info, see [Deploy a Cloud Witness for a Failover Cluster](../../../fail
 - **Connect your on-premises servers to an Azure Virtual Network with [Azure Network Adapter](https://aka.ms/WACNetworkAdapter)**
 Let Windows Admin Center simplify setting up a point-to-site VPN from an on-premises server into an Azure virtual network.
 
-- **Make Azure VMs look like your on-premises network with [Azure Extended Network](https://docs.microsoft.com/en-gb/azure/virtual-network/subnet-extension#extend-your-subnet-to-azure)**
+- **Make Azure VMs look like your on-premises network with [Azure Extended Network](https://docs.microsoft.com/azure/virtual-network/subnet-extension#extend-your-subnet-to-azure)**
 Windows Admin Center can set up a site-to-site VPN and extend your on-premises IP addresses into your Azure vNet to let you more easily migrate workloads into Azure without breaking dependencies on IP addresses.
 
 ## Centrally manage your hybrid environment from Azure
@@ -122,7 +122,7 @@ This is the complete list of Azure services that provide functionality to stand-
 - Apply governance policies to your on-premises servers through Azure Policy using [Azure Arc for servers](/azure/azure-arc/servers/overview)
 - Secure your servers and get advanced threat protection with [Azure Security Center](/azure/security-center/windows-admin-center-integration)
 - Connect your on-premises servers to an Azure Virtual Network with [Azure Network Adapter](https://aka.ms/WACNetworkAdapter)
-- Make Azure VMs look like your on-premises network with [Azure Extended Network](https://docs.microsoft.com/en-gb/azure/virtual-network/subnet-extension#extend-your-subnet-to-azure)
+- Make Azure VMs look like your on-premises network with [Azure Extended Network](https://docs.microsoft.com/azure/virtual-network/subnet-extension#extend-your-subnet-to-azure)
 
 ### Services for clusters
 

--- a/WindowsServerDocs/manage/windows-admin-center/azure/index.md
+++ b/WindowsServerDocs/manage/windows-admin-center/azure/index.md
@@ -41,7 +41,7 @@ From the Azure hybrid services tool, you can:
 - Apply governance policies to your on-premises servers through Azure Policy using [Azure Arc for servers](/azure/azure-arc/servers/overview)
 - Secure your servers and get advanced threat protection with [Azure Security Center](/azure/security-center/windows-admin-center-integration)
 - Connect your on-premises servers to an Azure Virtual Network with [Azure Network Adapter](https://aka.ms/WACNetworkAdapter)
-- Make Azure VMs look like your on-premises network with [Azure Extended Network](https://go.microsoft.com/fwlink/?linkid=2109517&clcid=0x409)
+- Make Azure VMs look like your on-premises network with [Azure Extended Network](https://docs.microsoft.com/azure/virtual-network/subnet-extension#extend-your-subnet-to-azure)
 
 ## Back up and protect your on-premises servers and VMs
 
@@ -83,7 +83,7 @@ For more info, see [Deploy a Cloud Witness for a Failover Cluster](../../../fail
 - **Connect your on-premises servers to an Azure Virtual Network with [Azure Network Adapter](https://aka.ms/WACNetworkAdapter)**
 Let Windows Admin Center simplify setting up a point-to-site VPN from an on-premises server into an Azure virtual network.
 
-- **Make Azure VMs look like your on-premises network with [Azure Extended Network](https://go.microsoft.com/fwlink/?linkid=2109517&clcid=0x409)**
+- **Make Azure VMs look like your on-premises network with [Azure Extended Network](https://docs.microsoft.com/en-gb/azure/virtual-network/subnet-extension#extend-your-subnet-to-azure)**
 Windows Admin Center can set up a site-to-site VPN and extend your on-premises IP addresses into your Azure vNet to let you more easily migrate workloads into Azure without breaking dependencies on IP addresses.
 
 ## Centrally manage your hybrid environment from Azure
@@ -122,7 +122,7 @@ This is the complete list of Azure services that provide functionality to stand-
 - Apply governance policies to your on-premises servers through Azure Policy using [Azure Arc for servers](/azure/azure-arc/servers/overview)
 - Secure your servers and get advanced threat protection with [Azure Security Center](/azure/security-center/windows-admin-center-integration)
 - Connect your on-premises servers to an Azure Virtual Network with [Azure Network Adapter](https://aka.ms/WACNetworkAdapter)
-- Make Azure VMs look like your on-premises network with [Azure Extended Network](https://go.microsoft.com/fwlink/?linkid=2109517&clcid=0x409)
+- Make Azure VMs look like your on-premises network with [Azure Extended Network](https://docs.microsoft.com/en-gb/azure/virtual-network/subnet-extension#extend-your-subnet-to-azure)
 
 ### Services for clusters
 


### PR DESCRIPTION
**Description:**

As suggested in issue ticket #4749 (Wrong Link?), this is a proposal to use a link URL that actually goes somewhere, instead of reloading this page.

Also note: the recursive link is used 3 times on this very page. The URL https://go.microsoft.com/fwlink/?linkid=2109517&clcid=0x409 points to https://docs.microsoft.com/windows-server/manage/windows-admin-center/azure/ instead of the indicated page [Azure Extended Network].

Thanks to @Theragus for pointing out the issue and posting a good replacement suggestion.

**Ticket closure or reference:**

Closes #4749