### PR TITLE
ADFS/Operations: restore broken links (404)

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/delegate-ad-fs-pshell-access.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/delegate-ad-fs-pshell-access.md
@@ -58,7 +58,7 @@ If the farm is not using delegated administration, grant the gMSA account admin 
 
 ### Create the JEA Role File
 
-On the AD FS server, create the JEA role in a notepad file. Instructions to create the role is provided on [JEA role capabilities](/powershell/jea/role-capabilities).
+On the AD FS server, create the JEA role in a notepad file. Instructions to create the role is provided on [JEA role capabilities](https://docs.microsoft.com/powershell/scripting/learn/remoting/jea/role-capabilities).
 
 The commandlets delegated in this example are `Reset-AdfsAccountLockout, Get-ADFSAccountActivity, and Set-ADFSAccountActivity`.
 
@@ -74,7 +74,7 @@ VisibleCmdlets = 'Reset-AdfsAccountLockout', 'Get-ADFSAccountActivity', 'Set-ADF
 
 
 ### Create the JEA Session Configuration File
-Follow the instructions to create the [JEA session configuration](/powershell/jea/session-configurations) file. The configuration file determines who can use the JEA endpoint, and what capabilities they have access to.
+Follow the instructions to create the [JEA session configuration](https://docs.microsoft.com/powershell/scripting/learn/remoting/jea/session-configurations) file. The configuration file determines who can use the JEA endpoint, and what capabilities they have access to.
 
 Role capabilities are referenced by the flat name (filename without the extension) of the role capability file. If multiple role capabilities are available on the system with the same flat name, PowerShell uses its implicit search order to select the effective role capability file. It does not give access to all role capability files with the same name.
 
@@ -94,7 +94,7 @@ RoleDefinitions = @{ JEAcontoso = @{ RoleCapabilityFiles = 'C:\Program Files\Win
 
 Save the session configuration file.
 
-It is strongly recommended to [test your session configuration file](/powershell/module/microsoft.powershell.core/test-pssessionconfigurationfile?view=powershell-5.1) if you have edited the pssc file manually using a text editor to ensure the syntax is correct. If a session configuration file does not pass this test, it is not successfully registered on the system.
+It is strongly recommended to [test your session configuration file](/powershell/module/microsoft.powershell.core/test-pssessionconfigurationfile) if you have edited the pssc file manually using a text editor to ensure the syntax is correct. If a session configuration file does not pass this test, it is not successfully registered on the system.
 
 ### Install the JEA session configuration on the AD FS Server
 


### PR DESCRIPTION
As pointed out in issue ticket #4750 (Broken Link - Create the JEA Role File),
the link URL to "JEA Role Capabilities" ends in a 404 page (broken link).

Thanks to @JoelCBennett for pointing out the broken link.

I have looked up the correct link URLs on docs.microsoft.com, 
but I have yet to determine the correct github.com directory structure
for these links (I have corrected 2 links and adjusted 1 to be version agnostic.

Closes #4750