### PR TITLE
Windows Commands/Shutdown: add comment quotes

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/shutdown.md
+++ b/WindowsServerDocs/administration/windows-commands/shutdown.md
@@ -18,7 +18,7 @@ Enables you to shut down or restart local or remote computers one at a time.
 ## Syntax
 
 ```
-shutdown [/i | /l | /s | /r | /a | /p | /h | /e] [/f] [/m \\<ComputerName>] [/t <XXX>] [/d [p|u:]<XX>:<YY> [/c comment]]
+shutdown [/i | /l | /s | /r | /a | /p | /h | /e] [/f] [/m \\<ComputerName>] [/t <XXX>] [/d [p|u:]<XX>:<YY> [/c "descriptive comment"]]
 ```
 
 ### Parameters
@@ -42,23 +42,23 @@ shutdown [/i | /l | /s | /r | /a | /p | /h | /e] [/f] [/m \\<ComputerName>] [/t 
 
 ## Remarks
 
--   Users must be assigned the **Shut down the system** user right to shut down a local or remotely administered computer that is using the **shutdown** command.
--   Users must be members of the Administrators group to annotate an unexpected shutdown of a local or remotely administered computer. If the target computer is joined to a domain, members of the Domain Admins group might be able to perform this procedure. For more information, see:
-    -   [Default local groups](/previous-versions/windows/it-pro/windows-server-2003/cc785098(v=ws.10))
-    -   [Default groups](/previous-versions/windows/it-pro/windows-server-2003/cc756898(v=ws.10))
--   If you want to shut down more than one computer at a time, you can call **shutdown** for each computer by using a script, or you can use **shutdown** **/i** to display the Remote Shutdown Dialog box.
--   If you specify major and minor reason codes, you must first define these reason codes on each computer where you plan to use the reasons. If the reason codes are not defined on the target computer, Shutdown Event Tracker cannot log the correct reason text.
--   Remember to indicate that a shutdown is planned by using the **p:** parameter. Omitting **p:** indicates that a shutdown is unplanned. If you type **p:** followed by the reason code for an unplanned shutdown, the command will not carry out the shutdown. Conversely, if you omit **p:** and type in the reason code for a planned shutdown, the command will not carry out the shutdown.
+- Users must be assigned the **Shut down the system** user right to shut down a local or remotely administered computer that is using the **shutdown** command.
+- Users must be members of the Administrators group to annotate an unexpected shutdown of a local or remotely administered computer. If the target computer is joined to a domain, members of the Domain Admins group might be able to perform this procedure. For more information, see:
+    - [Default local groups](/previous-versions/windows/it-pro/windows-server-2003/cc785098(v=ws.10))
+    - [Default groups](/previous-versions/windows/it-pro/windows-server-2003/cc756898(v=ws.10))
+- If you want to shut down more than one computer at a time, you can call **shutdown** for each computer by using a script, or you can use **shutdown** **/i** to display the Remote Shutdown Dialog box.
+- If you specify major and minor reason codes, you must first define these reason codes on each computer where you plan to use the reasons. If the reason codes are not defined on the target computer, Shutdown Event Tracker cannot log the correct reason text.
+- Remember to indicate that a shutdown is planned by using the **p:** parameter. Omitting **p:** indicates that a shutdown is unplanned. If you type **p:** followed by the reason code for an unplanned shutdown, the command will not carry out the shutdown. Conversely, if you omit **p:** and type in the reason code for a planned shutdown, the command will not carry out the shutdown.
 
 ## Examples
 
 To force applications to close and restart the local computer after a one-minute delay with the reason Application: Maintenance (Planned) and the comment Reconfiguring myapp.exe type:
 ```
-shutdown /r /t 60 /c Reconfiguring myapp.exe /f /d p:4:1
+shutdown /r /t 60 /c "Reconfiguring myapp.exe" /f /d p:4:1
 ```
 To restart the remote computer \\\\ServerName with the same parameters, type:
 ```
-shutdown /r /m \\servername /t 60 /c Reconfiguring myapp.exe /f /d p:4:1
+shutdown /r /m \\servername /t 60 /c "Reconfiguring myapp.exe" /f /d p:4:1
 ```
 
 ## Additional References


### PR DESCRIPTION
As described in the manual page document itself, "You must enclose comments in quotation marks.", those quotation marks are missing in the examples, even though the comments contain spaces between the words. This does not work when applied in a live test scenario, because the comment will not be treated as a string with spaces unless quotation marks are used.

Thanks to @RodneySandwith for reporting this issue in ticket #4725 (Examples on page for Shutdown options do not show required quotes on comment parameter /c)

Also removed redundant surplus spaces in bullet point lists.
MarkDown bullet point lists only need 1 space after the bullet point list indicator, not 3 or 4 spaces.

Closes #4725 