### PR TITLE
Append details to the page

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/clients/change-listening-port.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/change-listening-port.md
@@ -22,3 +22,31 @@ When you connect to a computer (either a Windows client or Windows Server) throu
 6. Close the registry editor, and restart your computer.
 
 The next time you connect to this computer by using the Remote Desktop connection, you must type the new port. If you're using a firewall, make sure to configure your firewall to permit connections to the new port number.
+
+You can always check the current port through PowerShell too with below commands:
+
+Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "PortNumber"
+
+Example:
+
+PortNumber   : 3389
+
+PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal
+               Server\WinStations\RDP-Tcp
+
+PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal
+               Server\WinStations
+
+PSChildName  : RDP-Tcp
+
+PSDrive      : HKLM
+
+PSProvider   : Microsoft.PowerShell.Core\Registry
+
+You can change RDP port by executing PowerShell commands too as example shown below by adding new RDP port as 3390
+
+Add New RDP Port in Registry:
+
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "PortNumber" -Value 3390
+
+New-NetFirewallRule -DisplayName 'RDPPORTLatest' -Profile 'Public' -Direction Inbound -Action Allow -Protocol TCP -LocalPort 3390


### PR DESCRIPTION
You can always check the current port through PowerShell too with below commands:

Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "PortNumber"
Ex:
PortNumber   : 3389
PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal
               Server\WinStations\RDP-Tcp
PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal
               Server\WinStations
PSChildName  : RDP-Tcp
PSDrive      : HKLM
PSProvider   : Microsoft.PowerShell.Core\Registry

You can change RDP port by executing PowerShell commands too as example shown below by adding new RDP port as 3390
Add New RDP Port in Registry:
Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "PortNumber" -Value 3390
New-NetFirewallRule -DisplayName 'RDPPORTLatest' -Profile 'Public' -Direction Inbound -Action Allow -Protocol TCP -LocalPort 3390