### PR TITLE
RDP client FAQ/Macbook: trackpad control panel

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-client-faq.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-client-faq.md
@@ -168,7 +168,7 @@ In order to make use of the right-click inside an open session you have three op
 
 - Standard PC two button USB mouse
 - Apple Magic Mouse: To enable right-click, click **System Preferences** in the dock, click **Mouse**, and then enable **Secondary click**.
-- Apple Magic Trackpad or MacBook Trackpad: To enable right-click, click **System Preferences** in the dock, click **Mouse**, and then enable **Secondary click**.
+- Apple Magic Trackpad or MacBook Trackpad: To enable right-click, click **System Preferences** in the dock, click **Trackpad**, and then enable **Secondary click**.
 
 ### Is AirPrint supported?
 No, the Remote Desktop client doesn't support AirPrint. (This is true for both Mac and iOS clients.)


### PR DESCRIPTION
As reported in issue ticket #4807 (**enable secondary right-click on a MacBook**), without a mouse, the Mouse settings don't offer that option, it just says "No mouse found".

You have to click Trackpad -- that's where you'll find the setting to enable Secondary click.

Thanks to @casagordita for reporting this useful detail correction.

Closes #4807