### PR TITLE
Windows Commands/eventcreate: review Examples

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/eventcreate.md
+++ b/WindowsServerDocs/administration/windows-commands/eventcreate.md
@@ -41,13 +41,13 @@ eventcreate [/s <computer> [/u <domain\user> [/p <password>]] {[/l {APPLICATION|
 The following examples show how you can use the **eventcreate** command:
 
 ```
-eventcreate /t error /id 100 /l application /d Create event in application log
-eventcreate /t information /id 1000 /so winmgmt /d Create event in WinMgmt source
-eventcreate /t error /id 2001 /so winword /l application /d new src Winword in application log
-eventcreate /s server /t error /id 100 /l application /d Remote machine without user credentials
-eventcreate /s server /u user /p password /id 100 /t error /l application /d Remote machine with user credentials
-eventcreate /s server1 /s server2 /u user /p password /id 100 /t error /so winmgmt /d Creating events on Multiple remote machines
-eventcreate /s server /u user /id 100 /t warning /so winmgmt /d Remote machine with partial user credentials
+eventcreate /t ERROR /id 100 /l application /d "Create event in application log"
+eventcreate /t INFORMATION /id 1000 /d "Create event in WinMgmt source"
+eventcreate /t ERROR /id 201 /so winword /l application /d "New src Winword in application log"
+eventcreate /s server /t ERROR /id 100 /l application /d "Remote machine without user credentials"
+eventcreate /s server /u user /p password /id 100 /t ERROR /l application /d "Remote machine with user credentials"
+eventcreate /s server1 /s server2 /u user /p password /id 100 /t ERROR /d "Creating events on Multiple remote machines"
+eventcreate /s server /u user /id 100 /t WARNING /d "Remote machine with partial user credentials"
 ```
 
 ## Additional References


### PR DESCRIPTION
Based on feedback in issue ticket #4783 (**Command-line examples don't work**),
I propose the following improvements to amend some known issues:

- add double quotes around the Description text (always presume spaces)
- remove source parameter `/so` for common OS applications like 'WinMgmt'
  (error messages state that /so can only be used with custom scripts)
- reduce example ID enumeration to be less than or equal to 1000 (as documented)

Thanks to @djmitchella for reporting this issue with the examples provided.

Closes #4783