### PR TITLE
Ubuntu 20.04 is Focal, not Disco

### DIFF
--- a/WindowsServerDocs/administration/Linux-Package-Repository-for-Microsoft-Software.md
+++ b/WindowsServerDocs/administration/Linux-Package-Repository-for-Microsoft-Software.md
@@ -47,7 +47,7 @@ Repositories can be configured automatically by installing the Linux package tha
 
  - Ubuntu 18.04 (Bionic)<p>`curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -`<p>`sudo apt-add-repository https://packages.microsoft.com/ubuntu/18.04/prod`<p>`sudo apt-get update`
 
- - Ubuntu 20.04 (Disco)<p>`curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -`<p>`sudo apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod`<p>`sudo apt-get update`
+ - Ubuntu 20.04 (Focal)<p>`curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -`<p>`sudo apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod`<p>`sudo apt-get update`
 
 ## Manual Configuration
 


### PR DESCRIPTION
Ubuntu 20.04 is known as Focal Fossa (short name: Focal).

See also: https://wiki.ubuntu.com/FocalFossa/ReleaseNotes

- 1 word correction, (Disco) -> (Focal)

Thanks to @fgggid for noticing and reporting.

Closes #4866