### PR TITLE
Data Deduplication: update PowerShell links

### DIFF
--- a/WindowsServerDocs/storage/data-deduplication/advanced-settings.md
+++ b/WindowsServerDocs/storage/data-deduplication/advanced-settings.md
@@ -18,10 +18,10 @@ The [default Data Deduplication job schedules](understand.md#job-info) are desig
 
 ### <a id="modifying-job-schedules-change-schedule"></a>Changing a Data Deduplication schedule
 Data Deduplication jobs are scheduled via Windows Task Scheduler and can be viewed and edited there under the path Microsoft\Windows\Deduplication. Data Deduplication includes several cmdlets that make scheduling easy.
-* [`Get-DedupSchedule`](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc730705(v=ws.11)) shows the current scheduled jobs.
-* [`New-DedupSchedule`](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc730705(v=ws.11)) creates a new scheduled job.
-* [`Set-DedupSchedule`](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc730705(v=ws.11)) modifies an existing scheduled job.
-* [`Remove-DedupSchedule`](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc730705(v=ws.11)) removes a scheduled job.
+* [`Get-DedupSchedule`](https://docs.microsoft.com/powershell/module/deduplication/get-dedupschedule?view=win10-ps) shows the current scheduled jobs.
+* [`New-DedupSchedule`](https://docs.microsoft.com/powershell/module/deduplication/new-dedupschedule?view=win10-ps) creates a new scheduled job.
+* [`Set-DedupSchedule`](https://docs.microsoft.com/powershell/module/deduplication/set-dedupschedule?view=win10-ps) modifies an existing scheduled job.
+* [`Remove-DedupSchedule`](https://docs.microsoft.com/powershell/module/deduplication/remove-dedupschedule?view=win10-ps) removes a scheduled job.
 
 The most common reason for changing when Data Deduplication jobs run is to ensure that jobs run during off hours. The following step-by-step example shows how to modify the Data Deduplication schedule for a *sunny day* scenario: a hyper-converged Hyper-V host that is idle on weekends and after 7:00 PM on weeknights. To change the schedule, run the following PowerShell cmdlets in an Administrator context.
 


### PR DESCRIPTION
As reported in issue ticket #4674 (**PowerShell cmdlet links go to wrong page**),
the links in the section "Changing a Data Deduplication schedule" go to the old
and outdated pages for Windows Server 2008 R2 instead of the current versions.

The new URLs point to the current pages with proper explanation for each cmdlet.

Thanks to Mark Goodman (@silvermarkg) for reporting the issue and suggesting
new URLs to the correct pages for each cmdlet in the description.

Closes #4674