### PR TITLE
Windows Commands/graftabl: add important note

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/graftabl.md
+++ b/WindowsServerDocs/administration/windows-commands/graftabl.md
@@ -9,6 +9,9 @@ manager: mtillman
 ms.date: 10/16/2017
 ---
 
+> [!IMPORTANT]
+> The **graftabl** command is a legacy command, and therefore outdated. It is normally not installed in modern Windows versions. Please see the [chcp](https://docs.microsoft.com/windows-server/administration/windows-commands/chcp) page for codepage handling.
+
 # graftabl
 
 Enables Windows operating systems to display an extended character set in graphics mode. If used without parameters, **graftabl** displays the previous and the current code page.


### PR DESCRIPTION
As reported in several tickets (#1100, #4171), the command `graftabl` is not available in most supported Windows installations.

The command has survived in the internal CMD help text, though, but only as a forgotten archaic remnant.

The page should be retired, maybe to the `/previous-versions/` hierarchy instead, but the "Windows Commands" category does not yet exist in that hierarchy (at least not from what I could find).

Closes #1100
Closes #4171