### PR TITLE
Hyper-V/Debian VM: improve step 4 phrasing

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/Supported-Debian-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-Debian-virtual-machines-on-Hyper-V.md
@@ -71,11 +71,11 @@ The following feature distribution map indicates the features that are present i
    ```Powershell
    Set-VMFirmware -VMName "VMname" -EnableSecureBoot Off
    ```
-4. The latest upstream kernel capabilities are only available by using the kernel included [Debian backports](https://wiki.debian.org/Backports).
+4. The latest upstream kernel capabilities are only available by using the kernels available in the [Debian Backports repository](https://wiki.debian.org/Backports).
 
 5. While Debian 7.x is out of support and uses an older kernel, the kernel included in Debian backports for Debian 7.x has improved Hyper-V capabilities.
 
-See Also
+## See Also
 
 * [Supported CentOS and Red Hat Enterprise Linux virtual machines on Hyper-V](Supported-CentOS-and-Red-Hat-Enterprise-Linux-virtual-machines-on-Hyper-V.md)
 


### PR DESCRIPTION
**Description:**

As discussed in issue ticket #3360 (Note 8 is unclear), the phrasing of the second last step in the **Notes** section (currently number 4) leaves a lot to be desired in terms of precision, specifically when it comes to determining exactly which kernels or configurations are required for each documented setup.

Thanks to all participants in that ticket for providing useful feedback.

Thanks also to Thomas Sjögren (@konstruktoid) for suggesting a useful phrasing:

"The latest upstream kernel capabilities are only available by using the kernels available in the Debian backports repository."

**Additional change:**

updated "See also" to be a MarkDown H2 heading (##).

**Ticket closure or reference:**

Closes #3360