### PR TITLE
Best Practices Analyzer for Hyper-V: link updated

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/best-practices-analyzer/Best-Practices-Analyzer-for-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/best-practices-analyzer/Best-Practices-Analyzer-for-Hyper-V.md
@@ -7,15 +7,16 @@ ms.topic: article
 ms.assetid: 3747faa5-6e9f-499e-8a79-3fb9d73b6b92
 ms.date: 8/16/2016
 ---
+
 # Best Practices Analyzer for Hyper-V
 
->Applies To: Windows Server 2016
+> Applies To: Windows Server 2016
 
 In Windows management, *best practices* are guidelines that are considered the ideal way, under normal circumstances, to configure a server as defined by experts. Best practice violations, even critical ones, might not necessarily cause problems. But, they can indicate server configurations that can result in poor performance, poor reliability, unexpected conflicts, increased security risks, or other potential problems.
 
 The Best Practices Analyzer scans your computer using rules based on these best practices and reports the results. Each best practice rule includes details about how to comply with the rule. This section documents these rules to help you understand the best practices that apply to Hyper-V, as well interpret results when a scan finds conditions that don't comply with best practices.
 
-For more details about Best Practices Analyzer and scans, see [Best Practices Analyzer](https://go.microsoft.com/fwlink/?LinkId=122786).
+For more details about Best Practices Analyzer and scans, see [Best Practices Analyzer](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/dn283329(v=ws.11)).
 
 ## About Hyper-V
 Hyper-V lets you run multiple operating systems at the same time on one physical computer, by running each one in a virtual machine. Virtual machines can help you use your computing resources more efficiently and flexibly. For more about Hyper-V, see [Hyper-V on Windows Server 2016](../Hyper-V-on-Windows-Server.md).


### PR DESCRIPTION
**Description:**

As stated in issue ticket #810 (Link to Best Practices Analyzer is outdated?), the existing Best Practices Analyzer URL links to the 2008 R2 page version.

Thanks to @olavt for reporting the issue.

My suggestion is to replace it with the 2012/2012 R2 page version, even if the new page link also belongs to the /previous-versions/ hierarchy.

I have made some effort to locate a similar Windows Server 2016 page, but those are mostly troubleshooting pages only, not general topic documentation pages.

**Additional changes:**

- added editorial blank line between the page index and the page title line
- added MarkDown indent marker compatibility spacing in `> Applies To:`

**Ticket closure or reference:**

Closes #810