### PR TITLE
ADDS/Azure CLI: Configure DNS & second DC promo

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/deploy/virtual-dc/adds-on-azure-vm.md
+++ b/WindowsServerDocs/identity/ad-ds/deploy/virtual-dc/adds-on-azure-vm.md
@@ -143,7 +143,6 @@ az vm create \
     --data-disk-caching None \
     --nsg $NetworkSecurityGroup \
     --private-ip-address $DC2IP
-
 ```
 
 ## DNS and Active Directory
@@ -188,6 +187,10 @@ When the VM has completed rebooting, log back in with the credentials used befor
 
 [Azure virtual networks do now support IPv6](/azure/virtual-network/virtual-networks-faq#do-vnets-support-ipv6) , but in case you want to set your VMs to prefer IPv4 over IPv6, information on how to complete this task can be found in the KB article [Guidance for configuring IPv6 in Windows for advanced users](https://support.microsoft.com/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users).
 
+### Configure DNS
+
+After promoting the first server in Azure, the servers will need to be set to the primary and secondary DNS Servers for the virtual network, and any on-premises DNS Servers would be demoted to tertiary and beyond. More information on changing DNS Servers can be found in the article [Create, change, or delete a virtual network](/azure/virtual-network/manage-virtual-network#change-dns-servers).
+
 ### Configure the second Domain Controller
 
 Connect to AZDC02 using the credentials you provided in the script.
@@ -215,11 +218,7 @@ When the wizard completes the install process, the VM reboots.
 
 When the VM has completed rebooting, log back in with the credentials used before, but this time as a member of the CONTOSO.com domain
 
-[Azure virtual networks do now support IPv6](/azure/virtual-network/virtual-networks-faq#do-vnets-support-ipv6) , but in case you want to set your VMs to prefer IPv4 over IPv6, information on how to complete this task can be found in the KB article [Guidance for configuring IPv6 in Windows for advanced users](https://support.microsoft.com/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users).
-
-### Configure DNS
-
-After promoting the new domain controllers in Azure, they will need to be set to the primary and secondary DNS Servers for the virtual network, and any on-premises DNS Servers would be demoted to tertiary and beyond. More information on changing DNS Servers can be found in the article [Create, change, or delete a virtual network](/azure/virtual-network/manage-virtual-network#change-dns-servers).
+[Azure virtual networks do now support IPv6](/azure/virtual-network/virtual-networks-faq#do-vnets-support-ipv6), but in case you want to set your VMs to prefer IPv4 over IPv6, information on how to complete this task can be found in the KB article [Guidance for configuring IPv6 in Windows for advanced users](https://support.microsoft.com/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users).
 
 ### Wrap up
 


### PR DESCRIPTION
As reported in issue ticket #4917 (**Configure DNS before configuring the second domain controller**), promoting the second server fails with the error message "An active directory domain controller for the domain <testdomain.com> could not be contacted" when trying to promote the second DC before the **Configure DNS** step has been performed.

Based on this feedback, I propose to move the [Configure DNS] paragraph up to before the [Configure the second Domain Controller] section, as well as adapting the first sentence text accordingly, to match the new sequence.

Thanks to @K-Dela-R for discovering and reporting this live example issue.

Closes #4917