### PR TITLE
Revert ""browser" to replace "bowser" in the disable SMB1 via GPP section"

### DIFF
--- a/WindowsServerDocs/storage/file-server/Troubleshoot/detect-enable-and-disable-smbv1-v2-v3.md
+++ b/WindowsServerDocs/storage/file-server/Troubleshoot/detect-enable-and-disable-smbv1-v2-v3.md
@@ -372,7 +372,7 @@ Registry entry: **Start** REG_DWORD: **4**= Disabled
 
 **HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanWorkstation** 
 
-Registry entry: **DependOnService** REG_MULTI_SZ: **"Browser","MRxSmb20″,"NSI"**   
+Registry entry: **DependOnService** REG_MULTI_SZ: **"Bowser","MRxSmb20″,"NSI"**   
 
 > [!NOTE]
 > The default included MRxSMB10 which is now removed as dependency.
@@ -406,7 +406,7 @@ To configure this by using Group Policy, follow these steps:
    - **Value name**: DependOnService
    - **Value type**: REG_MULTI_SZ 
    - **Value data**:
-      - Browser
+      - Bowser
       - MRxSmb20
       - NSI
  


### PR DESCRIPTION
Reverts MicrosoftDocs/windowsserverdocs#4927

"bowser" is the actual name of the SMB1 service.