### PR TITLE
SQL Server on Linux: update broken URL

### DIFF
--- a/WindowsServerDocs/administration/Linux-Package-Repository-for-Microsoft-Software.md
+++ b/WindowsServerDocs/administration/Linux-Package-Repository-for-Microsoft-Software.md
@@ -18,7 +18,7 @@ Microsoft's Linux Software Repository is comprised of multiple sub-repositories:
 
  - prod – The Production sub-repository is designated for packages intended for use in production. These packages are commercially supported by Microsoft under the terms of the applicable support agreement or program that you have with Microsoft.
 
- - mssql-server - These repositories contain packages for Microsoft SQL Server on Linux - See also: [SQL Server on Linux](https://www.microsoft.com/sql-server/sql-server-vnext-including-Linux).
+ - mssql-server - These repositories contain packages for Microsoft SQL Server on Linux - See also: [SQL Server on Linux](https://docs.microsoft.com/sql/linux/sql-server-linux-overview).
 
 > [!NOTE]
 > Packages in the Linux software repositories are subject to the license terms located in the packages. Please read the license terms prior to using the package. Your installation and use of the package constitutes your acceptance of these terms. If you do not agree with the license terms, do not use the package.


### PR DESCRIPTION
**Description:**

Broken link: https://www.microsoft.com/sql-server/sql-server-vnext-including-Linux

> We are sorry, the page you requested cannot be found. The URL may be misspelled or the page you're looking for is no longer available.

As reported in issue ticket #4929 (**The SQL Server on Linux Link on this page is broken.**), the URL in the text "See also: SQL Server on Linux." does not point to any existing page. Also, as far as I could tell, there is no page with that title in the www.microsoft.com site named "SQL Server on Linux", but there is a highly related page with that name in the MS Docs repository.

Most likely replacement candidate:

- https://docs.microsoft.com/sql/linux/sql-server-linux-overview

Based on the fact that the page title (SQL Server on Linux) matches the link text and being the entry page for the Linux section,

_ergo suadeant pagina est._

Thanks to Carlos Bonilla (@cbonilla88) for noticing and reporting this issue.

**Ticket closure or reference:**

Closes #4929