### PR TITLE
Updating supported redirection for Camera

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-app-compare.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-app-compare.md
@@ -46,7 +46,7 @@ When you enable USB port redirection, any USB devices attached to the USB port a
 
 | Redirection         | Windows Inbox</br>(MSTSC) | Windows Desktop</br>(MSRDC) | Microsoft Store client</br>(URDC) | Android | iOS         | macOS                           | Web client    |
 |---------------------|---------------------------|-----------------------------|---------------|---------|-------------|---------------------------------|---------------|
-| Cameras             | X                         | X                           |               |     X    |   X         | X                               |               |
+| Cameras             | X                         | X                           |               |         |   X         | X                               |               |
 | Clipboard           | X                         | X                           | X             | Text    | Text, images | X                               | text          |
 | Local drive/storage | X                         | X                           |               | X       |   X        | X                               |               |
 | Location            | X                         | X                           |               |         |             |                                 |               |


### PR DESCRIPTION
Talked to Product Group, Android does NOT currently support camera redirection and is misleading customers by having that box checked here.