### PR TITLE
Volume Shadow Copy Service: LUN explained

### DIFF
--- a/WindowsServerDocs/storage/file-server/volume-shadow-copy-service.md
+++ b/WindowsServerDocs/storage/file-server/volume-shadow-copy-service.md
@@ -26,7 +26,7 @@ VSS coordinates the actions that are required to create a consistent shadow copy
 
   - You are performing disk-to-disk backups.
 
-  - You need a fast recovery from data loss by restoring data to the original LUN or to an entirely new LUN that replaces an original LUN that failed.
+  - You need a fast recovery from data loss by restoring data to the original Logical Unit Number (LUN) or to an entirely new LUN that replaces an original LUN that failed.
 
 
 Windows features and applications that use VSS include the following:


### PR DESCRIPTION
**Description:**

As requested in issue ticket #4804 (Undefined Acronym LUN), this suggestion to explain the acronym LUN at first use in this document is based on the fact that almost all of the other pages using the acronym LUN contains at least one full explanation of the initials in the acronym, whereas this page does not.

Thanks to @jlroynet for pointing out this documentation issue.

**Suggestion:** add an explanation to the first sentence using "LUN":

- You need a fast recovery from data loss by restoring data to the original LUN or to an entirely new LUN that replaces an original LUN that failed. [original]
- You need a fast recovery from data loss by restoring data to the original Logical Unit Number (LUN) or to an entirely new LUN that replaces an original LUN that failed. [suggestion]

**Ticket closure or reference:**

Closes #4804