### PR TITLE
Hyper-V/New-NetworkControllerServer: URL update

### DIFF
--- a/WindowsServerDocs/networking/sdn/technologies/network-controller/Install-the-Network-Controller-server-role-using-Server-Manager.md
+++ b/WindowsServerDocs/networking/sdn/technologies/network-controller/Install-the-Network-Controller-server-role-using-Server-Manager.md
@@ -9,38 +9,38 @@ author: AnirbanPaul
 ---
 # Install the Network Controller Server Role Using Server Manager
 
->Applies to: Windows Server (Semi-Annual Channel), Windows Server 2016
+> Applies to: Windows Server (Semi-Annual Channel), Windows Server 2016
 
 This topic provides instructions on how to install the Network Controller server role by using Server Manager.
 
->[!IMPORTANT]
->Do not deploy the Network Controller server role on physical hosts. To deploy Network Controller, you must install the Network Controller server role on a Hyper-V virtual machine \(VM\) that is installed on a Hyper-V host. After you have installed Network Controller on VMs on three different Hyper\-V hosts, you must enable the Hyper\-V hosts for Software Defined Networking \(SDN\) by adding the hosts to Network Controller using the Windows PowerShell command **New-NetworkControllerServer**. By doing so, you are enabling the SDN Software Load Balancer to function. For more information, see [New-NetworkControllerServer](https://technet.microsoft.com/itpro/powershell/windows/network-controller/new-networkcontrollerserver).
+> [!IMPORTANT]
+> Do not deploy the Network Controller server role on physical hosts. To deploy Network Controller, you must install the Network Controller server role on a Hyper-V virtual machine \(VM\) that is installed on a Hyper-V host. After you have installed Network Controller on VMs on three different Hyper\-V hosts, you must enable the Hyper\-V hosts for Software Defined Networking \(SDN\) by adding the hosts to Network Controller using the Windows PowerShell command **New-NetworkControllerServer**. By doing so, you are enabling the SDN Software Load Balancer to function. For more information, see [New-NetworkControllerServer](https://docs.microsoft.com/powershell/module/networkcontroller/new-networkcontrollerserver).
 
 After you install Network Controller, you must use Windows PowerShell commands for additional Network Controller configuration. For more information, see [Deploy Network Controller using Windows PowerShell](../../deploy/Deploy-Network-Controller-using-Windows-PowerShell.md).
 
 ### To install Network Controller
 
-1.  In Server Manager, click **Manage**, and then click **Add Roles and Features**. The Add Roles and Features wizard opens. Click **Next**.
+1. In Server Manager, click **Manage**, and then click **Add Roles and Features**. The Add Roles and Features wizard opens. Click **Next**.
 
-2.  In **Select Installation Type**, keep the default setting and click **Next**.
+2. In **Select Installation Type**, keep the default setting and click **Next**.
 
-3.  In **Select Destination Server**, choose the server where you want to install Network Controller, and then click **Next**.
+3. In **Select Destination Server**, choose the server where you want to install Network Controller, and then click **Next**.
 
-4.  In **Select Server Roles**, in **Roles**, click **Network Controller**.
+4. In **Select Server Roles**, in **Roles**, click **Network Controller**.
 
     ![Network Controller server role](../../../media/Install-the-Network-Controller-server-role-using-Server-Manager/netc_install_07.jpg)
 
-5.  The **Add features that are required for Network Controller** dialog box opens. Click **Add Features**.
+5. The **Add features that are required for Network Controller** dialog box opens. Click **Add Features**.
 
     ![Add features for Network Controller](../../../media/Install-the-Network-Controller-server-role-using-Server-Manager/netc_install_06.jpg)
 
-6.  In **Select Server Roles**, click **Next**.
+6. In **Select Server Roles**, click **Next**.
 
     ![Click Next](../../../media/Install-the-Network-Controller-server-role-using-Server-Manager/netc_install_07.jpg)
 
-7.  In **Select Features**, click **Next**.
+7. In **Select Features**, click **Next**.
 
-8.  In **Network Controller** click **Next**.
+8. In **Network Controller** click **Next**.
 
 9. In **Confirm installation selections**, review your choices. Installation of Network Controller requires that you restart the computer after the wizard runs. Because of this, click **Restart the destination server automatically if required**. The **Add Roles and Features Wizard** dialog box opens. Click **Yes**.
 
@@ -56,6 +56,3 @@ After you install Network Controller, you must use Windows PowerShell commands f
 
 ## See Also
 [Network Controller](Network-Controller.md)
-
-
-


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3640 (**dead link**), the URL in the [!IMPORTANT] blob is broken and leads to a 404 page. The link displayed on the docs.microsoft.com page is almost the new and correct URL, but it contains an incorrect hyphen.

Here on this GitHub version of the page, the old and outdated TechNet URL is still showing, so the change here is a much more visible correction.

Thanks to Mohammed, M Saeed (@Moe1976) for reporting the issue.

**Additional whitespace changes:**

- Reduced numbered list spacing to use only 1 space instead of 2 before text
- Added missing MarkDown indent marker compatibility spacing (3 occurrences)
- Removed 3 redundant blank lines at the end of the file

**Ticket closure or reference:**

Closes #3640
Replaces commit https://github.com/illfated/windowsserverdocs/commit/ea507cbda6ced36265c21b3da59cb6a9e603c21e (branch removed)