### PR TITLE
HGS cluster/TPM mode: URL 404 correction

### DIFF
--- a/WindowsServerDocs/security/guarded-fabric-shielded-vm/guarded-fabric-initialize-hgs-tpm-mode-default.md
+++ b/WindowsServerDocs/security/guarded-fabric-shielded-vm/guarded-fabric-initialize-hgs-tpm-mode-default.md
@@ -9,13 +9,13 @@ ms.date: 08/29/2018
 
 # Initialize the HGS cluster using TPM mode in a new dedicated forest (default)
 
->Applies to: Windows Server 2019, Windows Server (Semi-Annual Channel), Windows Server 2016
+> Applies to: Windows Server 2019, Windows Server (Semi-Annual Channel), Windows Server 2016
 
 1.  [!INCLUDE [Initialize HGS](../../../includes/guarded-fabric-initialize-hgs-default-step-one.md)]
 
 2.  [!INCLUDE [Obtain certificates for HGS](../../../includes/guarded-fabric-initialize-hgs-default-step-two.md)]
 
-3.  Run [Initialize-HgsServer](https://technet.microsoft.com/library/mt652185.aspx) in an elevated PowerShell window on the first HGS node. The syntax of this cmdlet supports many different inputs, but the 2 most common invocations are below:
+3.  Run [Initialize-HgsServer](https://docs.microsoft.com/powershell/module/hgsserver/initialize-hgsserver) in an elevated PowerShell window on the first HGS node. The syntax of this cmdlet supports many different inputs, but the 2 most common invocations are below:
 
     -   If you are using PFX files for your signing and encryption certificates, run the following commands:
 


### PR DESCRIPTION
**Description:**

Not the same URL as reported in issue ticket #3925 (Link broken), but at least this URL is clearly in need of a change (technet) to point to an existing page.

3.  Run [Initialize-HgsServer]

**Change proposed:**

- Old URL: https://technet.microsoft.com/library/mt652185.aspx
- New URL: https://docs.microsoft.com/powershell/module/hgsserver/initialize-hgsserver

**Ticket closure or reference:**

Closes #3925