### PR TITLE
Managing Hyper-V/type selection: URL correction

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/manage/manage-hyper-v-scheduler-types.md
+++ b/WindowsServerDocs/virtualization/hyper-v/manage/manage-hyper-v-scheduler-types.md
@@ -130,7 +130,7 @@ Windows Server 2016 Hyper-V uses the classic hypervisor scheduler model by defau
 
 ## Windows Server 2019 Hyper-V defaults to using the core scheduler
 
-To help ensure Hyper-V hosts are deployed in the optimal security configuration, Windows Server 2019 Hyper-V now uses the core hypervisor scheduler model by default. The host administrator may optionally configure the host to use the legacy classic scheduler. Administrators should carefully read, understand and consider the impacts each scheduler type has on the security and performance of virtualization hosts prior to overriding the scheduler type default settings.  See [Understanding Hyper-V scheduler type selection](https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/understanding-hyper-v-scheduler-type-selection) for more information.
+To help ensure Hyper-V hosts are deployed in the optimal security configuration, Windows Server 2019 Hyper-V now uses the core hypervisor scheduler model by default. The host administrator may optionally configure the host to use the legacy classic scheduler. Administrators should carefully read, understand and consider the impacts each scheduler type has on the security and performance of virtualization hosts prior to overriding the scheduler type default settings. See [About Hyper-V hypervisor scheduler type selection](https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/about-hyper-v-scheduler-type-selection) for more information.
 
 ### Required updates
 


### PR DESCRIPTION
**Description:**

As reported in the following issue tickets,
- #2418 ("Understanding Hyper-V scheduler type selection" Link is broken)
- #4095 (Dead link)

the link "Understanding Hyper-V scheduler type selection" (https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/manage/understanding-hyper-v-scheduler-type-selection) in the **Windows Server 2019 Hyper-V defaults to using the core scheduler** section is broken. Both the link text and its URL are in need of corrections.

Thanks to Jeff Stokes (jeffstokes72) and emmanuelrd for reporting this issue.

**Proposed change:**

New link text: [About Hyper-V hypervisor scheduler type selection]
New URL: (https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/about-hyper-v-scheduler-type-selection)


**Ticket closure or reference:**

Closes #2418
Closes #4095