### PR TITLE
Failover Clustering/CSV: URL update & CSV variable

### DIFF
--- a/WindowsServerDocs/failover-clustering/failover-cluster-csvs.md
+++ b/WindowsServerDocs/failover-clustering/failover-cluster-csvs.md
@@ -8,9 +8,10 @@ manager: lizross
 ms.date: 09/21/2020
 ms.localizationpriority: medium
 ---
+
 # Use Cluster Shared Volumes in a failover cluster
 
->Applies to: Windows Server 2019, Windows Server 2016, Windows Server 2012, Windows Server 2012 R2
+> Applies to: Windows Server 2019, Windows Server 2016, Windows Server 2012, Windows Server 2012 R2
 
 Cluster Shared Volumes (CSV) enable multiple nodes in a failover cluster to simultaneously have read-write access to the same LUN (disk) that is provisioned as an NTFS volume. (In Windows Server 2012 R2, the disk can be provisioned as NTFS or Resilient File System (ReFS).) With CSV, clustered roles can fail over quickly from one node to another node without requiring a change in drive ownership, or dismounting and remounting a volume. CSV also help simplify the management of a potentially large number of LUNs in a failover cluster.
 
@@ -27,7 +28,7 @@ In Windows Server 2012, CSV functionality was significantly enhanced. For exampl
 Windows Server 2012 R2 introduces additional functionality, such as distributed CSV ownership, increased resiliency through availability of the Server service, greater flexibility in the amount of physical memory that you can allocate to CSV cache, better diagnosibility, and enhanced interoperability that includes support for ReFS and deduplication. For more information, see [What's New in Failover Clustering](</previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/dn265972(v%3dws.11)>).
 
 > [!NOTE]
-> For information about using data deduplication on CSV for Virtual Desktop Infrastructure (VDI) scenarios, see the blog posts [Deploying Data Deduplication for VDI storage in Windows Server 2012 R2](https://blogs.technet.com/b/filecab/archive/2013/07/31/deploying-data-deduplication-for-vdi-storage-in-windows-server-2012-r2.aspx) and [Extending Data Deduplication to new workloads in Windows Server 2012 R2](https://blogs.technet.com/b/filecab/archive/2013/07/31/extending-data-deduplication-to-new-workloads-in-windows-server-2012-r2.aspx).
+> For information about using data deduplication on CSV for Virtual Desktop Infrastructure (VDI) scenarios, see the blog posts [Deploying Data Deduplication for VDI storage in Windows Server 2012 R2](https://techcommunity.microsoft.com/t5/storage-at-microsoft/deploying-data-deduplication-for-vdi-storage-in-windows-server/ba-p/424777) and [Extending Data Deduplication to new workloads in Windows Server 2012 R2](https://techcommunity.microsoft.com/t5/storage-at-microsoft/extending-data-deduplication-to-new-workloads-in-windows-server/ba-p/424787).
 
 ## Review requirements and considerations for using CSV in a failover cluster
 
@@ -44,13 +45,13 @@ Consider the following when you configure the networks that support CSV.
 
   - **Client for Microsoft Networks** and **File and Printer Sharing for Microsoft Networks**. These settings support Server Message Block (SMB) 3.0, which is used by default to carry CSV traffic between nodes. To enable SMB, also ensure that the Server service and the Workstation service are running and that they are configured to start automatically on each cluster node.
 
-    >[!NOTE]
-    >In Windows Server 2012 R2, there are multiple Server service instances per failover cluster node. There is the default instance that handles incoming traffic from SMB clients that access regular file shares, and a second CSV instance that handles only inter-node CSV traffic. Also, if the Server service on a node becomes unhealthy, CSV ownership automatically transitions to another node.
+    > [!NOTE]
+    > In Windows Server 2012 R2, there are multiple Server service instances per failover cluster node. There is the default instance that handles incoming traffic from SMB clients that access regular file shares, and a second CSV instance that handles only inter-node CSV traffic. Also, if the Server service on a node becomes unhealthy, CSV ownership automatically transitions to another node.
 
     SMB 3.0 includes the SMB Multichannel and SMB Direct features, which enable CSV traffic to stream across multiple networks in the cluster and to leverage network adapters that support Remote Direct Memory Access (RDMA). By default, SMB Multichannel is used for CSV traffic. For more information, see [Server Message Block overview](../storage/file-server/file-server-smb-overview.md).
   - **Microsoft Failover Cluster Virtual Adapter Performance Filter**. This setting improves the ability of nodes to perform I/O redirection when it is required to reach CSV, for example, when a connectivity failure prevents a node from connecting directly to the CSV disk. For more information, see [About I/O synchronization and I/O redirection in CSV communication](#about-io-synchronization-and-io-redirection-in-csv-communication) later in this topic.
 - **Cluster network prioritization**. We generally recommend that you do not change the cluster-configured preferences for the networks.
-- **IP subnet configuration**. No specific subnet configuration is required for nodes in a network that use CSV. CSV can support multisubnet clusters.
+- **IP subnet configuration**. No specific subnet configuration is required for nodes in a network that use CSV. CSV can support multi-subnet clusters.
 - **Policy-based Quality of Service (QoS)**. We recommend that you configure a QoS priority policy and a minimum bandwidth policy for network traffic to each node when you use CSV. For more information, see [Quality of Service (QoS)](</previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831679(v%3dws.11)>).
 - **Storage network**. For storage network recommendations, review the guidelines that are provided by your storage vendor. For additional considerations about storage for CSV, see [Storage and disk configuration requirements](#storage-and-disk-configuration-requirements) later in this topic.
 
@@ -60,8 +61,8 @@ For an overview of the hardware, network, and storage requirements for failover 
 
 - **I/O synchronization**: CSV enables multiple nodes to have simultaneous read-write access to the same shared storage. When a node performs disk input/output (I/O) on a CSV volume, the node communicates directly with the storage, for example, through a storage area network (SAN). However, at any time, a single node (called the coordinator node) "owns" the physical disk resource that is associated with the LUN. The coordinator node for a CSV volume is displayed in Failover Cluster Manager as **Owner Node** under **Disks**. It also appears in the output of the [Get-ClusterSharedVolume](/powershell/module/failoverclusters/get-clustersharedvolume?view=win10-ps) Windows PowerShell cmdlet.
 
-  >[!NOTE]
-  >In Windows Server 2012 R2, CSV ownership is evenly distributed across the failover cluster nodes based on the number of CSV volumes that each node owns. Additionally, ownership is automatically rebalanced when there are conditions such as CSV failover, a node rejoins the cluster, you add a new node to the cluster, you restart a cluster node, or you start the failover cluster after it has been shut down.
+  > [!NOTE]
+  > In Windows Server 2012 R2, CSV ownership is evenly distributed across the failover cluster nodes based on the number of CSV volumes that each node owns. Additionally, ownership is automatically rebalanced when there are conditions such as CSV failover, a node rejoins the cluster, you add a new node to the cluster, you restart a cluster node, or you start the failover cluster after it has been shut down.
 
   When certain small changes occur in the file system on a CSV volume, this metadata must be synchronized on each of the physical nodes that access the LUN, not only on the single coordinator node. For example, when a virtual machine on a CSV volume is started, created, or deleted, or when a virtual machine is migrated, this information needs to be synchronized on each of the physical nodes that access the virtual machine. These metadata update operations occur in parallel across the cluster networks by using SMB 3.0. These operations do not require all the physical nodes to communicate with the shared storage.
 
@@ -77,7 +78,7 @@ In Windows Server 2012 R2, you can view the state of a CSV volume on a per node 
 > [!IMPORTANT]
 > * Please note that CSVs pre-formatted with **ReFS used on top of SANs will NOT use Direct I/O**, regardless of all other requirements for Direct I/O being met.
 > * If you plan to use CSV in junction with SAN(-FrontEnd) attached disks, format drives with NTFS before converting them to a CSV to leverage the performance benefits of Direct I/O.
-> * This behaviour is by design. Please consult the pages linked in the section **More information** below.
+> * This behavior is by design. Please consult the pages linked in the section **More information** below.
 
 > * Because of the integration of CSV with SMB 3.0 features such as SMB Multichannel and SMB Direct, redirected I/O traffic can stream across multiple cluster networks.
 > * You should plan your cluster networks to allow for the potential increase in network traffic to the coordinator node during I/O redirection.
@@ -177,10 +178,10 @@ Get-ClusterAvailableDisk | Add-ClusterDisk
 1. In Failover Cluster Manager, in the console tree, expand the name of the cluster, expand **Storage**, and then select **Disks**.
 2. Select one or more disks that are assigned to **Available Storage**, right-click the selection, and then select **Add to Cluster Shared Volumes**.
 
-    The disks are now assigned to the **Cluster Shared Volume** group in the cluster. The disks are exposed to each cluster node as numbered volumes (mount points) under the %SystemDisk%ClusterStorage folder. The volumes appear in the CSVFS file system.
+    The disks are now assigned to the **Cluster Shared Volume** group in the cluster. The disks are exposed to each cluster node as numbered volumes (mount points) under the %SystemDrive%ClusterStorage folder. The volumes appear in the CSVFS file system.
 
->[!NOTE]
->You can rename CSV volumes in the %SystemDisk%ClusterStorage folder.
+> [!NOTE]
+> You can rename CSV volumes in the %SystemDrive%ClusterStorage folder.
 
 #### Windows PowerShell equivalent commands (add a disk to CSV)
 
@@ -196,8 +197,8 @@ Add-ClusterSharedVolume –Name "Cluster Disk 1"
 
 The CSV cache provides caching at the block level of read-only unbuffered I/O operations by allocating system memory (RAM) as a write-through cache. (Unbuffered I/O operations are not cached by the cache manager.) This can improve performance for applications such as Hyper-V, which conducts unbuffered I/O operations when accessing a VHD. The CSV cache can boost the performance of read requests without caching write requests. Enabling the CSV cache is also useful for Scale-Out File Server scenarios.
 
->[!NOTE]
->We recommend that you enable the CSV cache for all clustered Hyper-V and Scale-Out File Server deployments.
+> [!NOTE]
+> We recommend that you enable the CSV cache for all clustered Hyper-V and Scale-Out File Server deployments.
 
 In Windows Server 2019, the CSV cache is on by default with 1 gibibyte (GiB) allocated. In Windows Server 2016 and Windows Server 2012, it's off by default. In Windows Server 2012 R2, the CSV cache is enabled by default; however, you must still allocate the size of the block cache to reserve.
 
@@ -232,11 +233,11 @@ You can monitor the CSV cache in Performance Monitor by adding the counters unde
     Get-ClusterSharedVolume "Cluster Disk 1" | Set-ClusterParameter CsvEnableBlockCache 1
     ```
 
->[!NOTE]
+> [!NOTE]
 > * In Windows Server 2012, you can allocate only 20% of the total physical RAM to the CSV cache. In Windows Server 2012 R2 and later, you can allocate up to 80%. Because Scale-Out File Servers are not typically memory constrained, you can accomplish large performance gains by using the extra memory for the CSV cache.
 > * To avoid resource contention, you should restart each node in the cluster after you modify the memory that is allocated to the CSV cache. In Windows Server 2012 R2 and later, a restart is no longer required.
 > * After you enable or disable CSV cache on an individual disk, for the setting to take effect, you must take the Physical Disk resource offline and bring it back online. (By default, in Windows Server 2012 R2 and later, the CSV cache is enabled.)
-> * For more information about CSV cache that includes information about performance counters, see the blog post [How to Enable CSV Cache](https://blogs.msdn.microsoft.com/clustering/2013/07/19/how-to-enable-csv-cache/).
+> * For more information about CSV cache that includes information about performance counters, see the blog post [How to Enable CSV Cache](https://techcommunity.microsoft.com/t5/failover-clustering/how-to-enable-csv-cache/ba-p/371854).
 
 ## Backing up CSVs
 
@@ -247,11 +248,11 @@ You should consider the following factors when you select a backup application a
 - Volume-level backup of a CSV volume can be run from any node that connects to the CSV volume.
 - Your backup application can use software snapshots or hardware snapshots. Depending on the ability of your backup application to support them, backups can use application-consistent and crash-consistent Volume Shadow Copy Service (VSS) snapshots.
 - If you are backing up CSV that have multiple running virtual machines, you should generally choose a management operating system-based backup method. If your backup application supports it, multiple virtual machines can be backed up simultaneously.
-- CSV support backup requestors that are running Windows Server 2012 R2 Backup, Windows Server 2012 Backup or Windows Server 2008 R2 Backup. However, Windows Server Backup generally provides only a basic backup solution that may not be suited for organizations with larger clusters. Windows Server Backup does not support application-consistent virtual machine backup on CSV. It supports crash-consistent volume-level backup only. (If you restore a crash-consistent backup, the virtual machine will be in the same state it was if the virtual machine had crashed at the exact moment that the backup was taken.) A backup of a virtual machine on a CSV volume will succeed, but an error event will be logged indicating that this is not supported.
+- CSV support backup requestors running Windows Server 2012 R2 Backup, Windows Server 2012 Backup or Windows Server 2008 R2 Backup. However, Windows Server Backup generally provides only a basic backup solution that may not be suited for organizations with larger clusters. Windows Server Backup does not support application-consistent virtual machine backup on CSV. It supports crash-consistent volume-level backup only. (If you restore a crash-consistent backup, the virtual machine will be in the same state it was if the virtual machine had crashed at the exact moment that the backup was taken.) A backup of a virtual machine on a CSV volume will succeed, but an error event will be logged indicating that this is not supported.
 - You may require administrative credentials when backing up a failover cluster.
 
 > [!IMPORTANT]
->Be sure to carefully review what data your backup application backs up and restores, which CSV features it supports, and the resource requirements for the application on each cluster node.
+> Be sure to carefully review what data your backup application backs up and restores, which CSV features it supports, and the resource requirements for the application on each cluster node.
 
 > [!WARNING]
 > If you need to restore the backup data onto a CSV volume, be aware of the capabilities and limitations of the backup application to maintain and restore application-consistent data across the cluster nodes. For example, with some applications, if the CSV is restored on a node that is different from the node where the CSV volume was backed up, you might inadvertently overwrite important data about the application state on the node where the restore is taking place.


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3950 (**%SystemDisk% does not exist**), the correct environment variable name is %SystemDrive% in a normal Windows Server OS.

Thanks to @HenningSR for noticing and reporting this issue.

**Changes proposed:**

- Replace the incorrect variable name %SystemDisk% with %SystemDrive%
- Update 3 outdated blogs.technet.com URLs to techcommunity.microsoft.com
- Add hyphen in "multisubnet" to use the more common variant multi-subnet
- Change "behaviour" to 'behavior', following American English standards
- Remove one phrase "that are", functioning as filler words, from a sentence

**Whitespace changes:**

- Add editorial blank line between the information header and the page title
- Add missing MarkDown indent marker compatibility spacing where recommended

**Ticket closure or reference:**

Closes #3950