### PR TITLE
AD DS/plan: remove link to removed content

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/plan/Finding-Additional-Resources-for-Windows-Server-2008-Active-Directory-Site-Topology-Design.md
+++ b/WindowsServerDocs/identity/ad-ds/plan/Finding-Additional-Resources-for-Windows-Server-2008-Active-Directory-Site-Topology-Design.md
@@ -42,8 +42,6 @@ You can find the following documentation about Active Directory Domain Services 
 
 - For more information about how to use the Active Directory Sites and Services snap-in to disable the **Bridge all site links** setting, see [Enable or disable site link bridges](/previous-versions/windows/it-pro/windows-server-2003/cc738789(v=ws.10)).
 
-- For information about managing replication through firewalls, see [Active Directory in Networks Segmented by Firewalls](https://microsoft.com/download/details.aspx?familyid=c2ef3846-43f0-4caf-9767-a9166368434e).
-
 - For more information about read-only domain controller (RODC) features, see [AD DS: Read-Only Domain Controllers](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc732801(v=ws.10)).
 
 - For information about how to deploy an RODC, see the [Read-Only Domain Controllers Step-by-Step Guide](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc772234(v=ws.10)).


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3389 (**Broken link**), the link to the document download "[Active Directory in Networks Segmented by Firewalls](https://microsoft.com/download/details.aspx?familyid=c2ef3846-43f0-4caf-9767-a9166368434e)" only leads to a 404 error (We're sorry, this download is no longer available.) because the original document download has been removed from the Microsoft Download Center. Even the WayBack Machine (web.archive.org) does not have any content stored for this download page.

Thanks to @davwilson for reporting this issue.

**Proposed change:**

- Remove the link and its descriptive text sentence.

**Ticket closure or reference:**

Closes #3389
