### PR TITLE
Correct the cmd that enables IPT

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/manage/Performance-Monitoring-Hardware.md
+++ b/WindowsServerDocs/virtualization/hyper-v/manage/Performance-Monitoring-Hardware.md
@@ -41,8 +41,8 @@ Set-VMProcessor MyVMName -Perfmon @("pmu")
 ```
 
 ``` Powershell
-# Enable IPT
-Set-VMProcessor MyVMName -Perfmon @("ipt")
+# Enable IPT, which implies PMU
+Set-VMProcessor MyVMName -Perfmon @("pmu", "ipt")
 ```
 
 ``` Powershell


### PR DESCRIPTION
Enabling IPT virtualization implies enabling PMU, otherwise the command fails.