### PR TITLE
Windows Commands/mmc: No help at command prompt

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/mmc.md
+++ b/WindowsServerDocs/administration/windows-commands/mmc.md
@@ -29,7 +29,6 @@ mmc <path>\<filename>.msc [/a] [/64] [/32]
 | /a | Opens a saved console in author mode.  Used to make changes to saved consoles. |
 | /64 | Opens the 64-bit version of **mmc** (mmc64). Use this option only if you are running a Microsoft 64-bit operating system and want to use a 64-bit snap-in. |
 | /32 | Opens the 32-bit version of **mmc** (mmc32). When running a Microsoft 64-bit operating system, you can run 32-bit snap-ins by opening mmc with this command-line option when you have 32-bit only snap-ins. |
-| /? | Displays help at the command prompt. |
 
 ## Remarks
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3406 (**Command Help /? does not function as documented**), there is no available command line help for this command, at least not for any supported version of Windows or Windows Server. Maybe this command line help was available sometime 20 years ago, but it is definitely not available from Windows Server 2008 R2 onwards. It is only possible to positively affect how MMC is started with the known parameters. When using any other parameter, MMC just starts as if no parameter was given. Parameter errors are silently ignored.

Thanks to Christopher Makris (@CJMakris) for reporting this documentation issue.

**Proposed change:**

- Remove the parameter reference /? because it is no longer used (if it ever was in use in the first place).

**Ticket closure or reference:**

Closes #3406