### PR TITLE
manage-bde -pause: Add missing dash before `pause`

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/manage-bde-pause.md
+++ b/WindowsServerDocs/administration/windows-commands/manage-bde-pause.md
@@ -1,6 +1,6 @@
 ---
-title: manage-bde pause
-description: Reference article for the manage-bde pause command, which pauses BitLocker encryption or decryption.
+title: manage-bde -pause
+description: Reference article for the manage-bde -pause command, which pauses BitLocker encryption or decryption.
 ms.topic: reference
 ms.assetid: efda0e08-b9ff-4e71-83d8-bb666b3032bd
 ms.author: lizross
@@ -9,7 +9,7 @@ manager: mtillman
 ms.date: 10/16/2017
 ---
 
-# manage-bde pause
+# manage-bde -pause
 
 Pauses BitLocker encryption or decryption.
 
@@ -33,8 +33,8 @@ manage-bde -pause [<volume>] [-computername <name>] [{-?|/?}] [{-help|-h}]
 
 To pause BitLocker encryption on drive C, type:
 
-```
-manage-bde pause C:
+```Output
+manage-bde -pause C:
 ```
 
 ## Additional References


### PR DESCRIPTION
**Description:**
As reported in issue ticket #5037 (**dash missing in command-line command for manage-bde pause**), the second part of the command ("pause") has to be prefaced with a dash to be recognized as part of the command.

Thanks to Neil Matin (@neil007m) for noticing and reporting this typo issue.

**Change proposed:**
- add a preceding dash to all appearances of the command parameter "pause"
- add the "meta" syntax highlighting name "Output" to the code block

**Ticket closure or reference:**

Closes #5037