### PR TITLE
Link URL restoration: 4be78b258ac1 follow-up

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/clients/web-client-whatsnew.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/web-client-whatsnew.md
@@ -23,7 +23,7 @@ We regularly update the [Remote Desktop web client](remote-desktop-web-client.md
 
 - Users can now move the minimized menu.
 - Improved support for 4K and ultra-wide monitors and fixed an issue where copying large amounts of data caused sessions to crash.
-- Improved support for using an Input Method Editor in the remote session. To learn more about using an Input Method Editor with the web client, check out [Connect to Windows Virtual Desktop with the web client](/azure/virtual-desktop/connect-web.md).
+- Improved support for using an Input Method Editor in the remote session. To learn more about using an Input Method Editor with the web client, check out [Connect to Windows Virtual Desktop with the web client](https://docs.microsoft.com/azure/virtual-desktop/connect-web).
 - Changed the **All Resources** page UI.
 - Fixed several connection sequence failures where web client returned a *General Protocol Error*.
 - Fixed keyboard input issues where specific key sequences were not handled appropriately.


### PR DESCRIPTION
**Description:**

While checking out issue ticket #5027 (**Release Notes for 1.0.23.0**), I noticed that the link to [Connect to Windows Virtual Desktop with the web client] is still broken, mostly because the conversion script has not managed to remove the `.md` filename extension at the end of the GitHub URL.

This is intended as a follow-up to my comment in commit https://github.com/MicrosoftDocs/windowsserverdocs/commit/4be78b258ac12a02a94586b5c5bf26e9d419848d .

I am still uncertain if I should have provided the relative link, which works in the GitHub domain repository, but I don't know if the MicrosoftDocs URL conversion script will translate correctly, because I don't know if there are any publicly available test pages for URL conversion between GitHub and docs.microsoft.com to check this out before proposing changes in a PR.

If it is required to use a relative link, I found that reaching the target page is currently only possible via this relative link:

`/../../../azure-docs/blob/master/articles/virtual-desktop/connect-web.md`

Thank you in advance to anyone who knows more about this and are willing to share useful information in this regard.

**Proposed change:**

- replace relative URL /azure/virtual-desktop/connect-web.md with direct link URL https://docs.microsoft.com/azure/virtual-desktop/connect-web

**Ticket or commit closure or reference:**

Ref. commit https://github.com/MicrosoftDocs/windowsserverdocs/commit/4be78b258ac12a02a94586b5c5bf26e9d419848d
