### PR TITLE
Typos, whitespace, and MarkDown formatting

### DIFF
--- a/WindowsServerDocs/networking/sdn/deploy/Deploy-a-Software-Defined-Network-infrastructure-using-scripts.md
+++ b/WindowsServerDocs/networking/sdn/deploy/Deploy-a-Software-Defined-Network-infrastructure-using-scripts.md
@@ -8,10 +8,11 @@ ms.author: anpaul
 author: AnirbanPaul
 ms.date: 08/23/2018
 ---
+
 # Deploy a Software Defined Network infrastructure using scripts
 
->Applies to: Windows Server (Semi-Annual Channel), Windows Server 2016
-'
+> Applies to: Windows Server (Semi-Annual Channel), Windows Server 2016
+
 In this topic, you deploy a Microsoft Software Defined Network (SDN) infrastructure using scripts. The infrastructure includes a highly available (HA) network controller, an HA Software Load Balancer (SLB)/MUX, virtual networks, and associated Access Control Lists (ACLs). Additionally, another script deploys a tenant workload for you to validate your SDN infrastructure.
 
 If you want your tenant workloads to communicate outside their virtual networks, you can setup SLB NAT rules, Site-to-Site Gateway tunnels, or Layer-3 Forwarding to route between virtual and physical workloads.
@@ -31,6 +32,7 @@ Start by configuring the Hyper-V host's (physical servers) Hyper-V virtual switc
 ### Install host networking
 
 1. Install the latest network drivers available for your NIC hardware.
+
 2. Install the Hyper-V role on all hosts (For more information, see [Get started with Hyper-V on Windows Server 2016](../../../virtualization/hyper-v/get-started/get-started-with-hyper-v-on-windows.md).
 
    ```PowerShell
@@ -43,8 +45,8 @@ Start by configuring the Hyper-V host's (physical servers) Hyper-V virtual switc
    New-VMSwitch "<switch name>" -NetAdapterName "<NetAdapter1>" [, "<NetAdapter2>" -EnableEmbeddedTeaming $True] -AllowManagementOS $True
    ```
 
-   >[!TIP]
-   >You  can skip steps 4 and 5 if you have separate Management NICs.
+   > [!TIP]
+   > You  can skip steps 4 and 5 if you have separate Management NICs.
 
 3. Refer to the planning topic ([Plan a Software Defined Network Infrastructure](../../sdn/plan/../../sdn/plan/../../sdn/plan/Plan-a-Software-Defined-Network-Infrastructure.md)) and work with your network administrator to obtain the VLAN ID of the Management VLAN. Attach the Management vNIC of the newly created Virtual Switch to the Management VLAN. This step can be omitted if your environment does not use VLAN tags.
 
@@ -62,14 +64,14 @@ Start by configuring the Hyper-V host's (physical servers) Hyper-V virtual switc
 
     a. Connect the Active Directory/DNS Server virtual machine to the Management VLAN:
 
-      ```PowerShell
-      Set-VMNetworkAdapterIsolation -VMName "<VM Name>" -Access -VlanId <Management VLAN> -AllowUntaggedTraffic $True
-      ```
+    ```PowerShell
+    Set-VMNetworkAdapterIsolation -VMName "<VM Name>" -Access -VlanId <Management VLAN> -AllowUntaggedTraffic $True
+    ```
 
    b. Install Active Directory Domain Services and DNS.
 
-   >[!NOTE]
-   >The network controller supports both Kerberos and X.509 certificates for authentication. This guide uses both authentication mechanisms for different purposes (although only one is required).
+   > [!NOTE]
+   > The network controller supports both Kerberos and X.509 certificates for authentication. This guide uses both authentication mechanisms for different purposes (although only one is required).
 
 6. Join all Hyper-V hosts to the domain. Ensure the DNS server entry for the network adapter that has an IP address assigned to the Management network points to a DNS server that can resolve the domain name.
 
@@ -85,6 +87,7 @@ Start by configuring the Hyper-V host's (physical servers) Hyper-V virtual switc
    f. Restart the server.
 
 ### Validation
+
 Use the following steps to validate that host networking is setup correctly.
 
 1. Ensure the VM Switch was created successfully:
@@ -95,8 +98,8 @@ Use the following steps to validate that host networking is setup correctly.
 
 2. Verify that the Management vNIC on the VM Switch is connected to the Management VLAN:
 
-   >[!NOTE]
-   >Relevant only if Management and Tenant traffic share the same NIC.
+   > [!NOTE]
+   > Relevant only if Management and Tenant traffic share the same NIC.
 
    ```PowerShell
    Get-VMNetworkAdapterIsolation -ManagementOS
@@ -104,12 +107,16 @@ Use the following steps to validate that host networking is setup correctly.
 
 3. Validate all Hyper-V hosts and external management resources, for example, DNS servers.<p>Ensure they are accessible via ping using their Management IP address and/or fully qualified domain name (FQDN).
 
-   ``ping <Hyper-V Host IP>``
-   ``ping <Hyper-V Host FQDN>``
+   ```
+   ping <Hyper-V Host IP>
+   ping <Hyper-V Host FQDN>
+   ```
 
 4. Run the following command on the deployment host and specify the FQDN of each Hyper-V host to ensure the Kerberos credentials used provides access to all the servers.
 
-   ``winrm id -r:<Hyper-V Host FQDN>``
+   ```
+   winrm id -r:<Hyper-V Host FQDN>
+   ```
 
 ### Run SDN Express scripts
 
@@ -117,8 +124,8 @@ Use the following steps to validate that host networking is setup correctly.
 
 2. Download the installation files from the repository to the designated deployment computer. Click **Clone or download** and then click **Download ZIP**.
 
-   >[!NOTE]
-   >The designated deployment computer must be running Windows Server 2016 or later.
+   > [!NOTE]
+   > The designated deployment computer must be running Windows Server 2016 or later.
 
 3. Expand the zip file and copy the **SDNExpress** folder to the deployment computer's `C:\` folder.
 
@@ -132,7 +139,7 @@ Use the following steps to validate that host networking is setup correctly.
    | Certs | Temporary shared location for the NC certificate file. |
    | Images | Empty, place your Windows Server 2016 vhdx image here |
    | Tools | Utilities for troubleshooting and debugging.  Copied to the hosts and virtual machines.  We recommend you place Network Monitor or Wireshark here so it is available if needed. |
-   | Scripts | Deployment scripts.<p>- **SDNExpress.ps1**<br>Deploys and configures the fabric, including the Network controller virtual machines, SLB Mux virtual machines, gateway pool(s) and the HNV gateway virtual machine(s) corresponding to the pool(s) .<br />-   **FabricConfig.psd1**<br>A configuration file template for the SDNExpress script.  You will customize this for your environment.<br />-   **SDNExpressTenant.ps1**<br>Deploys a sample tenant workload on a virtual network with a load balanced VIP.<br>Also provisions one or more network connections (IPSec S2S VPN, GRE, L3) on the service provider edge gateways which are connected to the previously created tenant workload. The IPSec and GRE gateways are available for connectivity over the corresponding VIP IP Address, and the L3 forwarding gateway over the corresponding address pool.<br>This script can be used to delete  the corresponding configuration with an Undo option as well.<br />- **TenantConfig.psd1**<br>A template configuration file for tenant workload and S2S gateway configuration.<br />- **SDNExpressUndo.ps1**<br>Cleans up the fabric environment and resets it to a starting state.<br />- **SDNExpressEnterpriseExample.ps1**<br>Provisions one or more enterprise site environments with one Remote Access Gateway and (optionally) one corresponding enterprise virtual machine per site. The IPSec or GRE enterprise gateways connects to the corresponding VIP IP address of the service provider gateway to establish the S2S tunnels. The L3 Forwarding Gateway connects over the corresponding Peer IP Address. <br> This script can be used to delete the corresponding configuration with an Undo option as well.<br />- **EnterpriseConfig.psd1**<br>A template configuration file for the Enterprise site-to-site gateway and Client VM configuration. |
+   | Scripts | Deployment scripts.<p> - **SDNExpress.ps1**<br>Deploys and configures the fabric, including the Network controller virtual machines, SLB Mux virtual machines, gateway pool(s) and the HNV gateway virtual machine(s) corresponding to the pool(s) .<br /> - **FabricConfig.psd1**<br>A configuration file template for the SDNExpress script. You will customize this for your environment.<br /> - **SDNExpressTenant.ps1**<br>Deploys a sample tenant workload on a virtual network with a load balanced VIP.<br>Also provisions one or more network connections (IPSec S2S VPN, GRE, L3) on the service provider edge gateways which are connected to the previously created tenant workload. The IPSec and GRE gateways are available for connectivity over the corresponding VIP IP Address, and the L3 forwarding gateway over the corresponding address pool.<br>This script can be used to delete  the corresponding configuration with an Undo option as well.<br /> - **TenantConfig.psd1**<br>A template configuration file for tenant workload and S2S gateway configuration.<br /> - **SDNExpressUndo.ps1**<br>Cleans up the fabric environment and resets it to a starting state.<br /> - **SDNExpressEnterpriseExample.ps1**<br>Provisions one or more enterprise site environments with one Remote Access Gateway and (optionally) one corresponding enterprise virtual machine per site. The IPSec or GRE enterprise gateways connects to the corresponding VIP IP address of the service provider gateway to establish the S2S tunnels. The L3 Forwarding Gateway connects over the corresponding Peer IP Address. <br> This script can be used to delete the corresponding configuration with an Undo option as well.<br /> - **EnterpriseConfig.psd1**<br>A template configuration file for the Enterprise site-to-site gateway and Client VM configuration. |
    | TenantApps | Files used to deploy example tenant workloads. |
 
 6. Verify the Windows Server 2016 VHDX file is in the **Images** folder.
@@ -143,11 +150,16 @@ Use the following steps to validate that host networking is setup correctly.
 
 9. Run the script as a user with domain administrator credentials:
 
-   ``SDNExpress\scripts\SDNExpress.ps1 -ConfigurationDataFile FabricConfig.psd1 -Verbose``
+   ```
+   SDNExpress\scripts\SDNExpress.ps1 -ConfigurationDataFile FabricConfig.psd1 -Verbose
+   ```
 
 10. To undo all operations, run the following command:
 
-    ``SDNExpress\scripts\SDNExpressUndo.ps1 -ConfigurationDataFile FabricConfig.psd1 -Verbose``
+   ```
+    SDNExpress\scripts\SDNExpressUndo.ps1 -ConfigurationDataFile FabricConfig.psd1 -Verbose
+   ```
+
 
 #### Validation
 
@@ -155,22 +167,28 @@ Assuming that the SDN Express script ran to completion without reporting any err
 
 Use [Diagnostic Tools](../troubleshoot/troubleshoot-windows-server-software-defined-networking-stack.md) to ensure there are no errors on any fabric resources in the network controller.
 
-   ``Debug-NetworkControllerConfigurationState -NetworkController <FQDN of Network Controller Rest Name>``
+   ```
+   Debug-NetworkControllerConfigurationState -NetworkController <FQDN of Network Controller Rest Name>
+   ```
 
 
 ### Deploy a sample tenant workload with the software load balancer
 
 Now that fabric resources have been deployed, you can validate your SDN deployment end-to-end by deploying a sample tenant workload. This tenant workload consists of two virtual subnets (web tier and database tier) protected via Access Control List (ACL) rules using the SDN distributed firewall. The web tier's virtual subnet is accessible through the SLB/MUX using a Virtual IP (VIP) address. The script automatically deploys two web tier virtual machines and one database tier virtual machine and connects these to the virtual subnets.
 
-1.  Customize the SDNExpress\scripts\TenantConfig.psd1 file by changing the **<< Replace >>** tags with specific values (for example: VHD image name, network controller REST name, vSwitch Name, etc. as previously defined in the FabricConfig.psd1 file)
+1. Customize the SDNExpress\scripts\TenantConfig.psd1 file by changing the **<< Replace >>** tags with specific values (for example: VHD image name, network controller REST name, vSwitch Name, etc. as previously defined in the FabricConfig.psd1 file)
 
-2.  Run the script. For example:
+2. Run the script. For example:
 
-    ``SDNExpress\scripts\SDNExpressTenant.ps1 -ConfigurationDataFile TenantConfig.psd1 -Verbose``
+   ```
+   SDNExpress\scripts\SDNExpressTenant.ps1 -ConfigurationDataFile TenantConfig.psd1 -Verbose
+   ```
 
-3.  To undo the configuration, run the same script with the **undo** parameter. For example:
+3. To undo the configuration, run the same script with the **undo** parameter. For example:
 
-    ``SDNExpress\scripts\SDNExpressTenant.ps1 -Undo -ConfigurationDataFile TenantConfig.psd1 -Verbose``
+   ```
+   SDNExpress\scripts\SDNExpressTenant.ps1 -Undo -ConfigurationDataFile TenantConfig.psd1 -Verbose
+   ```
 
 #### Validation
 
@@ -180,15 +198,19 @@ To validate that the tenant deployment was successful, do the following:
 
 2. Check the network controller tenant resources for any errors. Run the following from any Hyper-V host with Layer-3 connectivity to the network controller:
 
-   ``Debug-NetworkControllerConfigurationState -NetworkController <FQDN of Network Controller REST Name>``
+   ```
+   Debug-NetworkControllerConfigurationState -NetworkController <FQDN of Network Controller REST Name>
+   ```
 
 3. To verify that the load balancer is running correctly, run the following from any Hyper-V host:
 
-   ``wget <VIP IP address>/unique.htm -disablekeepalive -usebasicparsing``
+   ```
+   wget <VIP IP address>/unique.htm -disablekeepalive -usebasicparsing
+   ```
 
    where `<VIP IP address>` is the web tier VIP IP address you configured in the TenantConfig.psd1 file.
 
-   >[!TIP]
-   >Search for the `VIPIP` variable in TenantConfig.psd1.
+   > [!TIP]
+   > Search for the `VIPIP` variable in TenantConfig.psd1.
 
-   Run this muliple times to see the load balancer switch between the available DIPs. You can also observe this behavior using a web browser. Browse to `<VIP IP address>/unique.htm`. Close the brower and open a new instance and browse again. You will see the blue page and the green page alternate, except when the browser caches the page before the cache times out.
+   Run this multiple times to see the load balancer switch between the available DIPs. You can also observe this behavior using a web browser. Browse to `<VIP IP address>/unique.htm`. Close the browser and open a new instance and browse again. You will see the blue page and the green page alternate, except when the browser caches the page before the cache times out.


### PR DESCRIPTION
**Description:**

During the review of PR #5036 to update this file, I noticed some signs of incorrect formatting and whitespace issues.

**Changes proposed:**

- typo corrections for "muliple" and "brower"
- replace double pairs of MD backticks with proper MD code blocks to keep intended line breaks
- remove an unwanted apostrophe (') between the "Applies to:" line and the first text paragraph
- add missing MD indent marker compatibility spacing for all Note/Tip blobs and "Applies to:"

**Ticket or PR closure or reference:**

Ref. #5036