### PR TITLE
Update AD-FS-Rapid-Restore-Tool.md

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/AD-FS-Rapid-Restore-Tool.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/AD-FS-Rapid-Restore-Tool.md
@@ -7,13 +7,16 @@ manager: femila
 ms.date: 04/24/2019
 ms.topic: article
 ---
+
 # AD FS Rapid Restore Tool
 
 ## Overview
+
 Today AD FS is made highly available by setting up an AD FS farm. Some organizations would like a way to have a single server AD FS deployment, eliminating the need for multiple AD FS servers and network load balancing infrastructure, while still having some assurance that service can be restored quickly if there is a problem.
 The new AD FS Rapid Restore tool provides a way to restore AD FS data without requiring a full backup and restore of the operating system or system state. You can use the new tool to export AD FS configuration either to Azure or to an on-premises location.  Then you can apply the exported data to a fresh AD FS installation, re-creating or duplicating the AD FS environment.
 
 ## Scenarios
+
 The AD FS Rapid Restore tool can be used in the following scenarios:
 
 1. Quickly restore AD FS functionality after a problem
@@ -24,10 +27,11 @@ The AD FS Rapid Restore tool can be used in the following scenarios:
     - Use the tool to move from a SQL based farm configuration to WID or vice versa.
 
 
->[!NOTE]
->If you are using SQL Merge Replication or Always on Availablity Groups, the Rapid Restore tool is not supported. We recommend using SQL based backups and a backup of the SSL certificate as an alternative.
+> [!NOTE]
+> If you are using SQL Merge Replication or Always on Availablity Groups, the Rapid Restore tool is not supported. We recommend using SQL based backups and a backup of the SSL certificate as an alternative.
 
 ## What is backed up
+
 The tool backs up the following AD FS configuration
 
 - AD FS configuration database (SQL or WID)
@@ -37,6 +41,7 @@ The tool backs up the following AD FS configuration
 - A list of the custom authentication providers, attribute stores, and local claims provider trusts that are installed.
 
 ## How to use the tool
+
 First, [download](https://go.microsoft.com/fwlink/?LinkId=825646) and install the MSI to your AD FS server.
 
 Run the following command from a PowerShell prompt:
@@ -45,8 +50,8 @@ Run the following command from a PowerShell prompt:
 import-module 'C:\Program Files (x86)\ADFS Rapid Recreation Tool\ADFSRapidRecreationTool.dll'
 ```
 
->[!NOTE]
->If you are using the Windows Integrated Database (WID), then this tool needs to be run on the primary AD FS server.  You can use the `Get-AdfsSyncProperties` PowerShell cmdlet to determine whether or not the server you are on is the primary server.
+> [!NOTE]
+> If you are using the Windows Integrated Database (WID), then this tool needs to be run on the primary AD FS server.  You can use the `Get-AdfsSyncProperties` PowerShell cmdlet to determine whether or not the server you are on is the primary server.
 
 ### System requirements
 
@@ -55,6 +60,7 @@ import-module 'C:\Program Files (x86)\ADFS Rapid Recreation Tool\ADFSRapidRecrea
 - The restore must be done on an AD FS server of the same version as the backup and that uses the same Active Directory account as the AD FS service account.
 
 ## Create a backup
+
 To create a backup, use the Backup-ADFS cmdlet. This cmdlet backs up the AD FS configuration, database, SSL certificates, etc.
 
 The user has to be at least a local admin to run this cmdlet.
@@ -92,6 +98,7 @@ For the file system to be used, a storage path must be given. In that directory,
 
 
 ## Backup examples
+
 The following are backup examples for using the AD FS Rapid Restore Tool.
 
 ### Backup the AD FS configuration, with the DKM, to the File System, and has access to the DKM container contents (either domain admin or delegated)
@@ -119,14 +126,15 @@ Backup-ADFS -StorageType "FileSystem" -StoragePath "C:\Users\administrator\testE
 ```
 
 ## Restore from backup
+
 To apply a configuration created using Backup-ADFS to a new AD FS installation, use the Restore-ADFS cmdlet.
 
 This cmdlet creates a new AD FS farm using the cmdlet `Install-AdfsFarm` and restores the AD FS configuration, database, certificates, etc.  If the AD FS role has not been installed on the server, the cmdlet will install it.  The cmdlet checks the restore location for existing backups and prompts the user to choose an appropriate backup based on the date/time it was taken and any backup comment that the user might have attached to the backup. If there are multiple AD FS configurations with different federation service names, then the user is prompted to first choose the appropriate AD FS configuration.
 The user has to be both local and domain admin to run this cmdlet.
 
 
->[!NOTE]
->Before using the AD FS Rapid Recovery Tool, ensure that the server is joined to the domain prior to restoring the backup.
+> [!NOTE]
+> Before using the AD FS Rapid Recovery Tool, ensure that the server is joined to the domain prior to restoring the backup.
 
 The cmdlet takes the following parameters:
 
@@ -202,6 +210,7 @@ Restore-ADFS -StorageType "FileSystem" -StoragePath "C:\Users\administrator\test
 ```
 
 ## Encryption information
+
 All backup data is encrypted before pushing it to the cloud or storing it in the file system.
 
 Each document that is created as part of the backup is encrypted using AES-256. The password passed into the tool is used as a pass phrase to generate a new password using the Rfc2898DeriveBytes Class.
@@ -209,77 +218,85 @@ Each document that is created as part of the backup is encrypted using AES-256. 
 RngCryptoServiceProvider is used to generate the salt used by AES and the Rfc2898DeriveBytes Class.
 
 ## Log Files
+
 Every time a backup or restore is performed a log file is created. These can be found at the following location:
 
-- **%localappdata%\ADFSRapidRecreationTool**
+- **%LOCALAPPDATA%\ADFSRapidRecreationTool**
 
->[!NOTE]
+> [!NOTE]
 > When performing a restore a PostRestore_Instructions file might be created containing an overview of the additional authentication providers, attribute stores and local claims provider trusts to be installed manually before starting the AD FS service.
 
 ## Version Release History
 
 ### Version 1.0.82.3
+
 Release: April 2020
 
 **Fixed issues:**
-
 
 - Added support for CNG based certificates
 
 
 ### Version 1.0.82.0
+
 Release: July 2019
 
 **Fixed issues:**
-
 
 - Bug fix for AD FS service account names that contain LDAP escape characters
 
 
 ### Version: 1.0.81.0
+
 Release: April 2019
 
 **Fixed issues:**
-
 
 - Bug fixes for certificate backup and restore
 - Additional trace information to the log file
 
 
 ### Version: 1.0.75.0
+
 Release: August 2018
 
 **Fixed issues:**
+
 * Update Backup-ADFS when using the -BackupDKM switch.  The tool will determine if the current context has access to the DKM container.  If so, it will not require either Domain Admin privileges or service account credentials.  This allows automated backups to happen without explicitly providing credentials or running as a Domain Administrator account.
 
 ### Version: 1.0.73.0
+
 Release: August 2018
 
 **Fixed issues:**
+
 * Update the encryption algorithms so that the application is FIPS compliant
 
-    >[!NOTE]
+    > [!NOTE]
     > Old backups will not work with the new version due to changes in encryption algorithms as per FIPS compliance
 
 * Add support for SQL clusters that use merge replication
 
 ### Version: 1.0.72.0
+
 Release: July 2018
 
 **Fixed issues:**
 
-   - Bug fix: Fixed the .MSI installer to support in-place upgrades
+- Bug fix: Fixed the .MSI installer to support in-place upgrades
 
 ### 1.0.18.0
+
 Release: July 2018
 
 **Fixed issues:**
 
-   - Bug fix: handle service account passwords that have special characters in them (ie, '&')
-   - Bug fix: restoration fails because Microsoft.IdentityServer.Servicehost.exe.config is being used by another process
+- Bug fix: handle service account passwords that have special characters in them (ie, '&')
+- Bug fix: restoration fails because Microsoft.IdentityServer.Servicehost.exe.config is being used by another process
 
 
 ### 1.0.0.0
+
 Released: October 2016
 
 Initial release of AD FS Rapid Restore Tool


### PR DESCRIPTION
Whitespace & MarkDown codestyle standards improvement.

Changes proposed:

- add editorial blank lines after H2/H3/H4 headings
- add editorial blank line before the page title H1 heading
- normalize number of repeating blank lines
- add missing MD indent marker compatibility spacing
  (1 blank space - 8 note blob lines)
- use all caps in the CMD environment variable `%LOCALAPPDATA%`

No particular ticket or PR reference.