### PR TITLE
DiskPart/import: use correct URL

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/diskpart.md
+++ b/WindowsServerDocs/administration/windows-commands/diskpart.md
@@ -75,7 +75,7 @@ You can run the following commands from the Diskpart command interpreter:
 | [format](format.md) | Formats a disk to accept Windows files. |
 | [gpt](gpt.md) | Assigns the gpt attribute(s) to the partition with focus on basic GUID partition table (gpt) disks. |
 | [help](help.md) | Displays a list of the available commands or detailed help information on a specified command. |
-| [import](import.md) | Imports a foreign disk group into the disk group of the local computer. |
+| [import](import_1.md) | Imports a foreign disk group into the disk group of the local computer. |
 | [inactive](inactive.md) | Marks the system partition or boot partition with focus as inactive on basic master boot record (MBR) disks. |
 | [list](list.md) | Displays a list of disks, of partitions in a disk, of volumes in a disk, or of virtual hard disks (VHDs). |
 | [merge vdisk](merge-vdisk.md) | Merges a differencing virtual hard disk (VHD) with its corresponding parent VHD. |


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3844 (**The link for the diskpart import command actually points to the diskshadow import command**), there are 2 similar valid link addresses available in the same folder with `_1` as the only difference between them. The DiskShadow import command has been linked from the DiskPart page (described as the link to the DiskPart import command) for quite some time, but the correct link has also been available in the TOC list in the sidebar on the left side.

Thanks to @darwin-msft for noticing and reporting this issue.

**Proposed change:**

- replace the DiskShadow URL (import.md) with the DiskPart URL (import_1.md)

**Ticket closure or reference:**

Closes #3844