### PR TITLE
Update findstr.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/findstr.md
+++ b/WindowsServerDocs/administration/windows-commands/findstr.md
@@ -42,7 +42,7 @@ findstr [/b] [/e] [/l | /r] [/s] [/i] [/x] [/v] [/n] [/m] [/o] [/p] [/f:<file>] 
 | /d:`<dirlist>` | Searches the specified list of directories. Each directory must be separated with a semicolon (;), for example `dir1;dir2;dir3`. |
 | /a:`<colorattribute>` | Specifies color attributes with two hexadecimal digits. Type `color /?` for additional information. |
 | `<strings>` | Specifies the text to search for in *filename*. Required. |
-| `[\<drive>:][<path>]<filename>[ ...]` | Specifies the location and file or files to search. At least one file name is required. |
+| `[\<drive>:][<path>]<filename>[...]` | Specifies the location and file or files to search. At least one file name is required. |
 | /? | Displays Help at the command prompt. |
 
 #### Remarks
@@ -55,20 +55,20 @@ findstr [/b] [/e] [/l | /r] [/s] [/i] [/x] [/v] [/n] [/m] [/o] [/p] [/f:<file>] 
 
   - A meta-character is a symbol with special meaning (an operator or delimiter) in the regular-expression syntax.
 
-    The accepted meta-characters, are:
+    The accepted meta-characters are:
 
     | Meta-character | Value |
     | -------------- | ----- |
-    | `.` | **Wildcard** - Any character |
-    | `*` | **Repeat** - Zero or more occurrences of the previous character or class. |
-    | `^` | **Beginning line position** - Beginning of the line. |
-    | `$` | **Ending line position** - End of the line. |
-    | `[class]` | **Character class** - Any one character in a set. |
-    | `[^class]` | **Inverse class** - Any one character not in a set. |
-    | `[x-y]` | **Range** - Any characters within the specified range. |
-    | `\x` | **Escape** - Literal use of a meta-character. |
-    | `<string` | **Beginning word position** - Beginning of the word. |
-    | `string>` | **Ending word position** - End of the word. |
+    | `.`            | **Wildcard** - Any character |
+    | `*`            | **Repeat** - Zero or more occurrences of the previous character or class. |
+    | `^`            | **Beginning line position** - Beginning of the line. |
+    | `$`            | **Ending line position** - End of the line. |
+    | `[class]`      | **Character class** - Any one character in a set. |
+    | `[^class]`     | **Inverse class** - Any one character not in a set. |
+    | `[x-y]`        | **Range** - Any characters within the specified range. |
+    | `\x`           | **Escape** - Literal use of a meta-character. |
+    | `\<string`     | **Beginning word position** - Beginning of the word. |
+    | `string\>`     | **Ending word position** - End of the word. |
 
     The special characters in regular expression syntax have the most power when you use them together. For example, use the combination of the wildcard character (`.`) and repeat (`*`) character to match any string of characters: `.*`
 
@@ -119,13 +119,13 @@ findstr /g:stringlist.txt /f:filelist.txt > results.out
 To list every file containing the word *computer* within the current directory and all subdirectories, regardless of case, type:
 
 ```
-findstr /s /i /m <computer> *.*
+findstr /s /i /m \<computer\> *.*
 ```
 
 To list every file containing the word computer and any other words that begin with comp, (such as compliment and compete), type:
 
 ```
-findstr /s /i /m <comp.* *.*
+findstr /s /i /m \<comp.* *.*
 ```
 
 ## Additional References


### PR DESCRIPTION
**Description:**

As reported in issue ticket #3674 (**Missing character**), the backslash meta character is missing from 2 lines in the Meta-character table and their usage examples (2).

Thanks to Petr Laznovsky (@lazna) for noticing and reporting this issue.

**Proposed changes:**
- add missing backslash in `\<string` and its matching examples
- add missing backslash in `string\>` and the double example

**Whitespace changes:**
- remove unneeded blank in path/filename continuation indicator
- remove unneeded comma in Meta-character table description
- add NewLine at end-of-file (last text line)
- expand the Meta-character table for easier column editing

**Reference source for confirmation/verification of backslash usage:**
- https://ss64.com/nt/findstr.html

**Ticket closure or reference:**

Closes #3674