### PR TITLE
Add the "See Also" section with links to WSL FAQ

### DIFF
--- a/WindowsServerDocs/administration/Linux-Package-Repository-for-Microsoft-Software.md
+++ b/WindowsServerDocs/administration/Linux-Package-Repository-for-Microsoft-Software.md
@@ -87,10 +87,9 @@ curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 sudo apt-get update
 ```
 
-
 ## See Also
 
 - [Frequently Asked Questions about Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/faq)
-    - [How do I uninstall a WSL Distribution?](https://docs.microsoft.com/windows/wsl/faq#how-do-i-uninstall-a-wsl-distribution)
+- [How do I uninstall a WSL Distribution?](https://docs.microsoft.com/windows/wsl/faq#how-do-i-uninstall-a-wsl-distribution)
 - [Windows Subsystem for Linux Installation Guide for Windows 10](https://docs.microsoft.com/windows/wsl/install-win10)
 - [Windows Subsystem for Linux Documentation](https://docs.microsoft.com/windows/wsl/)

--- a/WindowsServerDocs/administration/Linux-Package-Repository-for-Microsoft-Software.md
+++ b/WindowsServerDocs/administration/Linux-Package-Repository-for-Microsoft-Software.md
@@ -86,3 +86,11 @@ curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 # Update package index files
 sudo apt-get update
 ```
+
+
+## See Also
+
+- [Frequently Asked Questions about Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/faq)
+    - [How do I uninstall a WSL Distribution?](https://docs.microsoft.com/windows/wsl/faq#how-do-i-uninstall-a-wsl-distribution)
+- [Windows Subsystem for Linux Installation Guide for Windows 10](https://docs.microsoft.com/windows/wsl/install-win10)
+- [Windows Subsystem for Linux Documentation](https://docs.microsoft.com/windows/wsl/)


### PR DESCRIPTION
**Description:**
As a suggested solution based on issue ticket #5023 (**need to say how to uninstall too**), I propose to add a "See Also" section, containing the **FAQ** and **Windows Subsystem for Linux Documentation** page links.

Thanks to @ladylazy9x for requesting a more direct way to find out how to uninstall WSL .

**Changes proposed:**
- add the "See Also" section title (MarkDown H2 heading)
- add a link to [Frequently Asked Questions about Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/faq)
    - add indented link to the FAQ [How do I uninstall a WSL Distribution?](https://docs.microsoft.com/windows/wsl/faq#how-do-i-uninstall-a-wsl-distribution)
- add a link to [Windows Subsystem for Linux Installation Guide for Windows 10](https://docs.microsoft.com/windows/wsl/install-win10)
- add a link to [Windows Subsystem for Linux Documentation](https://docs.microsoft.com/windows/wsl/)

**Ticket closure or reference:**
Closes #5023