### PR TITLE
Windows Commands/extract: add info about Extrac32

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/extract.md
+++ b/WindowsServerDocs/administration/windows-commands/extract.md
@@ -6,14 +6,20 @@ ms.assetid: 20dab03e-f6e1-4eb8-b8a1-fd6f1d97ee83
 ms.author: lizross
 author: eross-msft
 manager: mtillman
-ms.date: 10/16/2017
+ms.date: 12/29/2020
 ---
 
-# extract
+# extract / extrac32
 
 Extracts files from a cabinet or source.
 
+> [!NOTE]
+> On Windows Server 2016 and newer, and on Windows 10, the program file Extract.exe is neither provided nor supported.
+> It is replaced by Extrac32.exe, originally part of Internet Explorer, now part of the operating system.
+
 ## Syntax
+
+## Extract.exe
 
 ```
 extract [/y] [/a] [/d | /e] [/l dir] cabinet [filename ...]
@@ -35,6 +41,33 @@ extract [/y] /c source destination
 | /e | Extract (use instead of *.* to extract all files). |
 | /l dir | Location to place extracted files (default is current directory). |
 | /y | Don't prompt before overwriting an existing file. |
+
+## Extrac32.exe
+
+> [!NOTE]
+> Extrac32.exe can be used from the command line, but does not display any output on the console.
+> Redirect the help output through the [more](https://docs.microsoft.com/windows-server/administration/windows-commands/more) command, like this: `extrac32.exe /? | more`
+
+```
+Extrac32 [/Y] [/A] [/D | /E] [/L dir] cabinet [filename ...]
+Extrac32 [/Y] source [newname]
+Extrac32 [/Y] /C source destination
+```
+
+### Parameters
+
+| Parameter | Description |
+| :-------- | :---------- |
+| cabinet   | Cabinet file (contains two or more files). |
+| filename  | Name of the file to extract from the cabinet. Wild cards and multiple filenames (separated by blanks) may be used. |
+| source    | Compressed file (a cabinet with only one file). |
+| newname   | New filename to give the extracted file. If not supplied, the original name is used. |
+| /A        | Process ALL cabinets.  Follows cabinet chain starting in first cabinet mentioned. |
+| /C        | Copy source file to destination (to copy from DMF disks). |
+| /D        | Display cabinet directory (use with filename to avoid extract). |
+| /E        | Extract (use instead of *.* to extract all files). |
+| /L dir    | Location to place extracted files (default is current directory). |
+| /Y        | Do not prompt before overwriting an existing file. |
 
 ## Additional References
 


### PR DESCRIPTION
**Description:**
As noted in issue ticket MicrosoftDocs#1369 (**no está disponible en Windows 10**), the command `extract` is not available in Windows 10 (and confirmed to be not available in Windows Server 2016).

Thanks to @PabloJoaquin for pointing out and reporting the issue.

**Changes proposed:**

- add [Note] blob with information about `Extract.exe` being replaced in Server 2016 (and newer) and Windows 10
- add syntax and parameter table copied from the output of `Extrac32 /? | more` in the same pattern as for `extract`
- add extra [Note] blob describing how to  redirect (filter) the extrac32 help command output via [more]
- add link to the command page for [more], within the sentence on how to filter the output via [more]
- add H2 headings for Extract.exe and Extrac32.exe
- add **/ extrac32** in the page title

**Ticket closure or reference:**
Closes MicrosoftDocs#1369