### PR TITLE
Update domain-joined-device-public-key-authentication.md

### DIFF
--- a/WindowsServerDocs/security/kerberos/domain-joined-device-public-key-authentication.md
+++ b/WindowsServerDocs/security/kerberos/domain-joined-device-public-key-authentication.md
@@ -10,33 +10,36 @@ ms.date: 08/18/2017
 
 # Domain-joined Device Public Key Authentication
 
->Applies to: Windows Server 2016, Windows 10
+> Applies to: Windows Server 2016, Windows 10
 
-Kerberos added support for domain-joined devices to sign-in using a certificate beginning with Windows Server 2012 and Windows 8. This change allows 3rd party vendors to create solutions to provision and initialize certificates for domain-joined devices to use for domain authentication.
+Kerberos added support for domain-joined devices to sign in using a certificate, beginning with Windows Server 2012 and Windows 8. This change allows 3rd party vendors to create solutions to provision and initialize certificates to be used by domain-joined devices for domain authentication.
 
 ## Automatic public key provisioning
 
-Beginning with Windows 10 version 1507 and Windows Server 2016, domain-joined devices automatically provision a bound public key to a Windows Server 2016 domain controller (DC). Once a key is provisioned, then Windows can use public key authentication to the domain.
+Beginning with Windows 10 version 1507 and Windows Server 2016, domain-joined devices automatically provision a bound public key to a Windows Server 2016 domain controller (DC). Once a key is provisioned, Windows can use public key authentication to the domain.
 
 ### Key generation
-If the device is running Credential Guard, then a public/private key pair is created protected by Credential Guard.
 
-If Credential Guard is not available and a TPM is, then a public/private key pair is created protected by the TPM.
+If the device is running Credential Guard, a public/private key pair is created, and the private key is protected by Credential Guard.
 
-If neither is available, then a key pair is not generated and the device can only authenticate using password.
+If Credential Guard is not available and a TPM is, a public/private key pair is created, and the private key is protected by the TPM.
 
-### Provisioning computer account public key
-When Windows starts up, it checks if a public key is provisioned for its computer account. If not, then it generates a bound public key and configures it for its account in AD using a Windows Server 2016 or higher DC. If all the DCs are down-level, then no key is provisioned.
+If neither is available, a key pair is _not_ generated, and the device can only authenticate using passwords.
 
-### Configuring device to only use public key
-If the Group Policy setting **Support for device authentication using certificate** is set to **Force**, then the device needs to find a DC that runs Windows Server 2016 or later to authenticate. The setting is under Administrative Templates > System > Kerberos.
+### Provisioning a computer account public key
 
-### Configuring device to only use password
-If the Group Policy setting **Support for device authentication using certificate** is disabled, then password is always used. The setting is under Administrative Templates > System > Kerberos.
+When Windows starts up, it checks if a public key is provisioned for its computer account. If not, it then generates a bound public key and configures it for its account in AD using a Windows Server 2016 or higher DC. If all the DCs are down-level, no key is provisioned.
+
+### Configuring the device to only use public key
+
+If the Group Policy setting **Support for device authentication using certificate** is set to **Force**, the device then needs to find a DC that runs Windows Server 2016 or later to authenticate. The setting is under **Administrative Templates > System > Kerberos**.
+
+### Configuring the device to only use password
+
+If the Group Policy setting **Support for device authentication using certificate** is disabled, then password is always used. The setting is under **Administrative Templates > System > Kerberos**.
 
 ## Domain-joined device authentication using public key
-When Windows has a certificate for the domain-joined device, Kerberos first authenticates using the certificate and on failure retries with password. This allows the device to authenticate to down-level DCs.
+
+When Windows has a certificate for the domain-joined device, Kerberos first authenticates using the certificate, and on failure retries with password. This allows the device to authenticate to down-level DCs.
 
 Since the automatically provisioned public keys have a self-signed certificate, certificate validation fails on domain controllers that do not support Key Trust account mapping. By default, Windows retries authentication using the device's domain password.
-
-


### PR DESCRIPTION
**Description:**
Based on issue ticket #2570 (**Public key in TPM? Looks wrong.**), I still find the solution in PR #3922 not clear enough. 
To my understanding, it should be made perfectly clear that only the private key is protected by Credential Guard or TPM.

**Changes proposed:**

- Clarify that only the _private_key_ is protected by Credential Guard or TPM
- Change "sign-in" to 'sign in' (compound verb, not a noun)
- Remove/move/modify usage of "then" (readability/natural language)
- Change "password" to 'passwords' (plural) (readability & understanding)
- Grammar improvement in the last sentence of the first paragraph
- Add missing particle (a/the) in 3 of the H3 headings (natural language)
- Add readability commas (natural language)
- Add emphasis:
    - "a key pair is _not_ generated" ("not" cursive/italics)
    - "Administrative Templates > System > Kerberos" in **bold**
    - "Administrative Templates > System > Kerberos" (**bold** again)

**Whitespace changes:**

- Add MD indent marker compatibility spacing in `> Applies to:`
- Editorial blank line after H2/H3 headings (5 lines)

**Ticket closure or reference:**
Closes #2570