### PR TITLE
Update troubleshooting-cluster-event-id-1135.md

### DIFF
--- a/WindowsServerDocs/troubleshoot/troubleshooting-cluster-event-id-1135.md
+++ b/WindowsServerDocs/troubleshoot/troubleshooting-cluster-event-id-1135.md
@@ -5,6 +5,7 @@ ms.date: 05/28/2020
 author: Deland-Han
 ms.author: delhan
 ---
+
 # Troubleshooting cluster issue with Event ID 1135
 
 This article helps you diagnose and resolve Event ID 1135, which may be logged during the startup of the Cluster service in Failover Clustering environment.
@@ -28,9 +29,9 @@ A validation and the network tests would be recommended as one of the initial tr
 
 The Cluster service is the essential software component that controls all aspects of failover cluster operation and manages the cluster configuration database. If you see the event ID 1135, Microsoft recommends you to install the fixes mentioned in the below KB articles and reboot all the nodes of the cluster, then observe if issue reoccurs.
 
-- [Hotfix for Windows Server 2012 R2](https://support.microsoft.com/help/2920151)
-- [Hotfix for Windows Server 2012](https://support.microsoft.com/help/2784261)
-- [Hotfix for Windows Server 2008 R2](https://support.microsoft.com/help/2545685)
+- [Hotfix for Windows Server 2012 R2](https://docs.microsoft.com/troubleshoot/windows-server/high-availability/updates-for-windows-server-2012-r2-failover-cluster)
+- [Hotfix for Windows Server 2012](https://docs.microsoft.com/troubleshoot/windows-server/high-availability/updates-for-windows-server-2012-failover-cluster)
+- [Hotfix for Windows Server 2008 R2](https://docs.microsoft.com/troubleshoot/windows-server/high-availability/updates-for-windows-server-2008-r2-sp1-failover-cluster)
 
 ### Check if the cluster service running on all the nodes
 
@@ -38,18 +39,17 @@ Follow the following command according to your Windows operation system to valid
 
 #### For Windows Server 2008 R2 cluster
 
-from elevated cmd prompt run: **cluster.exe node /stat**
+From an elevated cmd prompt, run: **cluster.exe node /stat**
 
-#### For Windows Server 2012\ and Windows Server 2012 R2 cluster
+#### For Windows Server 2012 and Windows Server 2012 R2 cluster
 
-run PS command: **cluster node /status**
+Run the following PS command: [`Get-ClusterResource`](https://docs.microsoft.com/powershell/module/failoverclusters/get-clusterresource)
 
 Is the cluster service continuously running and available on all the nodes?
 
 ## Solution for cluster service is failing
 
-If cluster service is failing, troubleshoot using this article: [Windows Server 2008 and 2008R2 Failover Cluster Startup Switches](/archive/blogs/askcore/windows-server-2008-and-2008r2-failover-cluster-startup-switches).
-
+If the cluster service is failing, troubleshoot using this article: [Windows Server 2008 and 2008R2 Failover Cluster Startup Switches](/archive/blogs/askcore/windows-server-2008-and-2008r2-failover-cluster-startup-switches).
 
 ## Several scenarios of Event ID 1135
 
@@ -57,7 +57,11 @@ We want you to take a closer look on at the System Event logs on all the nodes o
 
 ```console
 Event ID 1135
-Cluster node ' **NODE A** ' was removed from the active failover cluster membership. The Cluster service on this node may have stopped. This could also be due to the node having lost communication with other active nodes in the failover cluster. Run the Validate a Configuration wizard to check your network configuration. If the condition persists, check for hardware or software errors related to the network adapters on this node. Also check for failures in any other network components to which the node is connected such as hubs, switches, or bridges.
+Cluster node ' **NODE A** ' was removed from the active failover cluster membership. The Cluster service on this node may have stopped. 
+This could also be due to the node having lost communication with other active nodes in the failover cluster. 
+Run the Validate a Configuration wizard to check your network configuration. 
+If the condition persists, check for hardware or software errors related to the network adapters on this node. 
+Also check for failures in any other network components to which the node is connected such as hubs, switches, or bridges.
 ```
 
 There are three typical scenarios:
@@ -118,7 +122,7 @@ Exclude the following file system locations from virus scanning on a server that
 
 - The path of the FileShare Witness
 
-- The *%Systemroot%\Cluster folder*
+- The *%Systemroot%\Cluster* folder
 
 Configure the real-time scanning component within your antivirus software to exclude the following directories and files:
 
@@ -137,14 +141,14 @@ Configure the real-time scanning component within your antivirus software to exc
 - mms.exe
 
     > [!NOTE]
-    > This file may have to be configured as a process exclusion within the antivirus software.)
+    > This file may have to be configured as a process exclusion within the antivirus software.
 
 - Vmwp.exe
 
     > [!NOTE]
     > This file may have to be configured as a process exclusion within the antivirus software.
 
-Additionally, when you use Live Migration together with Cluster Shared Volumes, exclude the CSV path *C:\Clusterstorage* and all its subdirectories. If you are troubleshooting failover issues or general problems with a Cluster services and antivirus software is installed, temporarily uninstall the antivirus software or check with the manufacturer of the software to determine whether the antivirus software works with Cluster services. Just disabling the antivirus software is insufficient in most cases. Even if you disable the antivirus software, the filter driver is still loaded when you restart the computer.
+Additionally, when you use Live Migration together with Cluster Shared Volumes, exclude the CSV path *C:\Clusterstorage* and all its subdirectories. If you are troubleshooting failover issues or general problems with Cluster services and antivirus software is installed, temporarily uninstall the antivirus software or check with the manufacturer of the software to determine whether the antivirus software works with Cluster services. Just disabling the antivirus software is insufficient in most cases. Even if you disable the antivirus software, the filter driver is still loaded when you restart the computer.
 
 ### Check for Network Port Configuration in Firewall
 
@@ -152,23 +156,22 @@ The Cluster service controls server cluster operations and manages the cluster d
 
 System service name: **ClusSvc**
 
-|Application|Protocol|Ports|
-|---|---|---|
-|Cluster Service|UDP|3343|
-|Cluster Service|TCP|3343 (This port is required during a node join operation.)|
-|RPC|TCP|135|
-|Cluster Admin|UDP|137|
-|Kerberos|UDP\TCP|464*|
-|SMB|TCP|445|
-|Randomly allocated high UDP ports**|UDP|Random port number between 1024 and 65535<br/>Random port number between 49152 and 65535***|
-||||
+| Application | Protocol | Ports |
+| :---------- | :------: | ----- |
+| Cluster Service | UDP | 3343 |
+| Cluster Service | TCP | 3343 (This port is required during a node join operation.) |
+| RPC | TCP | 135 |
+| Cluster Admin | UDP | 137 |
+| Kerberos | UDP/TCP | 464* |
+| SMB | TCP | 445 |
+| Randomly allocated high UDP ports\*\* | UDP | Random port number between 1024 and 65535 <br/>Random port number between 49152 and 65535\*\*\* |
 
 > [!NOTE]
 > Additionally, for successful validation on Windows Failover Clusters on Windows Server 2008 and above, allow inbound and outbound traffic for ICMP4, ICMP6.
 
-- For more information, see [Creating a Windows Server 2012 Failover Cluster Fails with Error 0xc000005e](https://support.microsoft.com/help/2830510).
+- For more information, see [Creating a Windows Server 2012 Failover Cluster Fails with Error 0xc000005e](https://docs.microsoft.com/troubleshoot/windows-server/high-availability/creating-failover-cluster-fails-error-0xc0000055).
 
-- For more information about how to customize these ports, see [Service overview and network port requirements for Windows](https://support.microsoft.com/help/832017/) in the "References" section.
+- For more information about how to customize these ports, see [Service overview and network port requirements for Windows](https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/service-overview-and-network-port-requirements) in the "References" section.
 
 This is the range in Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008, and Windows Vista.
 
@@ -184,11 +187,11 @@ The cluster validation tool runs a suite of tests to verify that your hardware a
 
 Follow these instructions:
 
-1. Run the Cluster Validation report for any errors or warnings. For more information, see [Understanding Cluster Validation Tests: Network](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771323(v=ws.11)?redirectedfrom=MSDN)
+1. Run the Cluster Validation report for any errors or warnings. For more information, see [Understanding Cluster Validation Tests: Network](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771323(v=ws.11))
 
     ![subhatt1](media/troubleshooting-cluster-event-id-1135/18653.png)
 
-2. Verify for warnings and errors for Networks. For more information, see [Understanding Cluster Validation Tests: Network](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771323(v=ws.11)?redirectedfrom=MSDN).
+2. Verify for warnings and errors for Networks. For more information, see [Understanding Cluster Validation Tests: Network](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771323(v=ws.11)).
 
     ![Results by Category](media/troubleshooting-cluster-event-id-1135/18654.png)
     ![Network](media/troubleshooting-cluster-event-id-1135/18655.png)
@@ -201,7 +204,7 @@ The Adapters and Bindings tab lists the connections in the order in which the co
 
 Follow the below steps to change the binding order of network adapters:
 
-1. Click **Start**, click **Run**, type ncpa.cpl, and then click **OK**. You can see the available connections in the **LAN and High-Speed Internet** section of the **Network Connections** window.
+1. Click **Start**, click **Run**, type `ncpa.cpl`, and then click **OK**. You can see the available connections in the **LAN and High-Speed Internet** section of the **Network Connections** window.
 
 2. On the **Advanced** menu, click **Advanced Settings**, and then click the **Adapters and Bindings** tab.
 
@@ -215,15 +218,17 @@ Latency on your network could also cause this to happen. The packets may not be 
 
 This test validates that tested servers can communicate with acceptable latency on all networks.
 
-For Example: Under Validate Network Communication, you may see following messages for network latency issues.
+For example: Under Validate Network Communication, you may see the following messages for network latency issues:
 
 ```console
 Succeeded in pinging network interface node003.contoso.com IP Address 192.168.0.2 from network interface node004.contoso.com IP Address 192.168.0.3 with maximum delay 500 after 1 attempt(s).
-Either address 10.0.0.96 is not reachable from 192.168.0.2 or **the ping latency is greater than the maximum allowed 2000 ms** This may be expected, since network interfaces node003.contoso.com - Heartbeat Network and node004.contoso.com - Production Network are on different cluster networks
-Either address 192.168.0.2 is not reachable from 10.0.0.96 or **the ping latency is greater than the maximum allowed 2000 ms** This may be expected, since network interfaces node004.contoso.com - Production Network and node003.contoso.com - Heartbeat Network for MSCS are on different cluster networks
+Either address 10.0.0.96 is not reachable from 192.168.0.2 or **the ping latency is greater than the maximum allowed 2000 ms** 
+This may be expected, since network interfaces node003.contoso.com - Heartbeat Network and node004.contoso.com - Production Network are on different cluster networks
+Either address 192.168.0.2 is not reachable from 10.0.0.96 or **the ping latency is greater than the maximum allowed 2000 ms** 
+This may be expected, since network interfaces node004.contoso.com - Production Network and node003.contoso.com - Heartbeat Network for MSCS are on different cluster networks
 ```
 
-For multi-site cluster, you may increase the time-out values. For more information, see [Configure Heartbeat and DNS Settings in a Multi-Site Failover Cluster](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd197562(v=ws.10)?redirectedfrom=MSDN).
+For multi-site cluster, you may increase the time-out values. For more information, see [Configure Heartbeat and DNS Settings in a Multi-Site Failover Cluster](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd197562(v=ws.10)).
 
 Check with ISP for any WAN connectivity issues.
 
@@ -237,7 +242,7 @@ Check if you encounter any of the following issues.
 
     ![Add Counters](media/troubleshooting-cluster-event-id-1135/18652.png)
 
-    If you are experiencing network packet lost on VmWare virtualization platform, see the "Cluster installed in the VmWare virtualization platform" section.
+    If you are experiencing network packet lost on VMware virtualization platform, see the "Cluster installed in the VMware virtualization platform" section.
 
 2. Upgrade the NIC drivers
 
@@ -245,7 +250,7 @@ Check if you encounter any of the following issues.
     If there are network packets lost between nodes on Physical machines, please have your network adapter driver updates. Old or out-of-date network card drivers and/or firmware.
     At times, a simple misconfiguration of the network card or switch can also cause loss of heartbeats.
 
-##### Cluster installed in the VmWare virtualization platform
+##### Cluster installed in the VMware virtualization platform
 
 Verify VMware adapter issues in case of VMware environment.
 
@@ -254,20 +259,20 @@ This issue may occur if the packets are dropped during high traffic bursts. Ensu
 To reduce burst traffic drops, follow these steps:
 
 1. Open Run box by using Windows Key + R.
-2. Type devmgmt.msc and press **Enter**.
+2. Type `devmgmt.msc` and press **Enter**.
 3. Expand **Network adapters**
 4. Right-click **vmxnet3 and click Properties.**
 5. Click the **Advanced** tab.
 6. Click **Small Rx Buffers** and increase the value. The default value is 512 and the maximum is 8192.
 7. Click **Rx Ring #1** Size and increase the value. The default value is 1024 and the maximum is 4096.
 
-Check the following URLs to verify vmware adapter issues in case of VMware environment:
+Check the following URLs to verify VMware adapter issues in case of VMware environment:
 
-- [Nodes being removed from Failover Cluster membership on VMWare ESX?](/archive/blogs/askcore/nodes-being-removed-from-failover-cluster-membership-on-vmware-esx).
+- [Nodes being removed from Failover Cluster membership on VMware ESX?](/archive/blogs/askcore/nodes-being-removed-from-failover-cluster-membership-on-vmware-esx).
 
 - [Large packet loss at the guest operating system level on the VMXNET3 vNIC in ESXi](https://kb.vmware.com/s/article/2039495)
 
-##### Noticed any Network congestion
+##### Notice any Network congestion
 
 Network congestion can also cause network connectivity issues.
 
@@ -277,7 +282,7 @@ Verify your network is configured as per MS and vendor recommendations, see [Con
 
 If it still does not work, please check if you have seen partitioned network in cluster GUI or you have NIC teaming enabled on the heartbeat NIC.
 
-If you see partitioned network in cluster GUI, see [“Partitioned” Cluster Networks](/archive/blogs/askcore/partitioned-cluster-networks) to troubleshoot the issue.
+If you see partitioned network in cluster GUI, see ["Partitioned" Cluster Networks](/archive/blogs/askcore/partitioned-cluster-networks) to troubleshoot the issue.
 
 If you have NIC teaming enabled on the heartbeat NIC, check Teaming software functionality as per teaming vendor's recommendation.
 


### PR DESCRIPTION
**Description:**

From issue ticket #5158 (**"mail filter" wording is not correct here.. it's causing confusion**):

> Document including below lines;
>
> "This issue may occur if the packets are dropped during high traffic bursts. Ensure that there is no traffic filtering occurring (for example, with a mail filter). After eliminating this possibility, gradually increase the number of buffers in the guest operating system and verify."
>
> Here we are telling that; MAIL FILTER can cause a package DISCARDs on network layer. This is not technically possible. On network layer a package is just a package never a SMTP nor HTTP package. It's low level thing yet and SMTP/MAIL filtering software's does not understand package meaning. Also mail filtering software's does not work on network layer, they works on application layer and look at traffic as SMTP protocol traffic. So please update above lines like below;
>
> "This issue may occur if the packets are dropped during high traffic bursts. Ensure that there is no traffic filtering occurring (for example, with a package filter). After eliminating this possibility, gradually increase the number of buffers in the guest operating system and verify."

Thanks to K. Ekici (@kekici) for noticing and pointing out this issue.

**Changes proposed:**

- modify "with a mail filter" to state 'with a packet filter' (as requested in the issue ticket)
- change the line "run PS command: **cluster node /status**" to 'Run the following PS command: [Get-ClusterResource]'
  (`Cluster.exe` is deprecated from Windows Server 2012 and newer, as well not being a PS command.)
  (Likely a forgotten copy-paste typo.)
- Link [Get-ClusterResource] to docs.microsoft.com/powershell/module/failoverclusters/get-clusterresource
- /previous-versions/ links (3):
    - add full URL https://docs.microsoft.com/previous-versions/windows/it-pro/ [ ... ]
     (existing relative paths are not publicly available on GitHub)
    - skip /en-us/ locale in the links, the pages are locale-agnostic
    - remove "?redirectedfrom=MSDN" from all 3 links
- I made an effort to locate current/new pages for the 3 /previous-versions/ links, but I don't have the required expertise in the Cluster Service topic to pick the correct ones.

- support.microsoft.com/help/ now permanently redirects to [docs.microsoft.com/troubleshoot/windows-server/] for all 5 URLs in this document:
    - `/help/2920151` => `[...]high-availability/updates-for-windows-server-2012-r2-failover-cluster`
    - `/help/2784261` => `[...]high-availability/updates-for-windows-server-2012-failover-cluster`
    - `/help/2545685` => `[...]high-availability/updates-for-windows-server-2008-r2-sp1-failover-cluster`
    - `/help/2830510` => `[...]high-availability/creating-failover-cluster-fails-error-0xc0000055`
    - `/help/832017/` => `[...]networking/service-overview-and-network-port-requirements`
    (all 5 URLs are now updated accordingly)

**Cosmetic/codestyle changes:**

- remove redundant ending parenthesis in the first Note blob (first of 3 in total)
- remove redundant grammatical particle "a" from "general problems with a Cluster services"
- remove redundant backslash from the heading "For Windows Server 2012\ and Windows Server 2012 R2 cluster"
- encapsulate `ncpa.cpl` in MarkDown backticks for emphasis and monospaced font view (filename)
- encapsulate `devmgmt.msc` in MarkDown backticks for emphasis and monospaced font view (filename)
- changed casing (8x) for "vmware" or "WMWare" to 'VMware' - name casing used on https://www.vmware.com/
- changed curly quote characters to straight quote characters in ["Partitioned" Cluster Networks]
- modify cursive formatting (single asterisk) in "The *%Systemroot%\Cluster folder*" to 'The *%Systemroot%\Cluster* folder'
- ClusSvc table: remove the empty row at the end (visible empty row on GitHub, ignored on docs.microsoft.com)
- ClusSvc table: add escape character (backslash) for each of the 2+3 asterisks in the last row, 1st and 3rd column
- ClusSvc table: change backslash to forward slash, "UDP\TCP" => UDP/TCP (forward slash is the default norm)
  (I could have corrected the order of UDP/TCP to TCP/UDP, but it may have been written in order of importance.)

**Whitespace changes:**

- add one editorial blank line between metadata and page title (H1 heading)
- simplify double blank line between paragraph and new H2 heading to single line (consistency)
- add 4 line breaks in the ``console output code block for Event ID 1135
  (previously, to read the full text you would have to scroll sideways impractically much to read all of it)
- add 2 line breaks in the ``console output code block under "you may see the following messages for network latency issues:" (readability)
- ClusSvc table: add MarkDown codestyle spacing

**Ticket closure or reference:**

Closes #5158
