### PR TITLE
Update guarded-fabric-initialize-hgs-tpm-mode-bastion.md

### DIFF
--- a/WindowsServerDocs/security/guarded-fabric-shielded-vm/guarded-fabric-initialize-hgs-tpm-mode-bastion.md
+++ b/WindowsServerDocs/security/guarded-fabric-shielded-vm/guarded-fabric-initialize-hgs-tpm-mode-bastion.md
@@ -10,13 +10,13 @@ ms.date: 08/29/2018
 
 # Initialize the HGS cluster using TPM mode in an existing bastion forest
 
->Applies to: Windows Server 2019, Windows Server (Semi-Annual Channel), Windows Server 2016
+> Applies to: Windows Server 2019, Windows Server (Semi-Annual Channel), Windows Server 2016
 
 Active Directory Domain Services will be installed on the machine, but should remain unconfigured.
 
 [!INCLUDE [Obtain certificates for HGS](../../../includes/guarded-fabric-initialize-hgs-default-step-two.md)]
 
-Before you continue, ensure that you have prestaged your cluster objects for the Host Guardian Service and granted the logged in user **Full Control** over the VCO and CNO objects in Active Directory.
+Before you continue, ensure that you have pre-staged your cluster objects for the Host Guardian Service and granted the logged in user **Full Control** over the VCO and CNO objects in Active Directory.
 The virtual computer object name needs to be passed to the `-HgsServiceName` parameter, and the cluster name to the `-ClusterName` parameter.
 
 > [!TIP]
@@ -30,7 +30,7 @@ $encryptionCertPass = Read-Host -AsSecureString -Prompt "Encryption certificate 
 
 Install-ADServiceAccount -Identity 'HGSgMSA'
 
-Initialize-HgsServer -UseExistingDomain -ServiceAccount 'HGSgMSA' -JeaReviewersGroup 'HgsJeaReviewers' -JeaAdministratorsGroup 'HgsJeaAdmins' -HgsServiceName 'HgsService' -SigningCertificatePath '.\signCert.pfx' -SigningCertificatePassword $signPass -EncryptionCertificatePath '.\encCert.pfx' -EncryptionCertificatePassword $encryptionCertPass -TrustTpm
+Initialize-HgsServer -ClusterName "MyHGSClusterName" -UseExistingDomain -ServiceAccount 'HGSgMSA' -JeaReviewersGroup 'HgsJeaReviewers' -JeaAdministratorsGroup 'HgsJeaAdmins' -HgsServiceName 'HgsService' -SigningCertificatePath '.\signCert.pfx' -SigningCertificatePassword $signPass -EncryptionCertificatePath '.\encCert.pfx' -EncryptionCertificatePassword $encryptionCertPass -TrustTpm
 ```
 
 If you are using certificates installed on the local machine (such as HSM-backed certificates and non-exportable certificates), use the `-SigningCertificateThumbprint` and `-EncryptionCertificateThumbprint` parameters instead.


### PR DESCRIPTION
**Description:**

Reported in issue ticket #5099 (**missing important parameter on Initialize-Cluster powershell command for installing to existing forest**) :

> The PowerShell for the Initialize-Cluster command IS MISSING AN IMPORTANT PARAMETER:

```PowerShell
-ClusterName "MyHGSClusterName"
```
> without this, a random cluster name (number suffix) is inserted, and you will get a cluster operation terminated / error occured.

***

Thanks to Ryan 'Skip' Johnson (@k3for) for noticing and reporting this documentation issue.

**Proposed changes:**

- add `-ClusterName "MyHGSClusterName"` to the PowerShell `Initialize-HgsServer` command line
- hyphenate prestaged -> pre-staged (based on dictionaries and observed usage)
- add missing MarkDown indent marker compatibility spacing in `>Applies to:`

**Ticket closure or reference:**

Closes #5099
Supersedes #5108