### PR TITLE
Update windows-server-release-info.md

### DIFF
--- a/WindowsServerDocs/get-started/windows-server-release-info.md
+++ b/WindowsServerDocs/get-started/windows-server-release-info.md
@@ -7,6 +7,7 @@ author: jasongerend
 ms.author: jgerend
 ms.localizationpriority: high
 ---
+
 # Windows Server release information
 
 Microsoft has updated its servicing model. The Semi-Annual Channel is a twice-per-year feature update release with 18-month servicing timelines for each release. This page is designed to help you determine the end of support date for the Semi-Annual Channel releases.
@@ -16,17 +17,17 @@ The Semi-Annual Channel provides opportunity for customers who are innovating qu
 ## Windows Server current versions by servicing option
 
 | Windows Server release | Version | OS Build | Availability | Mainstream support end date|Extended support end date |
-|----------------|---------|----------|----------|---------|----------|
+| ---------------------- | ------- | -------- | ------------ | -------------------------- | ------------------------ |
 | Windows Server, version 20H2 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 20H2 | 19042.508.200927-1902 | 10/20/2020 | 05/10/2022 | Review note |
 | Windows Server, version 2004 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 2004 | 19041.264.200508-2205 | 05/27/20 | 12/14/2021 | Review note |
 | Windows Server, version 1909 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 1909  | 18363.418.191007-0143 | 11/12/2019 | 05/11/2021 | Review note |
 | Windows Server, version 1903 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 1903  | 18362.30.190401-1528 | 5/21/2019 | 12/08/2020 | Review note |
-|Windows Server 2019 (Long-Term Servicing Channel) (Datacenter, Essentials, Standard)|1809|17763.107.1010129-1455|11/13/2018|01/09/2024|01/09/2029|
-|Windows Server, version 1809 (Semi-Annual Channel) (Datacenter Core, Standard Core)|1809|17763.107.1010129-1455|11/13/2018|11/10/2020|Review note|
+| Windows Server 2019 (Long-Term Servicing Channel) (Datacenter, Essentials, Standard)|1809|17763.107.1010129-1455|11/13/2018|01/09/2024|01/09/2029|
+| Windows Server, version 1809 (Semi-Annual Channel) (Datacenter Core, Standard Core)|1809|17763.107.1010129-1455|11/13/2018|11/10/2020|Review note|
 | Windows Server 2016 (Long-Term Servicing Channel)| 1607 | 14393.0 | 10/15/2016 |01/11/2022| 01/11/2027|
 
 > [!IMPORTANT]
 > End of service for Windows Server, version 1809 has been delayed due to the ongoing public health crisis. For more information, see [our Support article](https://support.microsoft.com/help/4557164).
 
->[!NOTE]
-> Windows Server, version 1803 and later are governed by the [Modern Lifecycle Policy](https://support.microsoft.com/help/30881). See the [Windows Lifecycle FAQ](https://support.microsoft.com/help/18581/lifecycle-faq-windows-products) and [Comparison of servicing channels](../get-started-19/servicing-channels-19.md) for details regarding servicing requirements and other important information.
+> [!NOTE]
+> Windows Server, version 1903 and later are governed by the [Modern Lifecycle Policy](https://support.microsoft.com/help/30881). See the [Windows Lifecycle FAQ](https://support.microsoft.com/help/18581/lifecycle-faq-windows-products) and [Comparison of servicing channels](../get-started-19/servicing-channels-19.md) for details regarding servicing requirements and other important information.


### PR DESCRIPTION
**Description:**

From issue ticket #5156 (**Windows Server, version 1803 and later are governed by the Modern Lifecycle Policy.**):
> There is a mistake with the note at the bottom of the page, that says "Windows Server, version 1803 and later are governed by the Modern Lifecycle Policy."
> But there is no version 1803 that appears in the list of Windows Server current versions by servicing option.
> Is it an error with the 1903 ?
>
> But the phrase version 1803 and later are governed by the Modern Lifecycle Policy, makes me think all versions are governed by[...], but it is not the case of the 1809... So it is very confusing for the reader.
> For me the note at the bottom is not clear and make the reading a little bit messy.
> Thanks for your return.

**Proposed change:**

- change version number 1803 to **1903** => "Windows Server, version 1903 and later are governed by the [Modern Lifecycle Policy]"

**Whitespace changes:**

- add editorial blank line between the metadata section and the page title (H1)
- add missing MarkDown indent marker compatibility spacing in Note blob
- add standard MarkDown spacing around the table grid lines/cell dividers

**Ticket closure or reference:**

Closes #5156