### PR TITLE
Update iscsi-boot-overview.md

### DIFF
--- a/WindowsServerDocs/storage/iscsi/iscsi-boot-overview.md
+++ b/WindowsServerDocs/storage/iscsi/iscsi-boot-overview.md
@@ -8,14 +8,15 @@ manager: dougkim
 ms.author: jgerend
 ms.date: 09/11/2018
 ---
+
 # iSCSI target boot overview
 
-> Applies to: Windows Server 2016
+> **Applies to:** Windows Server 2016
 
 iSCSI Target Server in Windows Server can boot hundreds of computers from a single operating system image that is stored in a centralized location. This improves efficiency, manageability, availability, and security.
 
 ## <a name="BKMK_OVER"></a>Feature description
-By using differencing virtual hard disks \(VHDs\), you can use a single operating system image \(the "master image"\) to boot up to 256 computers. As an example, let's assume that you deployed  Windows Server with an operating system image of approximately 20 GB, and you used two mirrored disk drives to act as the boot volume. You would have needed approximately 10 TB of storage for only the operating system image to boot 256 computers. With iSCSI Target Server, you will use 40 GB for the operating system base image, and 2 GB for differencing virtual hard disks per server instance, totaling 552 GB for the operating system images. This provides a savings of over 90% on storage for the operating system images alone.
+By using differencing virtual hard disks (VHDs), you can use a single operating system image (the "master image") to boot up to 256 computers. As an example, let's assume that you deployed  Windows Server with an operating system image of approximately 20 GB, and you used two mirrored disk drives to act as the boot volume. You would have needed approximately 10 TB of storage for only the operating system image to boot 256 computers. With iSCSI Target Server, you will use 40 GB for the operating system base image, and 2 GB for differencing virtual hard disks per server instance, totaling 552 GB for the operating system images. This provides a savings of over 90% on storage for the operating system images alone.
 
 ## <a name="BKMK_APP"></a>Practical applications
 Using a controlled operating system image provides the following benefits:
@@ -24,15 +25,15 @@ Using a controlled operating system image provides the following benefits:
 
 **Rapid deployment.** Because the master image is prepared by using Sysprep, when computers boot from the master image, they skip the file copying and installation phase that occurs during Windows Setup, and they go straight to the customization phase. In Microsoft internal testing, 256 computers were deployed in 34 minutes.
 
-**Fast recovery.** Because the operating system images are hosted on the computer running iSCSI Target Server, if a diskless client needs to be replaced, the new computer can point to the operating system image, and boot up immediately.
+**Fast recovery.** Because the operating system images are hosted on the computer running iSCSI Target Server, if a disk-less client needs to be replaced, the new computer can point to the operating system image, and boot up immediately.
 
 > [!NOTE]
-> Various vendors provide a storage area network \(SAN\) boot solution, which can be used by the iSCSI Target Server in Windows Server on commodity hardware.
+> Various vendors provide a storage area network (SAN) boot solution, which can be used by the iSCSI Target Server in Windows Server on commodity hardware.
 
 ## <a name="BKMK_HARD"></a>Hardware requirements
-iSCSI Target Server does not require special hardware for functional verification. In data centers with large\-scale deployments, the design should be validated against specific hardware. For reference, Microsoft internal testing indicated that a 256 computer deployment required 24x15k\-RPM  disks in a RAID 10 configuration for storage. A network bandwidth of 10 GB is optimal. A general estimate is 60 iSCSI boot servers per 1 GB network adapter.
+iSCSI Target Server does not require special hardware for functional verification. In data centers with large-scale deployments, the design should be validated against specific hardware. For reference, Microsoft internal testing indicated that a 256 computer deployment required 24x15k-RPM  disks in a RAID 10 configuration for storage. A network bandwidth of 10 Gigabit is optimal. A general estimate is 60 iSCSI boot servers per 1 Gigabit network adapter.
 
-A network adapter is not required for this scenario, and a software boot loader can be used \(such as iPXE open source boot firmware\).
+A specialized network adapter is not required for this scenario, and a software boot loader can be used (such as iPXE open source boot firmware).
 
 ## <a name="BKMK_SOFT"></a>Software requirements
 iSCSI Target Server can be installed as part of the File and iSCSI Services role service in Server Manager.
@@ -41,6 +42,7 @@ iSCSI Target Server can be installed as part of the File and iSCSI Services role
 > Booting Nano Server from iSCSI (either from the Windows iSCSI Target Server, or a 3rd party target implementation) is not supported.
 
 ## Additional References
-* [iSCSI Target Server](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh848272(v=ws.11))
-* [iSCSI initiator cmdlets](/powershell/module/iscsi/)
-* [iSCSI Target Server cmdlets](/powershell/module/iscsi/)
+
+* [iSCSI Target Server](https://docs.microsoft.com/windows-server/storage/iscsi/iscsi-target-server)
+* [iSCSI initiator cmdlets](https://docs.microsoft.com/powershell/module/iscsi/)
+* [iSCSI Target Server cmdlets](https://docs.microsoft.com/powershell/module/iscsitarget/)


### PR DESCRIPTION
**Description:**

From issue ticket #1335 (**network adapater**):

> "A network adapter is not required for this scenario" should actually say "A specialized network adapter is not required for this scenario"

Thanks to @stephc-msft for noticing and reporting the missing word and suggesting "specialized" so I did not need to consider alternatives.  :+1:

**Changes proposed:**

- Main sentence correction: "A **specialized** network adapter is not required for this scenario, [ ... ]"
- GB should never be used indiscriminately to mean both "Gigabyte" (storage) and "Gigabit" (speed).
- All 3 links under **Additional References** are updated to modern document pages, using _full_ URL address.
- Link 2 and 3 have now got **correct** and **individual URL addresses** instead of using identical ones.
- Removed all 10 backslash escape characters, redundant with normal parentheses and dashes.
- Source text editorial blank line between metadata and the page title (H1)
- Source text editorial blank line after **Additional References**
- "diskless" => disk-less (noun versus adjective)
- **Applies to:** in bold

**Ticket closure or reference:**
Closes #1335