### PR TITLE
windows-commands: fix findstr example

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/findstr.md
+++ b/WindowsServerDocs/administration/windows-commands/findstr.md
@@ -89,7 +89,7 @@ findstr hello there x.y
 To search for *hello there* in file *x.y*, type:
 
 ```
-findstr /c:hello there x.y
+findstr "/c:hello there" x.y
 ```
 
 To find all occurrences of the word *Windows* (with an initial capital letter W) in the file *proposal.txt*, type:


### PR DESCRIPTION
Prior to this change the search for "hello there" was missing quotes.
The bad example would erroneously search for string hello in file there.

Fixes https://github.com/MicrosoftDocs/windowsserverdocs/issues/5192

Closes #xxxx

---

/cc @eross-msft @RAJU2529