### PR TITLE
Quote character placement for findstr /c

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/findstr.md
+++ b/WindowsServerDocs/administration/windows-commands/findstr.md
@@ -89,7 +89,7 @@ findstr hello there x.y
 To search for *hello there* in file *x.y*, type:
 
 ```
-findstr "/c:hello there" x.y
+findstr /c:"hello there" x.y
 ```
 
 To find all occurrences of the word *Windows* (with an initial capital letter W) in the file *proposal.txt*, type:


### PR DESCRIPTION
The quote characters should only encapsulate the search term, not the parameter.

There are a lot of examples online, on expert sites, where this is properly used.

Ref. originating PR #5196