### PR TITLE
Update DirectAccess-Known-Issues.md

### DIFF
--- a/WindowsServerDocs/remote/remote-access/directaccess/DirectAccess-Known-Issues.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/DirectAccess-Known-Issues.md
@@ -17,17 +17,16 @@ ms.date: 08/07/2020
 Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy Table (NRPT).
 If DNS registration is needed, for example **Manage Out**, it can be explicitly enabled with this registry key on the client:
 
-Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`
-Type: `DWORD`
-Value name: `DisableNRPTForAdapterRegistration`
-Values:
-`1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)
+Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`<br/>
+Type: `DWORD`<br/>
+Value name: `DisableNRPTForAdapterRegistration`<br/>
+Values:<br/>
+`1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)<br/>
 `0` - DNS Registration enabled
 
 ## Recommended hotfixes and updates for Windows Server 2012 DirectAccess
 The following link lists Microsoft Technical Support documents for DirectAccess that you should review and apply before you start your deployment to avoid an unusable configuration.
 
 -   [Recommended hotfixes and updates for Windows Server 2012 DirectAccess](https://support.microsoft.com/kb/2883952)
-
 
 

--- a/WindowsServerDocs/remote/remote-access/directaccess/DirectAccess-Known-Issues.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/DirectAccess-Known-Issues.md
@@ -14,21 +14,20 @@ ms.date: 08/07/2020
 
 ## DNS registration of DirectAccess client IPv6 addresses
 
-Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy (NRPT).
-If the DNS registration is needed, for e.g. Manage Out, it can be explicitely enabled with this registry key on the client:
+Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy Table (NRPT).
+If DNS registration is needed, for example **Manage Out**, it can be explicitly enabled with this registry key on the client:
 
-Path: ```HKLM\System\CurrentControlSet\Services\Dnscache\Parameters```   
-Type: ``DWORD``   
-Value name: ``DisableNRPTForAdapterRegistration``   
-Values:   
-``1`` - DNS Registration disabled (default since Windows 10 May 2020 Update)   
-``0`` - DNS Registration enabled
+Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`
+Type: `DWORD`
+Value name: `DisableNRPTForAdapterRegistration`
+Values:
+`1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)
+`0` - DNS Registration enabled
 
 ## Recommended hotfixes and updates for Windows Server 2012 DirectAccess
 The following link lists Microsoft Technical Support documents for DirectAccess that you should review and apply before you start your deployment to avoid an unusable configuration.
 
 -   [Recommended hotfixes and updates for Windows Server 2012 DirectAccess](https://support.microsoft.com/kb/2883952)
-
 
 
 

--- a/WindowsServerDocs/remote/remote-access/directaccess/DirectAccess-Known-Issues.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/DirectAccess-Known-Issues.md
@@ -10,8 +10,19 @@ ms.date: 08/07/2020
 ---
 # DirectAccess Known Issues
 
->Applies To: Windows Server (Semi-Annual Channel), Windows Server 2016
+>Applies To: Windows Server (Semi-Annual Channel), Windows Server 2016, Windows Server 2019
 
+## DNS registration of DirectAccess client IPv6 addresses
+
+Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy (NRPT).
+If the DNS registration is needed, for e.g. Manage Out, it can be explicitely enabled with this registry key on the client:
+
+Path: ```HKLM\System\CurrentControlSet\Services\Dnscache\Parameters```   
+Type: ``DWORD``   
+Value name: ``DisableNRPTForAdapterRegistration``   
+Values:   
+``1`` - DNS Registration disabled (default since Windows 10 May 2020 Update)   
+``0`` - DNS Registration enabled
 
 ## Recommended hotfixes and updates for Windows Server 2012 DirectAccess
 The following link lists Microsoft Technical Support documents for DirectAccess that you should review and apply before you start your deployment to avoid an unusable configuration.


### PR DESCRIPTION
Documenting a change in the Win10 clients default behaviour in regards to DNS registration with NRPT configured DNS servers breaking Manage Out Scenarios and puzzling monitoring tools. The registry key was introduced with https://support.microsoft.com/en-us/help/4507466/windows-10-update-kb4507466 but only with Win10 2020 H1 it is activated by default.