### PR TITLE
Update da-adv-plan-s1-infrastructure.md

### DIFF
--- a/WindowsServerDocs/remote/remote-access/directaccess/single-server-advanced/da-adv-plan-s1-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/single-server-advanced/da-adv-plan-s1-infrastructure.md
@@ -317,6 +317,17 @@ Auto detection works as follows:
 
 -   If the corporate network is IPv6-based, the default address is the IPv6 address of DNS servers in the corporate network.
 
+> [!NOTE]
+> Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy (NRPT).
+> If the DNS registration is needed, for e.g. Manage Out, it can be explicitely enabled with this registry key on the client:
+> 
+> Path: ```HKLM\System\CurrentControlSet\Services\Dnscache\Parameters```   
+> Type: ``DWORD``   
+> Value name: ``DisableNRPTForAdapterRegistration``   
+> Values:   
+> ``1`` - DNS Registration disabled (default since Windows 10 May 2020 Update)   
+> ``0`` - DNS Registration enabled
+
 **Infrastructure servers**
 
 -   **Network location server**

--- a/WindowsServerDocs/remote/remote-access/directaccess/single-server-advanced/da-adv-plan-s1-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/single-server-advanced/da-adv-plan-s1-infrastructure.md
@@ -321,11 +321,11 @@ Auto detection works as follows:
 > Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy Table (NRPT).
 > If DNS registration is needed, for example **Manage Out**, it can be explicitly enabled with this registry key on the client:
 >
-> Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`
-> Type: `DWORD`
-> Value name: `DisableNRPTForAdapterRegistration`
-> Values:
-> `1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)
+> Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`<br/>
+> Type: `DWORD`<br/>
+> Value name: `DisableNRPTForAdapterRegistration`<br/>
+> Values:<br/>
+> `1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)<br/>
 > `0` - DNS Registration enabled
 
 **Infrastructure servers**

--- a/WindowsServerDocs/remote/remote-access/directaccess/single-server-advanced/da-adv-plan-s1-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/single-server-advanced/da-adv-plan-s1-infrastructure.md
@@ -318,15 +318,15 @@ Auto detection works as follows:
 -   If the corporate network is IPv6-based, the default address is the IPv6 address of DNS servers in the corporate network.
 
 > [!NOTE]
-> Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy (NRPT).
-> If the DNS registration is needed, for e.g. Manage Out, it can be explicitely enabled with this registry key on the client:
-> 
-> Path: ```HKLM\System\CurrentControlSet\Services\Dnscache\Parameters```   
-> Type: ``DWORD``   
-> Value name: ``DisableNRPTForAdapterRegistration``   
-> Values:   
-> ``1`` - DNS Registration disabled (default since Windows 10 May 2020 Update)   
-> ``0`` - DNS Registration enabled
+> Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy Table (NRPT).
+> If DNS registration is needed, for example **Manage Out**, it can be explicitly enabled with this registry key on the client:
+>
+> Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`
+> Type: `DWORD`
+> Value name: `DisableNRPTForAdapterRegistration`
+> Values:
+> `1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)
+> `0` - DNS Registration enabled
 
 **Infrastructure servers**
 
@@ -686,4 +686,3 @@ The Remote Access Management console will display the following error message: *
 ## Next steps
 
 -   [Step 2: Plan DirectAccess Deployments](da-adv-plan-s2-deployments.md)
-


### PR DESCRIPTION
Documenting a change in the Win10 clients default behaviour in regards to DNS registration with NRPT configured DNS servers breaking Manage Out Scenarios and puzzling monitoring tools. The registry key was introduced with https://support.microsoft.com/en-us/help/4507466/windows-10-update-kb4507466 but only with Win10 2020 H1 it is activated by default.