### PR TITLE
Update da-basic-plan-s1-infrastructure.md

### DIFF
--- a/WindowsServerDocs/remote/remote-access/directaccess/single-server-wizard/da-basic-plan-s1-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/single-server-wizard/da-basic-plan-s1-infrastructure.md
@@ -110,6 +110,17 @@ In a DirectAccess deployment, DNS is required for the following:
 
     2.  If the corporate network is IPv6-based, the default address is the IPv6 address of DNS servers in the corporate network.
 
+> [!NOTE]
+> Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy (NRPT).
+> If the DNS registration is needed, for e.g. Manage Out, it can be explicitely enabled with this registry key on the client:
+> 
+> Path: ```HKLM\System\CurrentControlSet\Services\Dnscache\Parameters```   
+> Type: ``DWORD``   
+> Value name: ``DisableNRPTForAdapterRegistration``   
+> Values:   
+> ``1`` - DNS Registration disabled (default since Windows 10 May 2020 Update)   
+> ``0`` - DNS Registration enabled
+
 -   **Infrastructure servers**
 
     1.  **Network location server**. DirectAccess clients attempt to reach the network location server to determine if they are on the internal network. Clients on the internal network must be able to resolve the name of the network location server, but must be prevented from resolving the name when they are located on the Internet. To ensure this occurs, by default, the FQDN of the network location server is added as an exemption rule to the NRPT. In addition, when you configure DirectAccess, the following rules are created automatically:

--- a/WindowsServerDocs/remote/remote-access/directaccess/single-server-wizard/da-basic-plan-s1-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/single-server-wizard/da-basic-plan-s1-infrastructure.md
@@ -114,11 +114,11 @@ In a DirectAccess deployment, DNS is required for the following:
 > Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy Table (NRPT).
 > If DNS registration is needed, for example **Manage Out**, it can be explicitly enabled with this registry key on the client:
 >
-> Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`
-> Type: `DWORD`
-> Value name: `DisableNRPTForAdapterRegistration`
-> Values:
-> `1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)
+> Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`<br/>
+> Type: `DWORD`<br/>
+> Value name: `DisableNRPTForAdapterRegistration`<br/>
+> Values:<br/>
+> `1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)<br/>
 > `0` - DNS Registration enabled
 
 -   **Infrastructure servers**

--- a/WindowsServerDocs/remote/remote-access/directaccess/single-server-wizard/da-basic-plan-s1-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/directaccess/single-server-wizard/da-basic-plan-s1-infrastructure.md
@@ -111,15 +111,15 @@ In a DirectAccess deployment, DNS is required for the following:
     2.  If the corporate network is IPv6-based, the default address is the IPv6 address of DNS servers in the corporate network.
 
 > [!NOTE]
-> Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy (NRPT).
-> If the DNS registration is needed, for e.g. Manage Out, it can be explicitely enabled with this registry key on the client:
-> 
-> Path: ```HKLM\System\CurrentControlSet\Services\Dnscache\Parameters```   
-> Type: ``DWORD``   
-> Value name: ``DisableNRPTForAdapterRegistration``   
-> Values:   
-> ``1`` - DNS Registration disabled (default since Windows 10 May 2020 Update)   
-> ``0`` - DNS Registration enabled
+> Starting with the Windows 10 May 2020 Update, a client no longer registers its IP addresses on DNS servers configured in a Name Resolution Policy Table (NRPT).
+> If DNS registration is needed, for example **Manage Out**, it can be explicitly enabled with this registry key on the client:
+>
+> Path: `HKLM\System\CurrentControlSet\Services\Dnscache\Parameters`
+> Type: `DWORD`
+> Value name: `DisableNRPTForAdapterRegistration`
+> Values:
+> `1` - DNS Registration disabled (default since the Windows 10 May 2020 Update)
+> `0` - DNS Registration enabled
 
 -   **Infrastructure servers**
 
@@ -253,4 +253,3 @@ If a DirectAccess server, client, or application server GPO has been deleted by 
 ### <a name="BKMK_Links"></a>Next step
 
 -   [Step 2: Plan the Basic DirectAccess Deployment](da-basic-plan-s2-deployment.md)
-


### PR DESCRIPTION
Documenting a change in the Win10 clients default behaviour in regards to DNS registration with NRPT configured DNS servers breaking Manage Out Scenarios and puzzling monitoring tools. The registry key was introduced with https://support.microsoft.com/en-us/help/4507466/windows-10-update-kb4507466 but only with Win10 2020 H1 it is activated by default.