### PR TITLE
Configure CEPCES02: "IISUsers" typo correction

### DIFF
--- a/WindowsServerDocs/identity/solution-guides/certificate-enrollment-certificate-key-based-renewal.md
+++ b/WindowsServerDocs/identity/solution-guides/certificate-enrollment-certificate-key-based-renewal.md
@@ -19,7 +19,7 @@ This article provides step-by-step instructions to implement the Certificate Enr
 
 This article also explains how CEP and CES works and provides setup guidelines.
 
-> [!Note]
+> [!NOTE]
 > The workflow that's included in this article applies to a specific scenario. The same workflow may not work for a different situation. However, the principles remain the same.
 >
 > Disclaimer: This setup is created for a specific requirement in which you do not want to use port 443 for the default HTTPS communication for CEP and CES servers. Although this setup is possible, it has limited supportability. Customer Services and Support can best assist you if you follow this guide carefully using minimal deviation from the provided web server configuration.
@@ -49,17 +49,17 @@ For this example, the instructions are based on an environment that uses the fol
 2. As a prerequisite, configure a CEP and CES server for username and password authentication.
    In this environment, we refer to the instance as "CEPCES01".
 
-3.	Configure another CEP and CES instance by using PowerShell for certificate-based authentication on the same server. The CES instance will use a service account.
+3. Configure another CEP and CES instance by using PowerShell for certificate-based authentication on the same server. The CES instance will use a service account.
 
     In this environment, we refer to the instance as “CEPCES02”. The service account that’s used is ”cepcessvc”.
 
-4.	Configure client-side settings.
+4. Configure client-side settings.
 
 ### Configuration
 
 This section provides the steps to configure the initial enrollment.
 
-> [!Note]
+> [!NOTE]
 > You can also configure any user service account, MSA, or GMSA for CES to work.
 
 As a prerequisite, you must configure CEP and CES on a server by using username and password authentication.
@@ -78,7 +78,7 @@ You can duplicate an existing computer template, and configure the following set
 
 4. Publish the new template on the CA.
 
-> [!Note]
+> [!NOTE]
 > Make sure the compatibility settings on the template is set to **Windows Server 2012 R2** as there is a known issue in which the templates are not visible if the compatibility is set to Windows Server 2016 or later version. For more informaiton, see [Cannot select Windows Server 2016 CA-compatible certificate templates from Windows Server 2016 or later-based CAs or CEP servers](https://support.microsoft.com/en-in/help/4508802/cannot-select-certificate-templates-in-windows-server-2016).
 
 
@@ -96,7 +96,7 @@ See the following articles for step-by-step guidance to enable CEP and CES for u
 
 [Certificate Enrollment Web Service Guidance](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831822(v=ws.11)#configure-a-ca-for-the-certificate-enrollment-web-service)
 
-> [!Note]
+> [!NOTE]
 > Make sure that you do not select the “Enable Key-Based Renewal” option if you configure both CEP and CES instances of username and password authentication.
 
 **Method 2**
@@ -115,7 +115,7 @@ Install-AdcsEnrollmentPolicyWebService -AuthenticationType Username -SSLCertThum
 
 This command installs the Certificate Enrollment Policy Web Service (CEP) by specifying that a username and password is used for authentication.
 
-> [!Note]
+> [!NOTE]
 > In this command, \<**SSLCertThumbPrint**\> is the thumbprint of the certificate that will be used to bind IIS.
 
 ```PowerShell
@@ -145,7 +145,7 @@ Install-AdcsEnrollmentPolicyWebService -AuthenticationType Certificate -SSLCertT
 
 This command installs the Certificate Enrollment Policy Web Service (CEP) and specifies that a certificate is used for authentication.
 
-> [!Note]
+> [!NOTE]
 > In this command, \<SSLCertThumbPrint\> is the thumbprint of the certificate that will be used to bind IIS.
 
 Key-based renewal lets certificate clients renew their certificates by using the key of their existing certificate for authentication. When in key-based renewal mode, the service will return only certificate templates that are set for key-based renewal.
@@ -160,8 +160,8 @@ In this command, the identity of the Certificate Enrollment Web Service is speci
 
 The **RenewalOnly** cmdlet lets CES run in renewal only mode. The **AllowKeyBasedRenewal** cmdlet also specifies that the CES will accept key based renewal requests for the enrollment server. These are valid client certificates for authentication that do not directly map to a security principal.
 
-> [!Note]
-> The service account must be part of **IISUsers** group on the server.
+> [!NOTE]
+> The service account must be part of **IIS_IUSRS** group on the server.
 
 ##### Step 2 Check the IIS Manager console
 
@@ -170,7 +170,7 @@ After a successful installation, you expect to see the following display in the 
 
 Select **KeyBasedRenewal_ADPolicyProvider_CEP_Certificate** under **Default Web Site** and open **Application Settings**. Take a note of the **ID** and the **URI**. You can add a **Friendly Name** for management.
 
-> [!Note]
+> [!NOTE]
 > If the instance is installed on a new server double check the ID to make sure that the ID is the same one that was generated in the CEPCES01 instance. You can copy and paste the value directly if it is different.
 
 #### Complete Certificate Enrollment Web Services configuration
@@ -181,7 +181,7 @@ To be able to enroll the certificate on behalf of the functionality of CEP and C
 
 This account will be used for authentication towards key-based renewal and the “Publish to Active Directory” option on the certificate template.
 
-> [!Note]
+> [!NOTE]
 > You do not have to domain join the client machine. This account comes into picture while doing certificate based authentication in KBR for dsmapper service.
 
 ![New Object](media/certificate-enrollment-certificate-key-based-renewal-6.png)
@@ -195,10 +195,10 @@ Get-ADUser -Identity cepcessvc | Set-ADAccountControl -TrustedToAuthForDelegatio
 Set-ADUser -Identity cepcessvc -Add @{'msDS-AllowedToDelegateTo'=@('HOST/CA1.contoso.com','RPCSS/CA1.contoso.com')}
 ```
 
-> [!Note]
-> In this command, \<cepcessvc\> is the service account, and <CA1.contoso.com >is the Certification Authority.
+> [!NOTE]
+> In this command, \<cepcessvc\> is the service account, and <CA1.contoso.com> is the Certification Authority.
 
-> [!Important]
+> [!IMPORTANT]
 > We are not enabling the RENEWALONBEHALOF flag on the CA in this configuration because we are using constrained delegation to do the same job for us. This lets us to avoid adding the permission for the service account to the CA’s security.
 
 ##### Step 3: Configure a custom port on the IIS web server
@@ -247,7 +247,7 @@ On the client computer, set up the Enrollment policies and Auto-Enrollment polic
    c. Set a priority of **10**, and  then validate the policy server.
       ![Screenshot that shows where to set the priority.](media/certificate-enrollment-certificate-key-based-renewal-10.png)
 
-   > [!Note]
+   > [!NOTE]
    > Make sure that the port number is added to the URI and is allowed on the firewall.
 
 5. Enroll the first certificate for the computer through certlm.msc.
@@ -264,7 +264,7 @@ On the client computer, set up the Enrollment policies and Auto-Enrollment polic
 
    ![Enrollment Policy](media/certificate-enrollment-certificate-key-based-renewal-13.png)
 
-> [!Note]
+> [!NOTE]
 > Make sure that the priority value of the key-based renewal enrollment policy is lower than the priority of the Username Password enrollment policy priority. The first preference is given to the lowest priority.
 
 ## Testing the setup
@@ -295,7 +295,7 @@ Therefore, if you advance the time to 8:10 P.M. on the 19th since our renewal wi
 
 After the test finishes, revert the time setting to the original value, and then restart the client computer.
 
-> [!Note]
+> [!NOTE]
 > The previous screenshot is an example to demonstrate that the Auto-Enrollment engine works as expected because the CA date is still set to the 18th. Therefore, it continues to issue certificates. In a real-life situation, this large amount of renewals will not occur.
 
 ## References
@@ -308,7 +308,7 @@ After the test finishes, revert the time setting to the original value, and then
 
 [Install-AdcsEnrollmentWebService](/powershell/module/adcsdeployment/install-adcsenrollmentwebservice)
 
-See also
+### See also
 
 [Windows Server Security Forum](https://aka.ms/adcsforum)
 


### PR DESCRIPTION
**Description:**
From issue ticket #5233 (**IISUsers should read IIS_IUSRS**)
> Title says it all

Thanks to @andrePKI  for noticing and reporting the typo.

**Changes proposed:**
- typo correction "IISUsers" -> **IIS_IUSRS** (verified)

**Codestyle & whitespace:**
- change all [!Important] & [!Note] blob tags to UPPERCASE (MS Docs codestyle)
- convert 2 tabs to single space in numbered list
- \<CA1.contoso.com \> incorrect space moved to before the next word "is"
- add missing H3 heading style to the "See also" section title

**Ticket closure or reference:**

Closes #5233