### PR TITLE
Update cmdkey.md - fix backtick placement in delete

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/cmdkey.md
+++ b/WindowsServerDocs/administration/windows-commands/cmdkey.md
@@ -29,7 +29,7 @@ cmdkey [{/add:<targetname>|/generic:<targetname>}] {/smartcard | /user:<username
 | /smartcard | Retrieves the credential from a smart card. If more than one smart card is found on the system when this option is used, **cmdkey** displays information about all available smart cards, and then prompts the user to specify which one to use. |
 | /user:`<username>` | Specifies the user or account name to store with this entry. If `<username>` isn't supplied, it will be requested. |
 |/pass:`<password>` | Specifies the password to store with this entry. If `<password>` isn't supplied, it will be requested. Passwords are not displayed after they're stored. |
-| /delete{:`<targetname> | /ras}` | Deletes a user name and password from the list. If `<targetname>` is specified, that entry is deleted. If `/ras` is specified, the stored remote access entry is deleted. |
+| /delete:`{<targetname> \| /ras}` | Deletes a user name and password from the list. If `<targetname>` is specified, that entry is deleted. If `/ras` is specified, the stored remote access entry is deleted. |
 | /list:`<targetname>` | Displays the list of stored user names and credentials. If `<targetname>` isn't specified, all stored user names and credentials are listed. |
 | /? | Displays help at the command prompt. |
 


### PR DESCRIPTION
it looks sorta wonky with the backtick being there, so i moved it over. 

also fix the pipe not being escaped


Before: 

<img width="133" alt="2021-02-04 17_15_50 - Screenshot - cmdkey docs - before" src="https://user-images.githubusercontent.com/802786/106976271-58fecd80-6715-11eb-8f8e-bad39fd9c38a.png">



After:

<img width="146" alt="2021-02-04 17_16_18 - Screenshot - cmdkey docs - after" src="https://user-images.githubusercontent.com/802786/106976277-5ac89100-6715-11eb-846e-9aed6f3e6476.png">


Also, I'm unsure if this will impact the rendered build on docs.microsoft.com, but the rendered build on github was messing up because of the unescaped pipe character. Butting a backslash before it to escape it works in the github rendered view at least, but this can be removed if it breaks the view on docs.microsoft.com