### PR TITLE
VMConnect: add Server 2019, grammar & codestyle

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/learn-more/hyper-v-virtual-machine-connect.md
+++ b/WindowsServerDocs/virtualization/hyper-v/learn-more/hyper-v-virtual-machine-connect.md
@@ -7,21 +7,23 @@ ms.author: benarm
 author: BenjaminArmstrong
 ms.date: 10/04/2016
 ---
+
 # Hyper-V Virtual Machine Connection
 
->Applies To: Windows Server 2016, Windows 10, Windows 8.1, Windows Server 2012 R2, Windows Server 2012, Windows 8
+> **Applies to:** Windows Server 2019, Windows Server 2016, Windows 10, Windows 8.1, Windows Server 2012 R2, Windows Server 2012, Windows 8
 
-Virtual Machine Connection \(VMConnect\) is a tool that you use to connect to a virtual machine so that you can install or interact with the guest operating system in a virtual machine. Some of the tasks that you can perform by using VMConnect include the following:
+Virtual Machine Connection \(VMConnect\) is a tool you can use to connect to a virtual machine to install or interact with the guest operating system in a virtual machine. Some of the tasks you can perform by using VMConnect include the following:
 
--   Start and shut down a virtual machine
+- Start and shut down a virtual machine
 
--   Connect to a DVD image \(.iso file\) or a USB flash drive
+- Connect to a DVD image \(.iso file\) or a USB flash drive
 
--   Create a checkpoint
+- Create a checkpoint
 
--   Modify the settings of a virtual machine
+- Modify the settings of a virtual machine
 
 ## Tips for using VMConnect
+
 You may find the following information helpful for using VMConnect:
 
 |To do this…|Do this…|
@@ -41,6 +43,7 @@ You may find the following information helpful for using VMConnect:
 
 
 ## Keyboard shortcuts
+
 By default, the keyboard input and mouse clicks are sent to the virtual machine. So you may need to press CTRL + ALT + LEFT arrow before you use the following shortcut keys.
 
 |Key combination|Description|
@@ -55,6 +58,7 @@ By default, the keyboard input and mouse clicks are sent to the virtual machine.
 |CTRL\+C|Do a screen capture|
 
 ## See Also
--   [Use local resources on Hyper-V virtual machine with VMConnect](Use-local-resources-on-Hyper-V-virtual-machine-with-VMConnect.md)
--   [Hyper-V on Windows Server 2016](../Hyper-V-on-Windows-Server.md)
--   [Hyper-V on Windows 10](/virtualization/hyper-v-on-windows/)
+
+- [Use local resources on Hyper-V virtual machine with VMConnect](Use-local-resources-on-Hyper-V-virtual-machine-with-VMConnect.md)
+- [Hyper-V on Windows Server 2016](../Hyper-V-on-Windows-Server.md)
+- [Hyper-V on Windows 10](/virtualization/hyper-v-on-windows/)


### PR DESCRIPTION
**Description:**
From issue ticket #4051:
>> This page also applies to Server 2019. Also, should Windows 8 (be) removed?
>
> So far as I can see, this is not resolved, in that Server 2019 has not been added?

Thanks to @doctordns for reporting and keeping the issue ticket alive.

**Changes proposed:**

- Add "Windows Server 2019" in the "**Applies to:** " list/line.
- Improve English grammar by removing overused "that" in the introductory description.

**Codestyle & whitespace:**

- Add editorial blank line between metadata and the page title (H1)
- Add editorial blank line after H2 headings (3 occurrences)
- Add missing MarkDown indent marker compatibility spacing in "> Applies to:"
- Normalize bullet point list spacing, from 3 spaces to 1 (7 occurrences)
- Simplify capitalization to only the first letter in "Applies to:"
- Add missing colon in "Applies to:"
- Add **bold** format to "Applies to:"

**Ticket closure or reference:**

Closes #4051