### PR TITLE
Listing miniorange as ADFS MFA Vendor

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Configure-Additional-Authentication-Methods-for-AD-FS.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Configure-Additional-Authentication-Methods-for-AD-FS.md
@@ -34,6 +34,7 @@ Below is an alphabetical list of Microsoft and third-party providers with MFA of
 |Login People|Login People MFA API connector for AD FS 2012 R2 (public beta)|[https://www.loginpeople.com](https://www.loginpeople.com)|
 |Microsoft Corp.|Microsoft Azure MFA|[Walkthrough Guide: Manage Risk with Additional Multi-Factor Authentication for Sensitive Applications](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn280946(v=ws.11)) (see step 3)|
 Mideye | Mideye Authentication Provider for ADFS | [Mideye two-factor authentication with Microsoft Active Directory Federation Service](https://www.mideye.com/support/administrators/documentation/integration/microsoft-adfs/)|
+MiniOrange | 15+ MFA methods for ADFS |[miniOrange MFA for ADFS](https://idp.miniorange.com/steps-to-enable-2fa-on-top-of-adfs-authentication/)|
 |Okta | Okta MFA for Active Directory Federation Services | [Okta MFA for Active Directory Federation Services (ADFS)](https://help.okta.com/en/prod/Content/Topics/integrations/adfs-okta-int.htm)|
 |One Identity| Starling 2FA AD FS|[Starling 2FA AD FS Adapter](https://www.oneidentity.com/products/starling-two-factor-authentication/)|
 |One Identity| Defender AD FS|[Defender AD FS Adapter](https://www.oneidentity.com/products/defender/)|


### PR DESCRIPTION
Hello,

We have many customers who are already using miniOrange MFA services for ADFS. It would be great for both of us and beneficial for our mutual customers to get solutions easily if you list miniOrange MFA to your ADFS MFA page.

About miniOrange:
miniOrange is a cloud and on-premise based Identity and Access Management (IAM) solution provider.
miniOrange also makes provision for web-based security solutions for Single Sign-On, 15+ ways for Multi-Factor Authentication (MFA), User Provisioning, Identity Brokering, Social Login, etc.

Thank you!