### PR TITLE
Fix wrong date format for Windows Server 2004

### DIFF
--- a/WindowsServerDocs/get-started/windows-server-release-info.md
+++ b/WindowsServerDocs/get-started/windows-server-release-info.md
@@ -18,7 +18,7 @@ The Semi-Annual Channel provides opportunity for customers who are innovating qu
 | Windows Server release | Version | OS Build | Availability | Mainstream support end date|Extended support end date |
 |----------------|---------|----------|----------|---------|----------|
 | Windows Server, version 20H2 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 20H2 | 19042.508.200927-1902 | 10/20/2020 | 05/10/2022 | Review note |
-| Windows Server, version 2004 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 2004 | 19041.264.200508-2205 | 05/27/20 | 12/14/2021 | Review note |
+| Windows Server, version 2004 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 2004 | 19041.264.200508-2205 | 05/27/2020 | 12/14/2021 | Review note |
 | Windows Server, version 1909 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 1909  | 18363.418.191007-0143 | 11/12/2019 | 05/11/2021 | Review note |
 | Windows Server, version 1903 (Semi-Annual Channel) (Datacenter Core, Standard Core) | 1903  | 18362.30.190401-1528 | 5/21/2019 | 12/08/2020 | Review note |
 |Windows Server 2019 (Long-Term Servicing Channel) (Datacenter, Essentials, Standard)|1809|17763.107.1010129-1455|11/13/2018|01/09/2024|01/09/2029|


### PR DESCRIPTION
Hello,

I realized the date format for 2004 wasn't following the same as the other.
Date format used is mm/dd/yyyy for the other entries. This one had mm/dd/yy.