### PR TITLE
updating Windows Server Core limitations and FOD

### DIFF
--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -49,38 +49,50 @@ The following table shows which applications are available *locally* on Server C
 |------------------------------------|-----------------|--------------------------------|
 | Command prompt                     | available       | available                      |
 | Windows PowerShell/ Microsoft .NET | available       | available                      |
-| Perfmon.exe                        | not available   | available                      |
+| Perfmon.exe                        | with FOD 1903   | available                      |
 | Windbg (GUI)                       | supported       | supported                      |
-| Resmon.exe                         | not available   | available                      |
+| Resmon.exe                         | with FOD 1903   | available                      |
 | Regedit                            | available       | available                      |
 | Fsutil.exe                         | available       | available                      |
 | Disksnapshot.exe                   | not available   | available                      |
 | Diskpart.exe                       | available       | available                      |
-| Diskmgmt.msc                       | not available   | available                      |
-| Devmgmt.msc                        | not available   | available                      |
+| Diskmgmt.msc                       | with FOD 1903   | available                      |
+| Devmgmt.msc                        | with FOD 1903   | available                      |
 | Server Manager                     | not available   | available                      |
-| Mmc.exe                            | not available   | available                      |
-| Eventvwr                           | not available   | available                      |
+| Mmc.exe                            | with FOD 1903   | available                      |
+| Eventvwr                           | with FOD 1903   | available                      |
 | Wevtutil (Event queries)           | available       | available                      |
 | Services.msc                       | not available   | available                      |
 | Control Panel                      | not available   | available                      |
 | Windows Update (GUI)               | not available   | available                      |
-| Windows Explorer                   | not available   | available                      |
+| Windows Explorer                   | with FOD 1903   | available                      |
 | Taskbar                            | not available   | available                      |
 | Taskbar notifications              | not available   | available                      |
 | Taskmgr                            | available       | available                      |
-| Internet Explorer or Edge          | not available   | available                      |
+| Taskscheduler (taskschd.msc)       | with FOD 1903   | available                      |
+| Internet Explorer                  | with FOD 1903   | available                      |
+| Edge                               | not available   | available*                     |
+| Edge Chromium (Enterprise)         | optional install| optional install               |
 | Built-in help system               | not available   | available                      |
 | Windows 10 Shell                   | not available   | available                      |
 | Windows Media Player               | not available   | available                      |
 | PowerShell                         | available       | available                      |
-| PowerShell ISE                     | not available   | available                      |
+| PowerShell ISE                     | FOD 1903**      | available**                    |
 | PowerShell IME                     | available       | available                      |
 | Mstsc.exe                          | not available   | available                      |
 | Remote Desktop Services            | available       | available                      |
-| Hyper-V Manager                    | not available   | available                      |
+| Hyper-V Manager                    | FOD 1903        | available                      |
 | WordPad\*                          | not available   | available                      |
 
+Features indicated with an asterisk ( * ) are end of support by March 21, 2021. Edge Chromium is a more versatile and modern Browser to replace Internet Explorer and EdgeHTML.
+Features indicated with 2 asterisks ( ** ) are officially deprecated. Please consider to use Visual Studio Code instead of ISE.
+
+>[!NOTE]
+> The idea of installing of Feature on Demand on Server Core is to a balance between security and a smaller footprint and application compatibility.
+> We do not encourage to install Feature on Demand per default, nor to enchance local administration of Server Core, but to mitigate possible application compatibility issues, of 3rd application application hosted on Server Core installation that will only run as intended when some of the removed featureset of Server Core is added back by Feature on Demand. 
+> For modern Remote Administration please use in-built tools like PowerShell 5.1, Sconfig. or External Tools like Windows Admin Center via web browser.
+> Alternatively Server Manager with RSAT Tools on a remote management client or server with a graphical experience.
+> Adding Feature on Demand can lower security and increase the amount of servicing through updates and restarts.
 
 For more information about what *is* included in Server Core, see [Roles, Role Services, and Features included in Windows Server - Server Core](server-core-roles-and-services.md). And for information about what *is not* included in Server Core, see [Roles, Role Services, and Features not included in Server Core](server-core-removed-roles.md)
 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -86,7 +86,7 @@ The following table shows which applications are available *locally* on Server C
 
 \* To read .RTF files locally stored on a Server Core SKU, users can copy the file(s) to a different Windows computer where WordPad is present.
 
-Features indicated with 2 asterisks ( \** ) are end of support by March 21, 2021. Edge Chromium is a more versatile and modern Browser to replace Internet Explorer and EdgeHTML.
+Features indicated with 2 asterisks ( \** ) reached end of support by March 21, 2021. Edge Chromium is a more versatile and modern Browser, replacing Internet Explorer and EdgeHTML.
 
 Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please consider to use Visual Studio Code instead of ISE.
 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -92,7 +92,7 @@ Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please c
 
 > [!NOTE]
 > **Adding Features on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**
-> The idea of installing of Features on Demand on Server Core is to a balance between security and a smaller footprint and application compatibility.
+> The idea of installing Features on Demand on Server Core is to a balance between security, a smaller footprint, and application compatibility.
 > 
 > We do not encourage to install Features on Demand per default, nor to improve local administration capabilities of Server Core, but to mitigate possible application compatibility issues, of 3rd party applications hosted on a Server Core installation, which might only run as intended when some of the removed featuresets of Server Core is added back by installing Features on Demand.
 > 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -71,21 +71,24 @@ The following table shows which applications are available *locally* on Server C
 | Taskmgr                            | available       | available                      |
 | Taskscheduler (taskschd.msc)       | with FOD 1903   | available                      |
 | Internet Explorer                  | with FOD 1903   | available                      |
-| Edge                               | not available   | available*                     |
+| Edge                               | not available   | available**                    |
 | Edge Chromium (Enterprise)         | optional install| optional install               |
 | Built-in help system               | not available   | available                      |
 | Windows 10 Shell                   | not available   | available                      |
 | Windows Media Player               | not available   | available                      |
 | PowerShell                         | available       | available                      |
-| PowerShell ISE                     | FOD 1903**      | available**                    |
+| PowerShell ISE                     | FOD 1903***     | available***                   |
 | PowerShell IME                     | available       | available                      |
 | Mstsc.exe                          | not available   | available                      |
 | Remote Desktop Services            | available       | available                      |
 | Hyper-V Manager                    | FOD 1903        | available                      |
 | WordPad\*                          | not available   | available                      |
 
-Features indicated with an asterisk ( * ) are end of support by March 21, 2021. Edge Chromium is a more versatile and modern Browser to replace Internet Explorer and EdgeHTML.
-Features indicated with 2 asterisks ( ** ) are officially deprecated. Please consider to use Visual Studio Code instead of ISE.
+\* To read .RTF  files locally stored on a Server Core SKU, users can copy the file(s) to a different Windows computer where WordPad is present.
+
+Features indicated with 2 asterisks ( \** ) are end of support by March 21, 2021. Edge Chromium is a more versatile and modern Browser to replace Internet Explorer and EdgeHTML.
+
+Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please consider to use Visual Studio Code instead of ISE.
 
 >[!NOTE]
 > **Adding Feature on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**
@@ -95,12 +98,12 @@ Features indicated with 2 asterisks ( ** ) are officially deprecated. Please con
 > 
 > For modern Remote Administration please use in-built tools like PowerShell 5.1, Sconfig. or external Tools like web-based Windows Admin Center, or PowerShell 7 for enchanced capabilites.
 > 
-> Alternatively you can still use Server Manager with RSAT Tools on a remote management Client or Windows Server with a graphical experience.
+> Alternatively you can use Server Manager with RSAT Tools on a current remote management Client or current Windows Server with a graphical experience.
 
 
 For more information about what *is* included in Server Core, see [Roles, Role Services, and Features included in Windows Server - Server Core](server-core-roles-and-services.md). And for information about what *is not* included in Server Core, see [Roles, Role Services, and Features not included in Server Core](server-core-removed-roles.md)
 
-\* To read .RTF  files locally stored on a Server Core SKU, users can copy the file(s) to a different Windows computer where WordPad is present.
+
 
 ## Get started using Server Core
 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -122,4 +122,4 @@ Using Server Core:
 - [Configure memory dump files](server-core-memory-dump.md)
 
 Adding and managing Features on Demand (FOD):
-[Server Core App Compatibility Feature on Demand (FOD)](../../get-started-19/install-fod-19.md)
+- [Server Core App Compatibility Feature on Demand (FOD)](../../get-started-19/install-fod-19.md)

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -98,7 +98,7 @@ Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please c
 > 
 > For modern Remote Administration, please use built-in tools like PowerShell 5.1 or Sconfig.exe, or use external Tools, like web-based Windows Admin Center or PowerShell 7, for enhanced capabilities.
 > 
-> Alternatively you can use Server Manager with RSAT Tools on a current remote management Client or current Windows Server with a graphical experience.
+> Alternatively, you can use Server Manager with RSAT Tools on a current remote management Client or on a current Windows Server with Desktop Experience.
 
 
 For more information about what *is* included in Server Core, see [Roles, Role Services, and Features included in Windows Server - Server Core](server-core-roles-and-services.md). And for information about what *is not* included in Server Core, see [Roles, Role Services, and Features not included in Server Core](server-core-removed-roles.md)

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -88,11 +88,15 @@ Features indicated with an asterisk ( * ) are end of support by March 21, 2021. 
 Features indicated with 2 asterisks ( ** ) are officially deprecated. Please consider to use Visual Studio Code instead of ISE.
 
 >[!NOTE]
+> **Adding Feature on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**
 > The idea of installing of Feature on Demand on Server Core is to a balance between security and a smaller footprint and application compatibility.
+> 
 > We do not encourage to install Feature on Demand per default, nor to enchance local administration of Server Core, but to mitigate possible application compatibility issues, of 3rd application application hosted on Server Core installation that will only run as intended when some of the removed featureset of Server Core is added back by Feature on Demand. 
-> For modern Remote Administration please use in-built tools like PowerShell 5.1, Sconfig. or External Tools like Windows Admin Center via web browser.
-> Alternatively Server Manager with RSAT Tools on a remote management client or server with a graphical experience.
-> Adding Feature on Demand can lower security and increase the amount of servicing through updates and restarts.
+> 
+> For modern Remote Administration please use in-built tools like PowerShell 5.1, Sconfig. or external Tools like web-based Windows Admin Center, or PowerShell 7 for enchanced capabilites.
+> 
+> Alternatively you can still use Server Manager with RSAT Tools on a remote management Client or Windows Server with a graphical experience.
+
 
 For more information about what *is* included in Server Core, see [Roles, Role Services, and Features included in Windows Server - Server Core](server-core-roles-and-services.md). And for information about what *is not* included in Server Core, see [Roles, Role Services, and Features not included in Server Core](server-core-removed-roles.md)
 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -90,7 +90,7 @@ Features indicated with 2 asterisks ( \** ) are end of support by March 21, 2021
 
 Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please consider to use Visual Studio Code instead of ISE.
 
->[!NOTE]
+> [!NOTE]
 > **Adding Features on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**
 > The idea of installing of Features on Demand on Server Core is to a balance between security and a smaller footprint and application compatibility.
 > 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -122,4 +122,4 @@ Using Server Core:
 - [Configure memory dump files](server-core-memory-dump.md)
 
 Adding and managing Features on Demand (FOD):
-[Server Core App Compatibility Feature on Demand (FOD)}(../../get-started-19/install-fod-19.md)
+[Server Core App Compatibility Feature on Demand (FOD)](../../get-started-19/install-fod-19.md)

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -94,7 +94,7 @@ Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please c
 > **Adding Features on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**
 > The idea of installing Features on Demand on Server Core is to a balance between security, a smaller footprint, and application compatibility.
 > 
-> We do not encourage to install Features on Demand per default, nor to improve local administration capabilities of Server Core, but to mitigate possible application compatibility issues, of 3rd party applications hosted on a Server Core installation, which might only run as intended when some of the removed featuresets of Server Core is added back by installing Features on Demand.
+> We do not encourage installing Features on Demand by default, nor to improve local administration capabilities of Server Core, but to mitigate possible application compatibility issues, of 3rd party applications hosted on a Server Core installation, which might only run as intended when some of the removed feature sets of Server Core is re-added by installing Features on Demand.
 > 
 > For modern Remote Administration please use in-built tools like PowerShell 5.1, Sconfig. or external Tools like web-based Windows Admin Center, or PowerShell 7 for enchanced capabilites.
 > 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -84,7 +84,7 @@ The following table shows which applications are available *locally* on Server C
 | Hyper-V Manager                    | FOD 1903        | available                      |
 | WordPad\*                          | not available   | available                      |
 
-\* To read .RTF  files locally stored on a Server Core SKU, users can copy the file(s) to a different Windows computer where WordPad is present.
+\* To read .RTF files locally stored on a Server Core SKU, users can copy the file(s) to a different Windows computer where WordPad is present.
 
 Features indicated with 2 asterisks ( \** ) are end of support by March 21, 2021. Edge Chromium is a more versatile and modern Browser to replace Internet Explorer and EdgeHTML.
 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -96,7 +96,7 @@ Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please c
 > 
 > We do not encourage installing Features on Demand by default, nor to improve local administration capabilities of Server Core, but to mitigate possible application compatibility issues, of 3rd party applications hosted on a Server Core installation, which might only run as intended when some of the removed feature sets of Server Core is re-added by installing Features on Demand.
 > 
-> For modern Remote Administration please use in-built tools like PowerShell 5.1, Sconfig. or external Tools like web-based Windows Admin Center, or PowerShell 7 for enchanced capabilites.
+> For modern Remote Administration, please use built-in tools like PowerShell 5.1 or Sconfig.exe, or use external Tools, like web-based Windows Admin Center or PowerShell 7, for enhanced capabilities.
 > 
 > Alternatively you can use Server Manager with RSAT Tools on a current remote management Client or current Windows Server with a graphical experience.
 

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -91,10 +91,10 @@ Features indicated with 2 asterisks ( \** ) are end of support by March 21, 2021
 Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please consider to use Visual Studio Code instead of ISE.
 
 >[!NOTE]
-> **Adding Feature on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**
-> The idea of installing of Feature on Demand on Server Core is to a balance between security and a smaller footprint and application compatibility.
+> **Adding Features on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**
+> The idea of installing of Features on Demand on Server Core is to a balance between security and a smaller footprint and application compatibility.
 > 
-> We do not encourage to install Feature on Demand per default, nor to improve local administration capabilities of Server Core, but to mitigate possible application compatibility issues, of 3rd party application application hosted on Server Core installation that will only run as intended when some of the removed featureset of Server Core is added back by Feature on Demand. 
+> We do not encourage to install Features on Demand per default, nor to improve local administration capabilities of Server Core, but to mitigate possible application compatibility issues, of 3rd party applications hosted on a Server Core installation, which might only run as intended when some of the removed featuresets of Server Core is added back by installing Features on Demand.
 > 
 > For modern Remote Administration please use in-built tools like PowerShell 5.1, Sconfig. or external Tools like web-based Windows Admin Center, or PowerShell 7 for enchanced capabilites.
 > 
@@ -120,3 +120,6 @@ Using Server Core:
 - [Manage Server Core](server-core-manage.md)
 - [Patching Server Core](server-core-servicing.md)
 - [Configure memory dump files](server-core-memory-dump.md)
+
+Adding and managing Features on Demand (FOD):
+[Server Core App Compatibility Feature on Demand (FOD)}(../../get-started-19/install-fod-19.md)

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -88,7 +88,7 @@ The following table shows which applications are available *locally* on Server C
 
 Features indicated with 2 asterisks ( \** ) reached end of support by March 21, 2021. Edge Chromium is a more versatile and modern Browser, replacing Internet Explorer and EdgeHTML.
 
-Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please consider to use Visual Studio Code instead of ISE.
+Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please consider using Visual Studio Code instead of ISE.
 
 > [!NOTE]
 > **Adding Features on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**

--- a/WindowsServerDocs/administration/server-core/what-is-server-core.md
+++ b/WindowsServerDocs/administration/server-core/what-is-server-core.md
@@ -94,7 +94,7 @@ Features indicated with 3 asterisks ( \*** ) are officially deprecated. Please c
 > **Adding Feature on Demand can lower security and increase the amount of servicing due security updates needed OS restarts.**
 > The idea of installing of Feature on Demand on Server Core is to a balance between security and a smaller footprint and application compatibility.
 > 
-> We do not encourage to install Feature on Demand per default, nor to enchance local administration of Server Core, but to mitigate possible application compatibility issues, of 3rd application application hosted on Server Core installation that will only run as intended when some of the removed featureset of Server Core is added back by Feature on Demand. 
+> We do not encourage to install Feature on Demand per default, nor to improve local administration capabilities of Server Core, but to mitigate possible application compatibility issues, of 3rd party application application hosted on Server Core installation that will only run as intended when some of the removed featureset of Server Core is added back by Feature on Demand. 
 > 
 > For modern Remote Administration please use in-built tools like PowerShell 5.1, Sconfig. or external Tools like web-based Windows Admin Center, or PowerShell 7 for enchanced capabilites.
 > 

--- a/WindowsServerDocs/get-started-19/install-fod-19.md
+++ b/WindowsServerDocs/get-started-19/install-fod-19.md
@@ -149,6 +149,7 @@ The App Compatibility FOD can only be installed on Server Core. Don't attempt to
 
    - If you have a volume license you can download the Windows Server and Server FOD ISO image files from the [Volume Licensing Service Center](https://www.microsoft.com/Licensing/servicecenter/default.aspx).
    - The Server FOD ISO image file is also available for Long-Term Servicing Channel releases on the [Microsoft Evaluation Center](https://www.microsoft.com/evalcenter/evaluate-windows-server) or on the [Visual Studio portal](https://visualstudio.microsoft.com) for subscribers.
+   - As a Windows Insider, preview updates of Features on Demand are available on the [Windows Server Insider page](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver)
 
 2. Open a PowerShell session as an administrator and then use the following commands to mount the image files as drives:
 

--- a/WindowsServerDocs/get-started-19/install-fod-19.md
+++ b/WindowsServerDocs/get-started-19/install-fod-19.md
@@ -149,7 +149,7 @@ The App Compatibility FOD can only be installed on Server Core. Don't attempt to
 
    - If you have a volume license you can download the Windows Server and Server FOD ISO image files from the [Volume Licensing Service Center](https://www.microsoft.com/Licensing/servicecenter/default.aspx).
    - The Server FOD ISO image file is also available for Long-Term Servicing Channel releases on the [Microsoft Evaluation Center](https://www.microsoft.com/evalcenter/evaluate-windows-server) or on the [Visual Studio portal](https://visualstudio.microsoft.com) for subscribers.
-   - As a Windows Insider, preview updates of Features on Demand are available on the [Windows Server Insider page](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver)
+   - As a Windows Insider, preview updates of Features on Demand are available on the [Windows Server Insider page](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver).
 
 2. Open a PowerShell session as an administrator and then use the following commands to mount the image files as drives:
 

--- a/WindowsServerDocs/get-started-19/install-fod-19.md
+++ b/WindowsServerDocs/get-started-19/install-fod-19.md
@@ -151,7 +151,7 @@ The App Compatibility FOD can only be installed on Server Core. Don't attempt to
    - The Server FOD ISO image file is also available for Long-Term Servicing Channel releases on the [Microsoft Evaluation Center](https://www.microsoft.com/evalcenter/evaluate-windows-server) or on the [Visual Studio portal](https://visualstudio.microsoft.com) for subscribers.
    - As a Windows Insider, preview updates of Features on Demand are available on the [Windows Server Insider page](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver).
 
-2. Open a PowerShell session as an administrator and then use the following commands to mount the image files as drives:
+2. Open a PowerShell session as an administrator and use the following commands to mount the image files as drives:
 
    ```PowerShell
    Mount-DiskImage -ImagePath Path_To_ServerFOD_ISO


### PR DESCRIPTION
This document was not intended to be complete by the note.

Yet in the field it is often cited for the **limitations** of Server Core and could lead Administrators and IT management to choose against the use of Server Core.

In fact many software vendors have not even tested or can tell if their Software **would** run on Server Core. With certain expierence of application and server migration, I can say that this is possible most of the time.

With a clear exception of Citrix some software vendors were then interested to support their software hosted on Server Core using Remote Tools.

I am adding this for the sake of the previous unintended completeness. 

FOD after 1903 is not very well documented, however later developments of Feature on Demand were important in certain scenarios to support Server Core.

Certainly Server 2022 is around the corner. Everywhere IT Pros, Microsoft, Vendors and Partners are vouching for the use of Server Core. 

Clear information is the foundation of good IT decisions in favour for this officially preferred installation method of modern versions of Windows Server.

This PR reflects the outcome of discussion with @illfated. Thanks for your advice, as always.

reference: @Karl-WE  #3016

added: another reason to complete this list is that the references on what *is* included and what **is not** included are great but focus on roles and features and not on all named tools here. So one might be disappointed to look into roles and features that give no clue about MMC or Explorer or etc. 
