### PR TITLE
Update gpresult.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/gpresult.md
+++ b/WindowsServerDocs/administration/windows-commands/gpresult.md
@@ -48,6 +48,8 @@ gpresult [/s <system> [/u <username> [/p [<password>]]]] [/user [<targetdomain>\
 
 - Because **/v** and **/z** produce a lot of information, it's useful to redirect output to a text file (for example, `gpresult/z >policy.txt`).
 
+- On ARM64 versions of Windows, only the gpresult in SysWow64 will work with the /h parameter.
+
 ### Examples
 
 To retrieve RSoP data for only the remote user, *maindom\hiropln* with the password *p@ssW23*, who's on the computer *srvmain*, type:

--- a/WindowsServerDocs/administration/windows-commands/gpresult.md
+++ b/WindowsServerDocs/administration/windows-commands/gpresult.md
@@ -48,7 +48,7 @@ gpresult [/s <system> [/u <username> [/p [<password>]]]] [/user [<targetdomain>\
 
 - Because **/v** and **/z** produce a lot of information, it's useful to redirect output to a text file (for example, `gpresult/z >policy.txt`).
 
-- On ARM64 versions of Windows, only the gpresult in SysWow64 will work with the /h parameter.
+- On ARM64 versions of Windows, only the `gpresult` in SysWow64 works with the `/h` parameter.
 
 ### Examples
 


### PR DESCRIPTION
We have had admins in App Assure ask about this several times; it would be nice to document that gpresult on ARM64 platforms only supports the /h switch by design.  Confirmed with engineering already in bug 31245712.