### PR TITLE
Link corrections in servermanagercmd.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/servermanagercmd.md
+++ b/WindowsServerDocs/administration/windows-commands/servermanagercmd.md
@@ -16,7 +16,7 @@ ms.date: 07/11/2018
 Installs and removes roles, role services, and features. Also displays the list of all roles, role services, and features available, and shows which are installed on this computer.
 
 > [!IMPORTANT]
-> This command, servermanagercmd, has been deprecated and it's not guaranteed to be supported in future releases of Windows. We recommend instead that you use the Windows PowerShell cmdlets that are available for Server Manager. For more information, see [Install or Uninstall Roles, Role Services, or Features](/administration/server-manager/install-or-uninstall-roles-role-services-or-features).
+> This command, servermanagercmd, has been deprecated and it's not guaranteed to be supported in future releases of Windows. We recommend instead that you use the Windows PowerShell cmdlets that are available for Server Manager. For more information, see [Install or Uninstall Roles, Role Services, or Features](/windows-server/administration/server-manager/install-or-uninstall-roles-role-services-or-features.md).
 
 ## Syntax
 
@@ -64,4 +64,4 @@ servermanagercmd -inputpath install.xml -whatif
 
 - [Command-Line Syntax Key](command-line-syntax-key.md)
 
-- [Server Manager overview](/administration/server-manager/server-manager)
+- [Server Manager overview](/windows-server/administration/server-manager/server-manager.md)


### PR DESCRIPTION
As reported in issue ticket #5368 (**Link to Install or Uninstall Roles, Role Services, or Features is dead.**),
the link to "Install or Uninstall Roles, Role Services, or Features" is broken 
and is missing an important part of its directory hierarchy structure.

I could have made a more relative link by going up 1 directory level, using the `../` "up one level" notation,
but I opted to include the top directory name instead to match the existing link format. 
(Feel free to ask me to change to the "up one level" version if that is preferred.)

Thanks to @rossmpersonal for finding and reporting this link issue.

I also stumbled across the exact same issue in the last link of this document, [Server Manager overview].
Applied the very same link correction to that link, which now works as intended.

Closes #5368