### PR TITLE
"Container Networking documentation" 404 update

### DIFF
--- a/WindowsServerDocs/networking/sdn/contact-sdn-team.md
+++ b/WindowsServerDocs/networking/sdn/contact-sdn-team.md
@@ -8,6 +8,7 @@ ms.author: anpaul
 author: AnirbanPaul
 ms.date: 08/07/2020
 ---
+
 # Contact the Datacenter and Cloud Networking Team
 
 > Applies To: Windows Server 2019, Windows Server 2016
@@ -22,21 +23,25 @@ Recently, we launched our presence on Twitter as [@Microsoft_SDN](https://twitte
 > In addition to a place where you can reach out with questions/feedback/requests, consider Twitter the place to get your "feed" on everything SDN and Windows container networking related -- Twitter is the first place we'll **post news**, announce **new features** and point the community to all of our **latest blogs and resources**.
 
 ## GitHub ([Microsoft/SDN repo](https://github.com/Microsoft/SDN/issues))
+
 Go [here](https://github.com/Microsoft/SDN/issues) to submit issues to the SDN team via our GitHub repository. This is the best place to **get help troubleshooting** or **report bugs**.
 
 > GitHub is the best place to contact us about topics that involve more detail than the kinds of things you could easily fit in a Tweet. *Need help with your SDN deployment? Unsure about how our features could suit your organization's unique needs? Being held up by a potential bug?* All good reasons to get in touch with us by submitting a GitHub issue.
 
 ## [Microsoft Docs](/)
-Our [Container Networking documentation](/virtualization/windowscontainers/manage-containers/container-networking) can be found on [Microsoft Docs (docs.microsoft.com)](/), which has **built-in commenting functionality**. To leave or to reply to a comment on Microsoft Docs just sign in, scroll down to the bottom of the Microsoft Docs page that you wish to reference, then make and submit your comment there.
+
+Our [Container Networking documentation](/virtualization/windowscontainers/container-networking/architecture.md) can be found on [Microsoft Docs (docs.microsoft.com)](/), which has **built-in commenting functionality**. To leave or to reply to a comment on Microsoft Docs just sign in, scroll down to the bottom of the Microsoft Docs page that you wish to reference, then make and submit your comment there.
 
 > [Microsoft Docs](/) is Microsoft's new unified documentation site. While most of our team's [SDN documentation](./software-defined-networking.md) remains on TechNet, our [Container Networking documentation](/virtualization/windowscontainers) is now on Microsoft Docs.
 >
 > *In general, If you run into a topic on Microsoft Docs that sparks a question or leaves you wanting more, just leave a comment on that page to share your feedback with the Microsoft team that can help.*
 
 ## Container-Specific Forums
+
 Feel free to use any avenue on this page to provide feedback related to containers and container networking. However, if you're looking for Microsoft's primary forums for the container community specifically, refer to the following:
 - [User voice](https://windowsserver.uservoice.com/forums/304624-containers) - best for *feature requests*
 - [Github (Virtualization repo)](https://github.com/Microsoft/Virtualization-Documentation) - best for seeking *troubleshooting help* and *reporting bugs*
 
 ### Not seeing the forum for you?
+
 Whenever possible, we encourage use of our public forums so that the broader community can benefit from access to the questions and comments that come our way. However, we also recognize that there are situations where email is simply the preferred way to get in touch with us. If you're in one of those situations, please send us an email at sdn_feedback@microsoft.com and we'll be happy to hear from you.


### PR DESCRIPTION
**Description:**

https://docs.microsoft.com/en-us/windows-server/networking/sdn/contact-sdn-team#microsoft-docs

As reported in issue ticket #5374 (**Link of Container Networking Documentation is broken**),
the first link named "Container Networking documentation" in the section returns a 404 error.

Thanks to S. Raza Syed (srazasyed) for noticing and reporting the issue.

The main reason is that there is no index.md / index.html / index.yml page in that directory.

**Proposed change:**

- Replace the existing incomplete link with /architecture.md (/virtualization/windowscontainers/container-networking/architecture)

**Whitespace corrections:**

- Add missing editorial blank line between H2/H3 headings and their following text.
- Add editorial blank line between the metadata section and the H1 title line.

**Ticket closure or reference:**

Closes #5374