### PR TITLE
Command Extensions: extra note and adjustments

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/setlocal.md
+++ b/WindowsServerDocs/administration/windows-commands/setlocal.md
@@ -6,7 +6,7 @@ ms.assetid: e4e4b6d3-3f1a-4851-a782-25ee2470e16e
 ms.author: jgerend
 author: JasonGerend
 manager: mtillman
-ms.date: 10/16/2017
+ms.date: 03/29/2021
 ---
 
 # setlocal
@@ -16,55 +16,58 @@ Starts localization of environment variables in a batch file. Localization conti
 ## Syntax
 
 ```
-setlocal [enableextensions | disableextensions] [enabledelayedexpansion | disabledelayedexpansion]
+Setlocal [EnableExtensions | DisableExtensions] [EnableDelayedExpansion | DisableDelayedExpansion]
 ```
 
 ### Parameters
 
 | Parameter | Description |
-|--|--|
-| enableextensions | Enables the command extensions until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
-| disableextensions | Disables the command extensions until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
-| enabledelayedexpansion | Enables the delayed environment variable expansion until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
-| disabledelayedexpansion | Disables the delayed environment variable expansion until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
+| :-------: | :---------- |
+| EnableExtensions | Enables the command extensions until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
+| DisableExtensions | Disables the command extensions until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
+| EnableDelayedExpansion | Enables the delayed environment variable expansion until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
+| DisableDelayedExpansion | Disables the delayed environment variable expansion until the matching **endlocal** command is encountered, regardless of the setting before the **setlocal** command was run. |
 | /? | Displays help at the command prompt. |
 
 #### Remarks
 
 - If you use **setlocal** outside of a script or batch file, it has no effect.
 
-- Use **setlocal** to change environment variables when you run a batch file. Environment changes made after you run **setlocal** are local to the batch file. The Cmd.exe program restores previous settings when it encounters an **endlocal** command or reaches the end of the batch file.
+- Use **setlocal** to change environment variables when you run a batch file. Environment changes made after you run **setlocal** are local to the batch file. The cmd.exe command-line interpreter restores previous settings when it encounters an **endlocal** command, or reaches the end of the batch file.
 
-- You can have more than one **setlocal** or **endlocal** command in a batch program (that is, nested commands).
+- You can have more than one **setlocal** or **endlocal** command in a batch script (that is, nested commands).
 
-- The **setlocal** command sets the ERRORLEVEL variable. If you pass {**enableextensions** | **disableextensions**} or {**enabledelayedexpansion** | **disabledelayedexpansion**}, the ERRORLEVEL variable is set to **0** (zero). Otherwise, it's set to **1**. You can use this information in batch scripts to determine whether the extensions are available, as shown in the following example:
+- Command Extensions is a mode of the [cmd](cmd.md) command interpreter that changes the behavior of variable expansion and of many internal commands (internal to cmd.exe). These changes are described in the documentation of each command. The cmd documentation page contains a list of affected commands. The [assoc](assoc.md), [color](color.md), and [ftype](ftype.md) commands are not available at all if Command Extensions are disabled.
+
+- The **setlocal** command sets the ERRORLEVEL variable. If you pass {**EnableExtensions** | **DisableExtensions**} or {**EnableDelayedExpansion** | **DisableDelayedExpansion**}, the ERRORLEVEL variable is set to **0** (zero). Otherwise, it's set to **1**. You can use this information in batch scripts to determine whether the extensions are available, as shown in the following example:
 
     ```
-    setlocal enableextensions
-    verify other 2>nul
-    if errorlevel 1 echo Unable to enable extensions
+    Setlocal EnableExtensions
+    Verify other 2>NUL
+    if ErrorLevel 1 Echo Unable to enable extensions.
     ```
 
-    Because **cmd** does not set the ERRORLEVEL variable when command extensions are disabled, the **verify** command initializes the ERRORLEVEL variable to a nonzero value when you use it with an invalid argument. Also, if you use the **setlocal** command with arguments {**enableextensions** | **disableextensions**} or {**enabledelayedexpansion** | **disabledelayedexpansion**} and it does not set the ERRORLEVEL variable to **1**, command extensions are not available.
+    Because **cmd** does not set the ERRORLEVEL variable when command extensions are disabled, the **Verify** command initializes the ERRORLEVEL variable to a nonzero value when you use it with an invalid argument. Also, if you use the **Setlocal** command with any of the arguments {**EnableExtensions** | **DisableExtensions**} or {**EnableDelayedExpansion** | **DisableDelayedExpansion**} and it does not set the ERRORLEVEL variable to **1**, command extensions are not available.
 
 ## Examples
 
 To localize environment variables in a batch file, follow this sample script:
 
 ```
-rem *******Begin Comment**************
-rem This program starts the superapp batch program on the network,
+rem ******* Begin Comment **************
+rem This program starts the SuperApp batch script on the network,
 rem directs the output to a file, and displays the file
 rem in Notepad.
-rem *******End Comment**************
+rem ******* End Comment **************
 @echo off
 setlocal
-path=g:\programs\superapp;%path%
-call superapp>c:\superapp.out
+path=g:\programs\SuperApp;%path%
+call SuperApp>c:\SuperApp.out
 endlocal
-start notepad c:\superapp.out
+start Notepad c:\SuperApp.out
 ```
 
 ## Additional References
 
+- [The command-line interpreter cmd.exe](cmd.md)
 - [Command-Line Syntax Key](command-line-syntax-key.md)


### PR DESCRIPTION
**Description:**

This concludes my previous attempt to update the document page `setlocal.md`, PR #4461

As discussed in issue ticket #4305 , this provides a more complete description for Command Extensions.

**Proposed change:**
- Add a bullet point entry in the **Remarks** section, describing practical details when using Command Extensions.

**Additional changes:**
- CamelCase capitalization for improved readability
- capitalization of NUL (entity name standard)
- "batch program" => 'batch script' (commonality)
- Parameters table: center first column, add spacing

Closes #4305

#sign-off