### PR TITLE
Updated Remote Desktop Client for Windows Store to 10.2.1844

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-clients.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-clients.md
@@ -26,7 +26,7 @@ The following client apps are available:
 | Client | Get the app | Documentation | Latest version |
 |-----------------|-------------|------|---|
 | Windows Desktop | [Windows Desktop client](windowsdesktop.md#install-the-client) | [Get started](windowsdesktop.md), [What's new](windowsdesktop-whatsnew.md) | 1.2.1844  |
-| Microsoft Store   | [Windows 10 client in the Microsoft Store](https://go.microsoft.com/fwlink/?LinkID=616709) | [Get started](windows.md), [What's new](windows-whatsnew.md)  | 1.2.1810  |
+| Microsoft Store   | [Windows 10 client in the Microsoft Store](https://go.microsoft.com/fwlink/?LinkID=616709) | [Get started](windows.md), [What's new](windows-whatsnew.md)  | 10.2.1810  |
 | Android         | [Android client in Google Play](https://play.google.com/store/apps/details?id=com.microsoft.rdc.androidx)     | [Get started](remote-desktop-android.md), [What's new](android-whatsnew.md) | 10.0.10 |
 | iOS             | [iOS client in the App Store](https://apps.apple.com/app/microsoft-remote-desktop/id714464092)     | [Get started](remote-desktop-ios.md), [What's new](ios-whatsnew.md)         | 10.2.5 |
 | macOS | [macOS client in the App Store](https://apps.apple.com/app/microsoft-remote-desktop/id1295203466?mt=12) | [Get started](remote-desktop-mac.md), [What's new](mac-whatsnew.md)       | 10.5.2 |


### PR DESCRIPTION
The listed Remote Desktop Client version is 1.2.1844. This doesn't match the actual version which is 10.2.1844. The Windows Desktop Client may be wrong too, but I'm not sure.