### PR TITLE
Update .net framework version note

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/AD-FS-Rapid-Restore-Tool.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/AD-FS-Rapid-Restore-Tool.md
@@ -57,7 +57,7 @@ import-module 'C:\Program Files (x86)\ADFS Rapid Recreation Tool\ADFSRapidRecrea
 ### System requirements
 
 - This tool works for AD FS in Windows Server 2012 R2 and later.
-- The required .NET framework is at least 4.0.
+- The required .NET framework is at least 4.0. (Note: For version 1.0.82.3 or later, it requires at least .NET framework 4.6)
 - The restore must be done on an AD FS server of the same version as the backup and that uses the same Active Directory account as the AD FS service account.
 
 ## Create a backup


### PR DESCRIPTION
Below error occurred on Server 2012 R2 that only has .net 4.5, when using ADFS rapid restore tool version 1.0.82.3. As per checking, the latest version code was targeted on .net 4.6 instead of 4.5. Some functions are only available in 4.6. 

Backup-ADFS : Method not found: 'System.String System.String.Format(System.IFormatProvider, System.String, System.Object)'.
At line:1 char:1
+ Backup-ADFS -StorageType "FileSystem" -StoragePath "C:\scripts\ADFSBackup\Backup ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 + CategoryInfo : NotSpecified: (:) [Backup-ADFS], MissingMethodException
 + FullyQualifiedErrorId : System.MissingMethodException,Microsoft.ADFSRapidRecreationTool.BackupADFS

The function here used (System.String System.String.Format(System.IFormatProvider, System.String, System.Object)) actually is not available in .net 4.5. 

.net 4.5
![image](https://user-images.githubusercontent.com/25541899/114147111-f01d1700-994a-11eb-80f1-038e86c928f4.png)

.net 4.6
![image](https://user-images.githubusercontent.com/25541899/114147383-3d00ed80-994b-11eb-8246-9c1bc9827de2.png)

Our [Official article](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/ad-fs-rapid-restore-tool#system-requirements) and [download link](https://www.microsoft.com/en-us/download/details.aspx?id=56569) that saying .net 4.0 or later is latest requirement, which is wrong for latest ADFS Rapid restore tool version. This statement should be changed. 
