### PR TITLE
Typo & whitespace corrections

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-ios.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/remote-desktop-ios.md
@@ -9,9 +9,10 @@ ms.author: helohr
 ms.date: 08/20/2020
 ms.localizationpriority: medium
 ---
+
 # Get started with the iOS client
 
->Applies to: Windows 10, Windows 8.1, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2
+> Applies to: Windows 10, Windows 8.1, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2
 
 You can use the Remote Desktop client for iOS to work with Windows apps, resources, and desktops from your iOS device (iPhones and iPads).
 
@@ -78,7 +79,7 @@ To add a workspace:
 
 After you've finished, the Connection Center should display the remote resources.
 
-Once subscribed to a feed, the feed's content will update automatically on a regular basis. Resources may be added, changed, or removed based on changes made by your administrator.
+Once subscribed to a feed, the feed content will update automatically on a regular basis. Resources may be added, changed, or removed based on changes made by your administrator.
 
 ## Manage your user accounts
 
@@ -154,14 +155,14 @@ The client uses standard touch gestures. You can also use touch gestures to repl
 > In Windows 8 or later, the native touch gestures are supported in Direct Touch mode. For more information on Windows 8 gestures, see [Touch: Swipe, tap, and beyond](https://windows.microsoft.com/windows-8/touch-swipe-tap-beyond).
 
 | Mouse mode    | Mouse operation      | Gesture                                                    |
-|---------------|----------------------|------------------------------------------------------------|
-| Direct touch  | Left-click           | Tap with one finger                                               |
-| Direct touch  | Right-click          | Tap and hold with one finger                                      |
-| Mouse pointer | Left-click           | Tap with one finger                                               |
-| Mouse pointer | Left-click and drag  | Tap and hold with one finger, then drag                   |
-| Mouse pointer | Right-click          | Tap with two fingers                                              |
-| Mouse pointer | Right-click and drag | Double-tap and hold with two fingers, then drag                    |
-| Mouse pointer | Mouse wheel          | Double-tap and hold with two fingers, then drag up or down                |
+|:------------- |:-------------------- |:---------------------------------------------------------- |
+| Direct touch  | Left-click           | Tap with one finger                                        |
+| Direct touch  | Right-click          | Tap and hold with one finger                               |
+| Mouse pointer | Left-click           | Tap with one finger                                        |
+| Mouse pointer | Left-click and drag  | Tap and hold with one finger, then drag                    |
+| Mouse pointer | Right-click          | Tap with two fingers                                       |
+| Mouse pointer | Right-click and drag | Double-tap and hold with two fingers, then drag            |
+| Mouse pointer | Mouse wheel          | Double-tap and hold with two fingers, then drag up or down |
 | Mouse pointer | Zoom                 | With two fingers, pinch to zoom out and spread fingers apart to zoom in |
 
 ## Supported input devices
@@ -179,9 +180,9 @@ You can use either an on-screen keyboard or physical keyboard in your remote ses
 
 For on-screen keyboards, use the button on the right edge of the bar above the keyboard to switch between the standard and additional keyboard.
 
-If Bluetooth is enabled for your iOS device, the client automatically detects the Bluetooth keyboard.
+If Bluetooth is enabled on your iOS device, the client automatically detects the Bluetooth keyboard.
 
 While certain key combinations might not work as expected in a remote session, many of the common Windows key combinations, such as CTRL+C, CTRL+V, and ALT+TAB will work.
 
 > [!TIP]
-> Questions and comments are always welcome. However, if you post support requests or product feedback in this article's comments section, we won't be able to respond to your feedback. If you need help or want to troubleshoot your client, we highly recommend you go to the [Remote Desktop client forum](/answers/topics/windows-remote-desktop-client.html) and start a new thread. If you have a feature suggestion, you can tell us using the [client user voice forum](https://remotedesktop.uservoice.com/forums/272085-remote-desktop-for-android).
+> Questions and comments are always welcome. However, if you post support requests or product feedback in this article's comments section, we won't be able to respond to your feedback. If you need help or want to troubleshoot your client, we highly recommend you go to the [Remote Desktop client forum](/answers/topics/windows-remote-desktop-client.html) and start a new thread. If you have a feature suggestion, you can tell us using the [Client UserVoice forum](https://remotedesktop.uservoice.com/forums/272085-remote-desktop-for-android).


### PR DESCRIPTION
**Description:**

Corrections for the typo reported in issue ticket #5455 (**Small Typo**), as well as a couple additional corrections and whitespace adjustments.

Thanks to Bryan Streber (@Bryan-Streber) for reporting the issue.

**Changes proposed:**

- change "ot" => 'to' (swap character order)
- change "the feed's content" to 'the feed content' (common usage adaption)
- replace "for" with 'on' regarding Bluetooth on the device
- change "client user voice" to 'Client UserVoice' in the forum link description

**Whitespace adjustments:**

- add 1 blank editorial line between the metadata section and the page title (H1)
- add missing MarkDown indent marker compatibility spacing (1 occurrence)
- align most of the table end dividers for easier editing in the future
- add left alignment and 1 divider space for each column in the second row (horizontal divider)

**Ticket closure or reference:**

Closes #5455