### PR TITLE
Fix missing space between bolded text and regular text

### DIFF
--- a/WindowsServerDocs/administration/windows-server-update-services/deploy/1-install-the-wsus-server-role.md
+++ b/WindowsServerDocs/administration/windows-server-update-services/deploy/1-install-the-wsus-server-role.md
@@ -31,7 +31,7 @@ The next step in the deployment of your WSUS server is to install the WSUS serve
 
 6.  On the **select server roles** page, select **Windows Server Update Services**.  **Add features that are required for Windows Server Update Services** opens. Click **Add Features**, and then click **Next**.
 
-7.  On the **select features**page. retain the default selections, and then click **Next**.
+7.  On the **select features** page, retain the default selections, and then click **Next**.
 
     > [!IMPORTANT]
     > WSUS only requires the default Web Server role configuration. If you are prompted for additional Web Server role configuration while setting up WSUS you can safely accept the default values and continue setting up WSUS.


### PR DESCRIPTION
Step 7 has a missing space between the 'features' and 'page' words, possibly not spotted due to the bold markdown. Also has a full-stop instead of a comma.