### PR TITLE
W32Time: Remove link to deleted KB 902229 (2003)

### DIFF
--- a/WindowsServerDocs/networking/windows-time-service/How-the-Windows-Time-Service-Works.md
+++ b/WindowsServerDocs/networking/windows-time-service/How-the-Windows-Time-Service-Works.md
@@ -10,17 +10,17 @@ ms.topic: article
 
 # How the Windows Time Service Works
 
->Applies to: Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows 10 or later
+> **Applies to:** Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows 10 or later
 
 **In this section**
 
--   [Windows Time Service Architecture](#windows-time-service-architecture)
+- [Windows Time Service Architecture](#windows-time-service-architecture)
 
--   [Windows Time Service Time Protocols](#windows-time-service-time-protocols)
+- [Windows Time Service Time Protocols](#windows-time-service-time-protocols)
 
--   [Windows Time Service Processes and Interactions](#windows-time-service-processes-and-interactions)
+- [Windows Time Service Processes and Interactions](#windows-time-service-processes-and-interactions)
 
--   [Network Ports Used by Windows Time Service](#network-ports-used-by-windows-time-service)
+- [Network Ports Used by Windows Time Service](#network-ports-used-by-windows-time-service)
 
 > [!NOTE]
 > This topic explains only how the Windows Time service (W32Time) works. For information about how to configure Windows Time service, see [Configuring Systems for High Accuracy](configuring-systems-for-high-accuracy.md).
@@ -30,11 +30,11 @@ ms.topic: article
 
 Although the Windows Time service is not an exact implementation of the Network Time Protocol (NTP), it uses the complex suite of algorithms that is defined in the NTP specifications to ensure that clocks on computers throughout a network are as accurate as possible. Ideally, all computer clocks in an AD DS domain are synchronized with the time of an authoritative computer. Many factors can affect time synchronization on a network. The following factors often affect the accuracy of synchronization in AD DS:
 
--   Network conditions
+- Network conditions
 
--   The accuracy of the computer's hardware clock
+- The accuracy of the computer's hardware clock
 
--   The amount of CPU and network resources available to the Windows Time service
+- The amount of CPU and network resources available to the Windows Time service
 
 > [!IMPORTANT]
 > Prior to Windows Server 2016, the W32Time service was not designed to meet time-sensitive application needs.  However, updates to Windows Server 2016 now allow you to implement a solution for 1ms accuracy in your domain.  See [Windows 2016 Accurate Time](accurate-time.md) and  [Support boundary to configure the Windows Time service for high-accuracy environments](support-boundary.md) for more information.
@@ -52,13 +52,13 @@ When the W32Time Manager receives time samples, it uses special algorithms in NT
 ## Windows Time Service Architecture
 The Windows Time service consists of the following components:
 
--   Service Control Manager
+- Service Control Manager
 
--   Windows Time Service Manager
+- Windows Time Service Manager
 
--   Clock Discipline
+- Clock Discipline
 
--   Time providers
+- Time providers
 
 The following figure shows the architecture of the Windows Time service.
 
@@ -70,13 +70,13 @@ The Service Control Manager is responsible for starting and stopping the Windows
 
 The time synchronization process involves the following steps:
 
--   Input providers request and receive time samples from configured NTP time sources.
+- Input providers request and receive time samples from configured NTP time sources.
 
--   These time samples are then passed to the Windows Time Service Manager, which collects all the samples and passes them to the clock discipline subcomponent.
+- These time samples are then passed to the Windows Time Service Manager, which collects all the samples and passes them to the clock discipline subcomponent.
 
--   The clock discipline subcomponent applies the NTP algorithms which results in the selection of the best time sample.
+- The clock discipline subcomponent applies the NTP algorithms which results in the selection of the best time sample.
 
--   The clock discipline subcomponent adjusts the time of the system clock to the most accurate time by either adjusting the clock rate or directly changing the time.
+- The clock discipline subcomponent adjusts the time of the system clock to the most accurate time by either adjusting the clock rate or directly changing the time.
 
 If a computer has been designated as a time server, it can send the time on to any computer requesting time synchronization at any point in this process.
 
@@ -87,6 +87,7 @@ Time protocols determine how closely two computers' clocks are synchronized. A t
 The Windows Time service uses the Network Time Protocol (NTP) to help synchronize time across a network. NTP is an Internet time protocol that includes the discipline algorithms necessary for synchronizing clocks. NTP is a more accurate time protocol than the Simple Network Time Protocol (SNTP) that is used in some versions of Windows; however W32Time continues to support SNTP to enable backward compatibility with computers running SNTP-based time services, such as Windows 2000.
 
 ### Network Time Protocol
+
 Network Time Protocol (NTP) is the default time synchronization protocol used by the Windows Time service in the operating system. NTP is a fault-tolerant, highly scalable time protocol and is the protocol used most often for synchronizing computer clocks by using a designated time reference.
 
 NTP time synchronization takes place over a period of time and involves the transfer of NTP packets over a network. NTP packets contain time stamps that include a time sample from both the client and the server participating in time synchronization.
@@ -94,18 +95,20 @@ NTP time synchronization takes place over a period of time and involves the tran
 NTP relies on a reference clock to define the most accurate time to be used and synchronizes all clocks on a network to that reference clock. NTP uses Coordinated Universal Time (UTC) as the universal standard for current time. UTC is independent of time zones and enables NTP to be used anywhere in the world regardless of time zone settings.
 
 #### NTP Algorithms
+
 NTP includes two algorithms, a clock-filtering algorithm and a clock-selection algorithm, to assist the Windows Time service in determining the best time sample. The clock-filtering algorithm is designed to sift through time samples that are received from queried time sources and determine the best time samples from each source. The clock-selection algorithm then determines the most accurate time server on the network. This information is then passed to the clock discipline algorithm, which uses the information gathered to correct the local clock of the computer, while compensating for errors due to network latency and computer clock inaccuracy.
 
 The NTP algorithms are most accurate under conditions of light-to-moderate network and server loads. As with any algorithm that takes network transit time into account, NTP algorithms might perform poorly under conditions of extreme network congestion. For more information about the NTP algorithms, see RFC 1305 in the IETF RFC Database.
 
 #### NTP Time Provider
+
 The Windows Time service is a complete time synchronization package that can support a variety of hardware devices and time protocols. To enable this support, the service uses pluggable time providers. A time provider is responsible for either obtaining accurate time stamps (from the network or from hardware) or for providing those time stamps to other computers over the network.
 
 The NTP provider is the standard time provider included with the operating system. The NTP provider follows the standards specified by NTP version 3 for a client and server, and can interact with SNTP clients and servers for backward compatibility with Windows 2000 and other SNTP clients. The NTP provider in the Windows Time service consists of the following two parts:
 
--   **NtpServer output provider.** This is a time server that responds to client time requests on the network.
+- **NtpServer output provider.** This is a time server that responds to client time requests on the network.
 
--   **NtpClient input provider.** This is a time client that obtains time information from another source, either a hardware device or an NTP server, and can return time samples that are useful for synchronizing the local clock.
+- **NtpClient input provider.** This is a time client that obtains time information from another source, either a hardware device or an NTP server, and can return time samples that are useful for synchronizing the local clock.
 
 Although the actual operations of these two providers are closely related, they appear independent to the time service. Starting with Windows 2000 Server, when a Windows computer is connected to a network, it is configured as an NTP client. Also, computers running the Windows Time service only attempt to synchronize time with a domain controller or a manually specified time source by default. These are the preferred time providers because they are automatically available, secure sources of time.
 
@@ -118,6 +121,7 @@ Generally, Windows time clients automatically obtain accurate time for synchroni
 The Windows Time service can be configured to work between forests, but it is important to note that this configuration is not secure. For example, an NTP server might be available in a different forest. However, because that computer is in a different forest, there is no Kerberos session key with which to sign and authenticate NTP packets. To obtain accurate time synchronization from a computer in a different forest, the client needs network access to that computer and the time service must be configured to use a specific time source located in the other forest. If a client is manually configured to access time from an NTP server outside of its own domain hierarchy, the NTP packets sent between the client and the time server are not authenticated, and therefore are not secure. Even with the implementation of forest trusts, the Windows Time service is not secure across forests. Although the Net Logon secure channel is the authentication mechanism for the Windows Time service, authentication across forests is not supported.
 
 #### Hardware Devices That Are Supported by the Windows Time Service
+
 Hardware-based clocks such as GPS or radio clocks are often used as highly accurate reference clock devices. By default, the Windows Time service NTP time provider does not support the direct connection of a hardware device to a computer, although it is possible to create a software-based independent time provider that supports this type of connection. This type of provider, in conjunction with the Windows Time service, can provide a reliable, stable time reference.
 
 Hardware devices, such as a cesium clock or a Global Positioning System (GPS) receiver, provide accurate current time by following a standard to obtain an accurate definition of time. Cesium clocks are extremely stable and are unaffected by factors such as temperature, pressure, or humidity, but are also very expensive. A GPS receiver is much less expensive to operate and is also an accurate reference clock. GPS receivers obtain their time from satellites that obtain their time from a cesium clock. Without the use of an independent time provider, Windows time servers can acquire their time by connecting to an external NTP server, which is connected to a hardware device by means of a telephone or the Internet. Organizations such as the United States Naval Observatory provide NTP servers that are connected to extremely reliable reference clocks.
@@ -125,9 +129,11 @@ Hardware devices, such as a cesium clock or a Global Positioning System (GPS) re
 Many GPS receivers and other time devices can function as NTP servers on a network. You can configure your AD DS forest to synchronize time from these external hardware devices only if they are also acting as NTP servers on your network. To do so, configure the domain controller functioning as the primary domain controller (PDC) emulator in your forest root to synchronize with the NTP server provided by the GPS device. To do so, see [Configure the Windows Time service on the PDC emulator in the Forest Root Domain](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc731191%28v=ws.10%29).
 
 ### Simple Network Time Protocol
+
 The Simple Network Time Protocol (SNTP) is a simplified time protocol that is intended for servers and clients that do not require the degree of accuracy that NTP provides. SNTP, a more rudimentary version of NTP, is the primary time protocol that is used in Windows 2000. Because the network packet formats of SNTP and NTP are identical, the two protocols are interoperable. The primary difference between the two is that SNTP does not have the error management and complex filtering systems that NTP provides. For more information about the Simple Network Time Protocol, see RFC 1769 in the IETF RFC Database.
 
 ### Time Protocol Interoperability
+
 The Windows Time service can operate in a mixed environment of computers running Windows 2000, Windows XP, and Windows Server 2003, because the SNTP protocol used in Windows 2000 is interoperable with the NTP protocol in Windows XP and Windows Server 2003.
 
 The time service in Windows NT Server 4.0, called TimeServ, synchronizes time across a Windows NT 4.0 network. TimeServ is an add-on feature available as part of the *Microsoft Windows NT 4.0 Resource Kit* and does not provide the degree of reliability of time synchronization that is required by Windows Server 2003.
@@ -148,13 +154,13 @@ To establish a computer running Windows Server 2003 as authoritative, the comput
 
 After you have established a Windows Server 2003 network, you can configure the Windows Time service to use one of the following options for synchronization:
 
--   Domain hierarchy-based synchronization
+- Domain hierarchy-based synchronization
 
--   A manually-specified synchronization source
+- A manually-specified synchronization source
 
--   All available synchronization mechanisms
+- All available synchronization mechanisms
 
--   No synchronization.
+- No synchronization.
 
 Each of these synchronization types is discussed in the following section.
 
@@ -163,31 +169,34 @@ Each of these synchronization types is discussed in the following section.
 Synchronization that is based on a domain hierarchy uses the AD DS domain hierarchy to find a reliable source with which to synchronize time. Based on domain hierarchy, the Windows Time service determines the accuracy of each time server. In a Windows Server 2003 forest, the computer that holds the primary domain controller (PDC) emulator operations master role, located in the forest root domain, holds the position of best time source, unless another reliable time source has been configured. The following figure illustrates a path of time synchronization between computers in a domain hierarchy.
 
 **Time Synchronization in an AD DS Hierarchy**
+
 ![Windows Time](../media/Windows-Time-Service/How-the-Windows-Time-Service-Works/trnt_ntw_adhc.gif)
 
 #### Reliable Time Source Configuration
+
 A computer that is configured to be a reliable time source is identified as the root of the time service. The root of the time service is the authoritative server for the domain and typically is configured to retrieve time from an external NTP server or hardware device. A time server can be configured as a reliable time source to optimize how time is transferred throughout the domain hierarchy. If a domain controller is configured to be a reliable time source, Net Logon service announces that domain controller as a reliable time source when it logs on to the network. When other domain controllers look for a time source to synchronize with, they choose a reliable source first if one is available.
 
 #### Time Source Selection
+
 The time source selection process can create two problems on a network:
 
--   Additional synchronization cycles.
+- Additional synchronization cycles.
 
--   Increased volume in network traffic.
+- Increased volume in network traffic.
 
 A cycle in the synchronization network occurs when time remains consistent between a group of domain controllers and the same time is shared between them continuously without a resynchronization with another reliable time source. The Windows Time service's time source selection algorithm is designed to protect against these types of problems.
 
 A computer uses one of the following methods to identify a time source to synchronize with:
 
--   If the computer is not a member of a domain, it must be configured to synchronize with a specified time source.
+- If the computer is not a member of a domain, it must be configured to synchronize with a specified time source.
 
--   If the computer is a member server or workstation within a domain, by default, it follows the AD DS hierarchy and synchronizes its time with a domain controller in its local domain that is currently running the Windows Time service.
+- If the computer is a member server or workstation within a domain, by default, it follows the AD DS hierarchy and synchronizes its time with a domain controller in its local domain that is currently running the Windows Time service.
 
 If the computer is a domain controller, it makes up to six queries to locate another domain controller to synchronize with. Each query is designed to identify a time source with certain attributes, such as a type of domain controller, a particular location, and whether or not it is a reliable time source. The time source must also adhere to the following constraints:
 
--   A reliable time source can only synchronize with a domain controller in the parent domain.
+- A reliable time source can only synchronize with a domain controller in the parent domain.
 
--   A PDC emulator can synchronize with a reliable time source in its own domain or any domain controller in the parent domain.
+- A PDC emulator can synchronize with a reliable time source in its own domain or any domain controller in the parent domain.
 
 If the domain controller is not able to synchronize with the type of domain controller that it is querying, the query is not made. The domain controller knows which type of computer it can obtain time from before it makes the query. For example, a local PDC emulator does not attempt to query numbers three or six because a domain controller does not attempt to synchronize with itself.
 
@@ -195,35 +204,35 @@ The following table lists the queries that a domain controller makes to find a t
 
 **Domain Controller Time Source Queries**
 
-|Query Number|Domain Controller|Location|Reliability of Time Source|
-|----------------|---------------------|------------|------------------------------|
-|1|Parent domain controller|In-site|Prefers a reliable time source but it can synchronize with a non-reliable time source if that is all that is available.|
-|2|Local domain controller|In-site|Only synchronizes with a reliable time source.|
-|3|Local PDC emulator|In-site|Does not apply.<p>A domain controller does not attempt to synchronize with itself.|
-|4|Parent domain controller|Out-of-site|Prefers a reliable time source but it can synchronize with a non-reliable time source if that is all that is available.|
-|5|Local domain controller|Out-of-site|Only synchronizes with a reliable time source.|
-|6|Local PDC emulator|Out-of-site|Does not apply.<p>A domain controller does not attempt to synchronize with itself.|
+| Query Number | Domain Controller | Location | Reliability of Time Source |
+|:------------:|:------------------|:---------|:---------------------------|
+| 1 | Parent domain controller | In-site      | Prefers a reliable time source but it can synchronize with a non-reliable time source if that is all that is available. |
+| 2 | Local domain controller  | In-site      | Only synchronizes with a reliable time source. |
+| 3 | Local PDC emulator       | In-site      | Does not apply.<p>A domain controller does not attempt to synchronize with itself. |
+| 4 | Parent domain controller | Out-of-site  | Prefers a reliable time source but it can synchronize with a non-reliable time source if that is all that is available. |
+| 5 | Local domain controller  | Out-of-site  | Only synchronizes with a reliable time source. |
+| 6 | Local PDC emulator       | Out-of-site  | Does not apply.<p>A domain controller does not attempt to synchronize with itself. |
 
-**Note**
-
--   A computer never synchronizes with itself. If the computer attempting synchronization is the local PDC emulator, it does not attempt Queries 3 or 6.
+> [!NOTE]
+> A computer never synchronizes with itself. If the computer attempting synchronization is the local PDC emulator, it does not attempt Queries 3 or 6.
 
 Each query returns a list of domain controllers that can be used as a time source. Windows Time assigns each domain controller that is queried a score based on the reliability and location of the domain controller. The following table lists the scores assigned by Windows Time to each type of domain controller.
 
 **Score Determination**
 
-|Domain Controller Status|Score|
-|----------------------------|---------|
-|Domain controller located in same site|8|
-|Domain controller marked as a reliable time source|4|
-|Domain controller located in the parent domain|2|
-|Domain controller that is a PDC emulator|1|
+| Domain Controller Status                       | Score |
+|:-----------------------------------------------|:-----:|
+| Domain controller located in same site             | 8 |
+| Domain controller marked as a reliable time source | 4 |
+| Domain controller located in the parent domain     | 2 |
+| Domain controller that is a PDC emulator           | 1 |
 
 When the Windows Time service determines that it has identified the domain controller with the best possible score, no more queries are made. The scores assigned by the time service are cumulative, which means that a PDC emulator located in the same site receives a score of nine.
 
 If the root of the time service is not configured to synchronize with an external source, the internal hardware clock of the computer governs the time.
 
 ### Manually-Specified Synchronization
+
 Manually-specified synchronization enables you to designate a single peer or list of peers from which a computer obtains time. If the computer is not a member of a domain, it must be manually configured to synchronize with a specified time source. A computer that is a member of a domain is configured by default to synchronize from the domain hierarchy, manually-specified synchronization is most useful for the forest root of the domain or for computers that are not joined to a domain. Manually specifying an external NTP server to synchronize with the authoritative computer for your domain provides reliable time. However, configuring the authoritative computer for your domain to synchronize with a hardware clock is actually a better solution for providing the most accurate, secure time to your domain.
 
 Manually-specified time sources are not authenticated unless a specific time provider is written for them, and they are therefore vulnerable to attackers. Also, if a computer synchronizes with a manually-specified source rather than its authenticating domain controller, the two computers might be out of synchronization, causing Kerberos authentication to fail. This might cause other actions requiring network authentication to fail, such as printing or file sharing. If only the forest root is configured to synchronize with an external source, all other computers within the forest remain synchronized with each other, making replay attacks difficult.
@@ -233,6 +242,7 @@ Manually-specified time sources are not authenticated unless a specific time pro
 The "all available synchronization mechanisms" option is the most valuable synchronization method for users on a network. This method allows synchronization with the domain hierarchy and may also provide an alternate time source if the domain hierarchy becomes unavailable, depending on the configuration. If the client is unable to synchronize time with the domain hierarchy, the time source automatically falls back to the time source specified by the **NtpServer** setting. This method of synchronization is most likely to provide accurate time to clients.
 
 ### Stopping Time Synchronization
+
 There are certain situations in which you will want to stop a computer from synchronizing its time. For example, if a computer attempts to synchronize from a time source on the Internet or from another site over a WAN by means of a dial-up connection, it can incur costly telephone charges. When you disable synchronization on that computer, you prevent the computer from attempting to access a time source over a dial-up connection.
 
 You can also disable synchronization to prevent the generation of errors in the event log. Each time a computer attempts to synchronize with a time source that is unavailable, it generates an error in the Event Log. If a time source is taken off of the network for scheduled maintenance and you do not intend to reconfigure the client to synchronize from another source, you can disable synchronization on the client to prevent it from attempting synchronization while the time server is unavailable.
@@ -242,19 +252,24 @@ It is useful to disable synchronization on the computer that is designated as th
 The only time servers that are trusted by clients even if they have not synchronized with another time source are those that have been identified by the client as reliable time servers.
 
 ### Disabling the Windows Time Service
+
 The Windows Time service (W32Time) can be completely disabled. If you choose to implement a third-party time synchronization product that uses NTP, you must disable the Windows Time service. This is because all NTP servers need access to User Datagram Protocol (UDP) port 123, and as long as the Windows Time service is running on the Windows Server 2003 operating system, port 123 remains reserved by Windows Time.
 
 ## Network Ports Used by Windows Time Service
+
 The Windows Time service communicates on a network to identify reliable time sources, obtain time information, and provide time information to other computers. It performs this communication as defined by the NTP and SNTP RFCs.
 
 **Port Assignments for the Windows Time Service**
 
-|Service name|UDP|TCP|
-|----------------|-------|-------|
-|NTP|123|N/A|
-|SNTP|123|N/A|
+| Service name | UDP | TCP |
+|:-------------|:---:|:---:|
+|     NTP      | 123 | N/A |
+|     SNTP     | 123 | N/A |
 
-## See Also
-[Windows Time Service Technical Reference](windows-time-service-tech-ref.md)
-[Windows Time Service Tools and Settings](Windows-Time-Service-Tools-and-Settings.md)
-[Microsoft Knowledge Base article 902229](https://go.microsoft.com/fwlink/?LinkId=186066)
+## Related topics
+
+- [Windows 2016 Accurate Time](accurate-time.md)
+- [Time Accuracy Improvements for Windows Server 2016](windows-server-2016-improvements.md)
+- [Windows Time Service Technical Reference](windows-time-service-tech-ref.md)
+- [Windows Time Service Tools and Settings](Windows-Time-Service-Tools-and-Settings.md)
+- [Support boundary to configure the Windows Time service for high-accuracy environments](support-boundary.md)

--- a/WindowsServerDocs/networking/windows-time-service/windows-time-service-tech-ref.md
+++ b/WindowsServerDocs/networking/windows-time-service/windows-time-service-tech-ref.md
@@ -9,54 +9,59 @@ ms.topic: article
 ---
 
 # Windows Time Service Technical Reference
->Applies to: Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows 10 or later
+
+> **Applies to:** Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows 10 or later
 
 The W32Time service provides network clock synchronization for computers without the need for extensive configuration. The W32Time service is essential to the successful operation of Kerberos V5 authentication and, therefore, to AD DS-based authentication. Any Kerberos-aware application, including most security services, relies on time synchronization between the computers that are participating in the authentication request. AD DS domain controllers must also have synchronized clocks to help to ensure accurate data replication.
 
 > [!NOTE]
-> In Windows Server 2003 and Microsoft Windows 2000 Server, the directory service is named Active Directory directory service. In  Windows Server 2008 R2  and  Windows Server 2008 , the directory service is named Active Directory Domain Services (AD DS). The rest of this topic refers to AD DS, but the information is also applicable to Active Directory Domain Services in Windows Server 2016.
+> In Windows Server 2003 and Microsoft Windows 2000 Server, the directory service is named Active Directory directory service. In  Windows Server 2008 R2  and  Windows Server 2008, the directory service is named Active Directory Domain Services (AD DS). The rest of this topic refers to AD DS, but the information is also applicable to Active Directory Domain Services in Windows Server 2016.
 
 The W32Time service is implemented in a dynamic link library called W32Time.dll, which is installed by default in **%Systemroot%\System32**. W32Time.dll was originally developed for Windows 2000 Server to support a specification by the Kerberos V5 authentication protocol that required clocks on a network to be synchronized. Starting with Windows Server 2003, W32Time.dll provided increased accuracy in network clock synchronization over the Windows Server 2000 operating system. Additionally, in Windows Server 2003, W32Time.dll supported a variety of hardware devices and network time protocols using time providers.
 
 Although originally designed to provide clock synchronization for Kerberos authentication, many current applications use timestamps to ensure transactional consistency, record the time of important events, and other business-critical, time-sensitive information.  These applications benefit from time synchronization between computers that are provided by the Windows Time service.
 
 ## Importance of Time Protocols
+
 Time protocols communicate between two computers to exchange time information and then use that information to synchronize their clocks. With the Windows Time service time protocol, a client requests time information from a server and synchronizes its clock based on the information that is received.
 
 The Windows Time service uses NTP to help synchronize time across a network. NTP is an Internet time protocol that includes the discipline algorithms necessary for synchronizing clocks. NTP is a more accurate time protocol than the Simple Network Time Protocol (SNTP) that is used in some versions of Windows; however, W32Time continues to support SNTP to enable backward compatibility with computers running SNTP-based time services such as Windows 2000.
+
 ## Where to find Windows Time service configuration-related information
+
 This guide does **not** discuss configuring the Windows Time service. There are several different topics on Microsoft TechNet and in the Microsoft Knowledge Base that do explain procedures for configuring the Windows Time service. If you require configuration information, the following topics should help you locate the appropriate information.
--   To configure the Windows Time service for the forest root primary domain controller (PDC) emulator, see:
 
-    -   [Configure the Windows Time service on the PDC emulator in the Forest Root Domain](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc731191%28v=ws.10%29)
+- To configure the Windows Time service for the forest root primary domain controller (PDC) emulator, see:
 
-    -   [Configuring a time source for the forest](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc794823%28v%3dws.10%29)
+    - [Configure the Windows Time service on the PDC emulator in the Forest Root Domain](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc731191%28v=ws.10%29)
 
-    -   Microsoft Knowledge Base article 816042, [How to configure an authoritative time server in Windows Server](https://go.microsoft.com/fwlink/?LinkID=60402), which describes configuration settings for computers running Windows Server 2008 R2, Windows Server 2008, Windows Server 2003, and Windows Server 2003 R2.
+    - [Configuring a time source for the forest](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc794823%28v%3dws.10%29)
 
--   To configure the Windows Time service on any domain member client or server, or even domain controllers that are not configured as the forest root PDC emulator, see [Configure a client computer for automatic domain time synchronization](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc816884%28v%3dws.10%29).
+    - Microsoft Knowledge Base article 816042, [How to configure an authoritative time server in Windows Server](https://go.microsoft.com/fwlink/?LinkID=60402), which describes configuration settings for computers running Windows Server 2008 R2, Windows Server 2008, Windows Server 2003, and Windows Server 2003 R2.
+
+- To configure the Windows Time service on any domain member client or server, or even domain controllers that are not configured as the forest root PDC emulator, see [Configure a client computer for automatic domain time synchronization](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc816884%28v%3dws.10%29).
 
     > [!WARNING]
     > Some applications may require their computers to have high-accuracy time services. If that is the case, you may choose to configure a manual time source, but be aware that the Windows Time service was not designed to function as a highly accurate time source. Ensure that you are aware of the support limitations for high-accuracy time environments as described in Microsoft Knowledge Base article 939322, [Support boundary to configure the Windows Time service for high-accuracy environments](support-boundary.md).
 
--   To configure the Windows Time service on any Windows-based client or server computers that are configured as workgroup members instead of domain members see [Configure a manual time source for a selected client computer](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc816656%28v%3dws.10%29).
+- To configure the Windows Time service on any Windows-based client or server computers that are configured as workgroup members instead of domain members see [Configure a manual time source for a selected client computer](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc816656%28v%3dws.10%29).
 
--   To configure the Windows Time service on a host computer that runs a virtual environment, see Microsoft Knowledge Base article 816042, [How to configure an authoritative time server in Windows Server](https://go.microsoft.com/fwlink/?LinkID=60402). If you are working with a non-Microsoft virtualization product, be sure to consult the documentation of the vendor for that product.
+- To configure the Windows Time service on a host computer that runs a virtual environment, see Microsoft Knowledge Base article 816042, [How to configure an authoritative time server in Windows Server](https://go.microsoft.com/fwlink/?LinkID=60402). If you are working with a non-Microsoft virtualization product, be sure to consult the documentation of the vendor for that product.
 
--   To configure the Windows Time service on a domain controller that is running in a virtual machine, it is recommended that you partially disable time synchronization between the host system and guest operating system acting as a domain controller. This enables your guest domain controller to synchronize time for the domain hierarchy, but protects it from having a time skew if it is restored from a Saved state. For more information, see Microsoft Knowledge Base article 976924, [You receive Windows Time Service event IDs 24, 29, and 38 on a virtualized domain controller that is running on a Windows Server 2008-based host server with Hyper-V](https://go.microsoft.com/fwlink/?LinkID=192236) and [Deployment Considerations for Virtualized Domain Controllers](https://go.microsoft.com/fwlink/?LinkID=192235).
+- To configure the Windows Time service on a domain controller that is running in a virtual machine, it is recommended that you partially disable time synchronization between the host system and guest operating system acting as a domain controller. This enables your guest domain controller to synchronize time for the domain hierarchy, but protects it from having a time skew if it is restored from a Saved state. For more information, see Microsoft Knowledge Base article 976924, [You receive Windows Time Service event IDs 24, 29, and 38 on a virtualized domain controller that is running on a Windows Server 2008-based host server with Hyper-V](https://go.microsoft.com/fwlink/?LinkID=192236) and [Deployment Considerations for Virtualized Domain Controllers](https://go.microsoft.com/fwlink/?LinkID=192235).
 
--   To configure the Windows Time service on a domain controller acting as the forest root PDC emulator that is also running in a virtual computer, follow the same instructions for a physical computer as described in [Configure the Windows Time service on the PDC emulator in the Forest Root Domain](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc731191%28v=ws.10%29).
+- To configure the Windows Time service on a domain controller acting as the forest root PDC emulator that is also running in a virtual computer, follow the same instructions for a physical computer as described in [Configure the Windows Time service on the PDC emulator in the Forest Root Domain](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc731191%28v=ws.10%29).
 
--   To configure the Windows Time service on a member server running as a virtual computer, use the domain time hierarchy as described in [Configure a client computer for automatic domain time synchronization](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc816884%28v%3dws.10%29).
+- To configure the Windows Time service on a member server running as a virtual computer, use the domain time hierarchy as described in [Configure a client computer for automatic domain time synchronization](/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc816884%28v%3dws.10%29).
 
 
 > [!IMPORTANT]
 > Prior to Windows Server 2016, the W32Time service was not designed to meet time-sensitive application needs.  However, updates to Windows Server 2016 now allow you to implement a solution for 1ms accuracy in your domain.  For more information about, see  [Windows 2016 Accurate Time](accurate-time.md) and [Support boundary to configure the Windows Time service for high-accuracy environments](support-boundary.md) for more information.
 
 ## Related topics
+
 - [Windows 2016 Accurate Time](accurate-time.md)
 - [Time Accuracy Improvements for Windows Server 2016](windows-server-2016-improvements.md)
 - [How the Windows Time Service Works](How-the-Windows-Time-Service-Works.md)
 - [Windows Time Service Tools and Settings](Windows-Time-Service-Tools-and-Settings.md)
 - [Support boundary to configure the Windows Time service for high-accuracy environments](support-boundary.md)
-- [Microsoft Knowledge Base article 902229](https://go.microsoft.com/fwlink/?LinkId=186066)


### PR DESCRIPTION
**Description:**

This PR is to resolve issue ticket #5497 (**Broken link to KB**).

Thanks to Elizabeth Greene (@ElizabethGreene) for reporting this issue, present in both article pages.

The KB 902229 page has been deleted, and the page can only be found in the web archives. The KB article is also specific to Windows Server 2003, and is therefore no longer relevant.

There is currently no known replacement for KB 902229, so the logical resolution is to remove the link from both articles in this PR.

**Changes proposed:**

- Remove the go.microsoft.com link redirecting to KB 902229.
- Replace the "See Also" section with the "Related topics" section (copied from the Windows Time Service Technical Reference page).

**Additional whitespace and codestyle changes:**

- Remove EOL (end-of-line) blanks (redundant whitespace).
- Standardize line spacing by adding 1 blank line after H2/H3 headings.
- Normalize bullet point lists to only one blank after bullet markers.
- Add MD indent marker spacing and **bold** to "Applies to:".
- Properly align MD tables and add centering to the values columns.
- (edit:) Apply proper Note Blob MD formatting to the Note below the "Domain Controller Time Source Queries" table.

**Ticket closure or reference:**

Closes #5497