### PR TITLE
Warn about WS-Federation endpoints not working with idpinitiatedsignon

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/troubleshooting/ad-fs-tshoot-initiatedsignon.md
+++ b/WindowsServerDocs/identity/ad-fs/troubleshooting/ad-fs-tshoot-initiatedsignon.md
@@ -55,6 +55,10 @@ You can test the seamless logon experience by making sure that the URL for your 
 
     ![Screenshot of the Sign in page showing that the user wasn't prompted for credentials.](media/ad-fs-tshoot-initiatedsignon/idp6.png)
 
+## Known Issues
+
+The AD FS sign-on page cannot be used to initiate a sign-on with a claims provider trust that is configured with a WS-Federation passive endpoint only. Register a relying party such as [ClaimsXRay](https://adfshelp.microsoft.com/ClaimsXray/TokenRequest) to verify that a WS-Federation claims provider trust works as intended.
+
 ## Next Steps
 
 - [AD FS Troubleshooting](ad-fs-tshoot-overview.md)


### PR DESCRIPTION
At least in Windows Server 2019, if the claims provider only has a WS-Federation endpoint, it cannot be used with the idpinitiatedsignon unless you were redirected there from a relying party.

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.IdentityServer.Web.Protocols.Saml.SamlProtocolHandler.SendSignInResponse(SamlContext context, MSISSignInResponse response)
   at Microsoft.IdentityServer.Web.PassiveProtocolListener.ProcessProtocolRequest(ProtocolContext protocolContext, PassiveProtocolHandler protocolHandler)
   at Microsoft.IdentityServer.Web.PassiveProtocolListener.OnGetContext(WrappedHttpListenerContext context)
```

We ran into this exception while testing our own WS-Federation provider with AD FS. With the help of Microsoft support, the only issue was that we tried to use idpinitiatedsignon directly, without being redirected there from a relying party. According to MS support, the idpinitiatedsignon page cannot be used to do that, if the claims provider is configured with WS-Federation only. According to them, adding a SAML 2.0 endpoint should have helped with that, but we didn't test it, since it was out of scope for our project.