### PR TITLE
404 WDAC Guide URL correction ( f281ba0 follow-up)

### DIFF
--- a/WindowsServerDocs/security/security-and-assurance.yml
+++ b/WindowsServerDocs/security/security-and-assurance.yml
@@ -60,7 +60,7 @@ landingContent:
       - linkListType: overview
         links:
           - text: Windows Defender Application Control (WDAC) Deployment Guide
-            url: /windows/security/threat-protection/windows-defender-application-control/windows-defender-application-contro
+            url: /windows/security/threat-protection/windows-defender-application-control/windows-defender-application-control-deployment-guide.md
           - text: Transport Layer Security Registry Settings
             url: ./tls/tls-registry-settings.md
           - text: Control Flow Guard


### PR DESCRIPTION
From issue ticket  #5568 (**Dead Link to Windows Defender Application Control (WDAC) Deployment Guide**):

> The Windows Server Security documentation page at https://docs.microsoft.com/en-us/windows-server/security/security-and-assurance has a dead link to the Windows Defender Application Control (WDAC) Deployment Guide. Please fix this.
> 
> Steps to reproduce:
> 
> 1. Go to https://docs.microsoft.com/en-us/windows-server/security/security-and-assurance .
> 2. Click on link to Windows Defender Application Control (WDAC) Deployment Guide under the Hardening the OS and applications box.
> 3. Get a 404.
> 
> Expected results: Arrive at the Windows Defender Application Control (WDAC) Deployment Guide page.
> Actual results: Get a 404.

**Proposed change:**
- insert the missing piece of the link, based on results from commit f281ba0

(The change at end-of-file (EOF) is a GitHub automated NewLine insertion, which was missing before.)

**Ticket closure or reference:**

Closes #5568