### PR TITLE
Added a note to have CX's wait for SYNC process run on secondary AD F…

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/deployment/Best-Practices-Securing-AD-FS.md
+++ b/WindowsServerDocs/identity/ad-fs/deployment/Best-Practices-Securing-AD-FS.md
@@ -172,6 +172,7 @@ WS-Trust Windows endpoints (*/adfs/services/trust/2005/windowstransport* and */a
 Set-AdfsEndpoint -TargetAddressPath /adfs/services/trust/2005/windowstransport -Proxy $false
 Set-AdfsEndpoint -TargetAddressPath /adfs/services/trust/13/windowstransport -Proxy $false
 ```
+Note: In case your AD FS farm runs on Windows Internal Databases (WID) and have a secondary AD FS server, after disabling the endpoints on primary server, wait for the SYNC to occur on secondary nodes before restarting the AD FS service on them. Use PowerShell command Get-AdfsSyncProperties on secondary node to track last SYNC process.
 
 ### Differentiate access policies for intranet and extranet access
 AD FS has the ability to differentiate access policies for requests that originate in the local, corporate network vs requests that come in from the internet via the proxy.  This can be done per application or globally.  For high business value applications or applications with sensitive or personally identifiable information, consider requiring multi factor authentication.  This can be done via the AD FS management snap-in.

--- a/WindowsServerDocs/identity/ad-fs/deployment/Best-Practices-Securing-AD-FS.md
+++ b/WindowsServerDocs/identity/ad-fs/deployment/Best-Practices-Securing-AD-FS.md
@@ -172,7 +172,8 @@ WS-Trust Windows endpoints (*/adfs/services/trust/2005/windowstransport* and */a
 Set-AdfsEndpoint -TargetAddressPath /adfs/services/trust/2005/windowstransport -Proxy $false
 Set-AdfsEndpoint -TargetAddressPath /adfs/services/trust/13/windowstransport -Proxy $false
 ```
-Note: In case your AD FS farm runs on Windows Internal Databases (WID) and have a secondary AD FS server, after disabling the endpoints on primary server, wait for the SYNC to occur on secondary nodes before restarting the AD FS service on them. Use PowerShell command Get-AdfsSyncProperties on secondary node to track last SYNC process.
+>[!NOTE]
+>In case your AD FS farm runs on Windows Internal Databases (WID) and have a secondary AD FS server, after disabling the endpoints on primary server, wait for the SYNC to occur on secondary nodes before restarting the AD FS service on them. Use PowerShell command Get-AdfsSyncProperties on secondary node to track last SYNC process.
 
 ### Differentiate access policies for intranet and extranet access
 AD FS has the ability to differentiate access policies for requests that originate in the local, corporate network vs requests that come in from the internet via the proxy.  This can be done per application or globally.  For high business value applications or applications with sensitive or personally identifiable information, consider requiring multi factor authentication.  This can be done via the AD FS management snap-in.

--- a/WindowsServerDocs/identity/ad-fs/deployment/Best-Practices-Securing-AD-FS.md
+++ b/WindowsServerDocs/identity/ad-fs/deployment/Best-Practices-Securing-AD-FS.md
@@ -173,7 +173,7 @@ Set-AdfsEndpoint -TargetAddressPath /adfs/services/trust/2005/windowstransport -
 Set-AdfsEndpoint -TargetAddressPath /adfs/services/trust/13/windowstransport -Proxy $false
 ```
 >[!NOTE]
->In case your AD FS farm runs on Windows Internal Databases (WID) and have a secondary AD FS server, after disabling the endpoints on primary server, wait for the SYNC to occur on secondary nodes before restarting the AD FS service on them. Use PowerShell command Get-AdfsSyncProperties on secondary node to track last SYNC process.
+>If your AD FS farm runs on Windows Internal Databases (WID) and has a secondary AD FS server, after disabling the endpoints on primary server, wait for the SYNC to occur on secondary nodes before restarting the AD FS service on them. Use the PowerShell command **Get-AdfsSyncProperties** on the secondary node to track last SYNC process.
 
 ### Differentiate access policies for intranet and extranet access
 AD FS has the ability to differentiate access policies for requests that originate in the local, corporate network vs requests that come in from the internet via the proxy.  This can be done per application or globally.  For high business value applications or applications with sensitive or personally identifiable information, consider requiring multi factor authentication.  This can be done via the AD FS management snap-in.


### PR DESCRIPTION
…S servers for a successful update on WAP servers

### Disable WS-Trust Windows endpoints on the proxy i.e. from extranet

WS-Trust Windows endpoints (*/adfs/services/trust/2005/windowstransport* and */adfs/services/trust/13/windowstransport*) are meant only to be intranet facing endpoints that use WIA binding on HTTPS. Exposing them to extranet could allow requests against these endpoints to bypass lockout protections. These endpoints should be disabled on the proxy (i.e. disabled from extranet) to protect AD account lockout by using following PowerShell commands. There is no known end user impact by disabling these endpoints on the proxy.

```powershell
Set-AdfsEndpoint -TargetAddressPath /adfs/services/trust/2005/windowstransport -Proxy $false
Set-AdfsEndpoint -TargetAddressPath /adfs/services/trust/13/windowstransport -Proxy $false
```

ADD NOTE BELOW:
Note: In case AD FS farm running on Windows Internal Databases (WID) with secondary AD FS servers, after disabling the endpoints on primary server, wait for the SYNC process to occur on secondary nodes (by default 5 minutes) before restarting the AD FS service on them. Use PowerShell command Get-AdfsSyncProperties on secondary nodes to track last SYNC process.