### PR TITLE
Update detect-enable-and-disable-smbv1-v2-v3.md

### DIFF
--- a/WindowsServerDocs/storage/file-server/Troubleshoot/detect-enable-and-disable-smbv1-v2-v3.md
+++ b/WindowsServerDocs/storage/file-server/Troubleshoot/detect-enable-and-disable-smbv1-v2-v3.md
@@ -356,7 +356,7 @@ To use Group Policy to configure this, follow these steps:
 
 In the **New Registry Properties** dialog box, select the following:
 
-- **Action**: Create
+- **Action**: Update
 - **Hive**: HKEY_LOCAL_MACHINE
 - **Key Path**: SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters
 - **Value name**: SMB1


### PR DESCRIPTION
Create only works if the named value doesn't exist already. By default the named value isn't there, but if it is (because of earlier administrative configurations for example), then it won't be changed! For example: suppose some admin configuration has set the named value with value 1 and later you want to set it to 0 through GPP, then it won't be set to 0 (disabled), because of Create. Taking Update as the action has the desired result though: update it when it already exists and if it doesn't exist yet, create it.
PS: Create is not always a wrong choice (in theory it could be the case that you only want to change the behavior, when the named value doesn't exist yet, although this seems a very exceptional scenario), but typically Update will cover the desired result better.