### PR TITLE
Update detect-enable-and-disable-smbv1-v2-v3.md

### DIFF
--- a/WindowsServerDocs/storage/file-server/Troubleshoot/detect-enable-and-disable-smbv1-v2-v3.md
+++ b/WindowsServerDocs/storage/file-server/Troubleshoot/detect-enable-and-disable-smbv1-v2-v3.md
@@ -208,7 +208,7 @@ Detect:
 Get-Item HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters | ForEach-Object {Get-ItemProperty $_.pspath}
 ```
 
-Default configuration = Enabled (No registry key is created), so no SMB1 value will be returned
+Default configuration = Enabled (No registry named value is created), so no SMB1 value will be returned
 
 Disable:
 


### PR DESCRIPTION
The registry key does exist by default; it's the named value that doesn't exist by default.