### PR TITLE
Fix incorrect unrevoke index

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/certutil.md
+++ b/WindowsServerDocs/administration/windows-commands/certutil.md
@@ -187,7 +187,7 @@ Where:
 
   - **8. CRL_REASON_REMOVE_FROM_CRL** - Remove From CRL
 
-  - **1. Unrevoke** - Unrevoke
+  - **-1. Unrevoke** - Unrevoke
 
 ```
 [-config Machine\CAName]


### PR DESCRIPTION
Unrevoke is represented by -1, not 1 as shown in the original documentation. Added the - to show the correct information.