### PR TITLE
Updating example script text

### DIFF
--- a/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-server-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-server-infrastructure.md
@@ -65,7 +65,7 @@ You manually enroll certificates on VPN servers.
 
 Since the RRAS server is not domain joined, autoenrollment cannot be used to enroll the VPN gateway certificate.  Therefore, use an offline certificate request procedure.
 
-1. On the RRAS server, generate a file called **VPNGateway.inf** based upon the [example certificate policy request](#example-vpngatewayinf-script) provided below and customize the following entries:
+1. On the RRAS server, generate a file called **VPNGateway.inf** based upon the [example certificate policy request](#example-vpngatewayinf-script) provided later in this article and customize the following entries:
 
    - In the [NewRequest] section, replace vpn.contoso.com used for the Subject Name with the chosen [_Customer_] VPN endpoint FQDN.
 

--- a/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-server-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-server-infrastructure.md
@@ -65,7 +65,7 @@ You manually enroll certificates on VPN servers.
 
 Since the RRAS server is not domain joined, autoenrollment cannot be used to enroll the VPN gateway certificate.  Therefore, use an offline certificate request procedure.
 
-1. On the RRAS server, generate a file called **VPNGateway.inf** based upon the example certificate policy request provided in Appendix A (section 0) and customize the following entries:
+1. On the RRAS server, generate a file called **VPNGateway.inf** based upon the [example certificate policy request](#example-vpngatewayinf-script) provided below and customize the following entries:
 
    - In the [NewRequest] section, replace vpn.contoso.com used for the Subject Name with the chosen [_Customer_] VPN endpoint FQDN.
 


### PR DESCRIPTION
The text relating to the example .inf file suggested that users look in an Appendix that doesn't exist. I modified the text to say that the example was below in the article and provided a link to the section.