### PR TITLE
Proman tls

### DIFF
--- a/WindowsServerDocs/security/tls/tls-ssl-schannel-ssp-overview.md
+++ b/WindowsServerDocs/security/tls/tls-ssl-schannel-ssp-overview.md
@@ -12,14 +12,14 @@ ms.date: 05/16/2018
 
 >Applies to: Windows Server 2022, Windows Server 2019, Windows Server 2016, Windows 10
 
-This topic for the IT professional introduces the TLS and SSL implementations in Windows using the Schannel Security Service Provider (SSP) by describing practical applications, changes in Microsoft's implementation, and software requirements, plus additional resources for Windows Server 2012 and Windows 8.
+This topic for the IT professional introduces the TLS and SSL implementations in Windows using the Schannel Security Service Provider (SSP) by describing practical applications, changes in Microsoft's implementation, and software requirements, plus additional resources for Windows Server and Windows client.
 
 ## <a name="BKMK_OVER"></a>Description
 Schannel is a Security Support Provider (SSP) that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) Internet standard authentication protocols.
 
 The Security Support Provider Interface (SSPI) is an API used by Windows systems to perform security-related functions including authentication. The SSPI functions as a common interface to several SSPs, including the Schannel SSP.
 
-TLS versions 1.0, 1.1, and 1.2, SSL versions 2.0 and 3.0, as well as the Datagram Transport Layer Security \(DTLS\) protocol version 1.0, and the Private Communications Transport \(PCT\) protocol are based on public key cryptography. The Schannel authentication protocol suite provides these protocols. All Schannel protocols use a client/server model.
+TLS versions 1.0, 1.1, 1.2 and 1.3, SSL versions 2.0 and 3.0, as well as the Datagram Transport Layer Security \(DTLS\) protocol version 1.0, and the Private Communications Transport \(PCT\) protocol are based on public key cryptography. The Schannel authentication protocol suite provides these protocols. All Schannel protocols use a client/server model.
 
 ## <a name="BKMK_APP"></a>Applications
 One problem when you administer a network is securing data that is being sent between applications across an untrusted network. You can use TLS and SSL to authenticate servers and client computers and then use the protocol to encrypt messages between the authenticated parties.

--- a/WindowsServerDocs/security/tls/transport-layer-security-protocol.md
+++ b/WindowsServerDocs/security/tls/transport-layer-security-protocol.md
@@ -12,7 +12,7 @@ ms.date: 05/16/2018
 
 >Applies to: Windows Server 2022, Windows Server 2019, Windows Server 2016, Windows 10
 
-This topic for the IT professional describes how the Transport Layer Security (TLS) protocol works and provides links to the IETF RFCs for TLS 1.0, TLS 1.1, and TLS 1.2.
+This topic for the IT professional describes how the Transport Layer Security (TLS) protocol works and provides links to the IETF RFCs for TLS 1.0, TLS 1.1, TLS 1.2 and TLS 1.3.
 
 The TLS (and SSL) protocols are located between the application protocol layer and the TCP/IP layer, where they can secure and send application data to the transport layer. Because the protocols work between the application layer and the transport layer, TLS and SSL can support multiple application layer protocols.
 
@@ -42,6 +42,8 @@ The Schannel SSP implements the TLS and SSL protocols without modification. The 
 -   Mandatory Cipher Suites
 
 -   Application Data Protocol
+
+[RFC 8446 - The Transport Layer Security (TLS) Protocol Version 1.3](https://datatracker.ietf.org/doc/html/rfc8446)
 
 [RFC 5246 - The Transport Layer Security (TLS) Protocol Version 1.2](http://tools.ietf.org/html/rfc5246)
 


### PR DESCRIPTION
updated documents to insert references to the TLS 1.3 standard and fixes some references that only covered server 2012