### PR TITLE
Remove duplicate /is /it documentation

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/robocopy.md
+++ b/WindowsServerDocs/administration/windows-commands/robocopy.md
@@ -98,15 +98,13 @@ robocopy c:\reports '\\marketing\videos' yearly-report.mov /mt /z
 | /xx | Excludes extra files and directories. |
 | /xl | Excludes "lonely" files and directories. |
 | /im | Include modified files (differing change times). |
-| /is | Includes the same files. |
-| /it | Includes tweaked files. |
+| /is | Includes the same files. Same files are identical in name, size, times, and all attributes. |
+| /it | Includes "tweaked" files. Tweaked files have the same name, size, and times, but different attributes. |
 | /xc | Excludes existing files with the same timestamp, but different file sizes. |
 | /xn | Excludes existing files newer than the copy in the source directory. |
 | /xo | Excludes existing files older than the copy in the source directory. |
 | /xx | Excludes extra files and directories present in the destination but not the source. Excluding extra files will not delete files from the destination.  |
 | /xl | Excludes "lonely" files and directories present in the source but not the destination. Excluding lonely files prevents any new files from being added to the destination. |
-| /is | Includes the same files. Same files are identical in name, size, times, and all attributes. |
-| /it | Includes "tweaked" files. Tweaked files have the same name, size, and times, but different attributes. |
 | /max:`<n>` | Specifies the maximum file size (to exclude files bigger than *n* bytes). |
 | /min:`<n>` | Specifies the minimum file size (to exclude files smaller than *n* bytes). |
 | /maxage:`<n>` | Specifies the maximum file age (to exclude files older than *n* days or date). |


### PR DESCRIPTION
They were listed twice: I kept the better explanations.