### PR TITLE
dnscmd /zoneexport command - fix path slashes

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/dnscmd.md
+++ b/WindowsServerDocs/administration/windows-commands/dnscmd.md
@@ -737,7 +737,7 @@ dnscmd [<servername>] /zonedelete <zonename> [/dsdel] [/f]
 
 ## dnscmd /zoneexport command
 
-Creates a text file that lists the resource records of a specified zone. The **zoneexport** operation creates a file of resource records for an active directory integrated zone for troubleshooting purposes. By default, the file that this command creates is placed in the DNS directory, which is by default the `%systemroot%/System32/Dns` directory.
+Creates a text file that lists the resource records of a specified zone. The **zoneexport** operation creates a file of resource records for an active directory integrated zone for troubleshooting purposes. By default, the file that this command creates is placed in the DNS directory, which is by default the `%systemroot%\System32\Dns` directory.
 
 ### Syntax
 


### PR DESCRIPTION
Fix Windows path slashes 
https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/dnscmd#dnscmd-zoneexport-command 
![image](https://user-images.githubusercontent.com/77168855/132844305-06e505bd-e554-4967-95f8-d019fb47f042.png)
