### PR TITLE
Correct PowerShell example for `sshd` service

### DIFF
--- a/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
+++ b/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
@@ -43,7 +43,7 @@ By default the sshd service is set to start manually. To start it each time the 
 
 ```powershell
 # Set the sshd service to be started automatically
-Get-Service -Name ssh-agent | Set-Service -StartupType Automatic
+Get-Service -Name sshd | Set-Service -StartupType Automatic
 
 # Now start the sshd service
 Start-Service sshd


### PR DESCRIPTION
The example code has the `ssh-agent` service being set to start automatically, *not* `sshd`.