### PR TITLE
Fix Windows Server 2022 App Compatibility FOD WIM image integration instructions

### DIFF
--- a/WindowsServerDocs/get-started/server-core-app-compatibility-feature-on-demand.md
+++ b/WindowsServerDocs/get-started/server-core-app-compatibility-feature-on-demand.md
@@ -203,7 +203,7 @@ The App Compatibility FOD can only be installed on Server Core. Don't attempt to
    ```PowerShell
    $capability_name = "ServerCore.AppCompatibility~~~~0.0.1.0"
    $package_path = "E:\LanguagesAndOptionalFeatures\Microsoft-Windows-InternetExplorer-Optional-Package~31bf3856ad364e35~amd64~~.cab"
-   $fod_drive = "E:\"
+   $fod_drive = "E:\LanguagesAndOptionalFeatures\"
 
    Add-WindowsCapability -Path $mount_folder -Name $capability_name -Source $fod_drive -LimitAccess
    Add-WindowsPackage -Path $mount_folder -PackagePath $package_path


### PR DESCRIPTION
Need to specify path to LanguagesAndOptionalFeatures folder, not just drive letter.