### PR TITLE
Configure `ssh-agent` to start automatically

### DIFF
--- a/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
+++ b/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
@@ -107,9 +107,9 @@ Remember that private key files are the equivalent of a password should be prote
 To help with that, use ssh-agent to securely store the private keys within a Windows security context, associated with your Windows login. To do that, start the ssh-agent service as Administrator and use ssh-add to store the private key.
 
 ```powershell
-# By default the ssh-agent service is disabled. Allow it to be manually started for the next step to work.
+# By default the ssh-agent service is disabled. Configure it to start automatically.
 # Make sure you're running as an Administrator.
-Get-Service ssh-agent | Set-Service -StartupType Manual
+Get-Service ssh-agent | Set-Service -StartupType Automatic
 
 # Start the service
 Start-Service ssh-agent


### PR DESCRIPTION
The documentation states:

> After completing these steps, whenever a private key is needed for authentication from this client, ssh-agent will automatically retrieve the local private key and pass it to your SSH client.

However, for this to work with current instructions, you need to manually start the agent after every reboot. This PR suggests to configure `ssh-agent` to start automatically instead, as proposed in #5704.