### PR TITLE
fixing a typo

### DIFF
--- a/WindowsServerDocs/networking/sdn/manage/Create-a-Tenant-VM.md
+++ b/WindowsServerDocs/networking/sdn/manage/Create-a-Tenant-VM.md
@@ -115,7 +115,7 @@ Ensure that you have already created a Virtual Network before using this example
    $CurrentFeature.SettingData.ProfileId = "{$($nic.InstanceId)}"
    $CurrentFeature.SettingData.ProfileData = 1
 
-   Set-VMSwitchExtensionPortFeature -VMSwitchExtensionFeature $CurrentFeature  -VMNetworkAdapter $vmNic
+   Set-VMSwitchExtensionPortFeature -VMSwitchExtensionFeature $CurrentFeature  -VMNetworkAdapter $vmNics
    }
    ```
 


### PR DESCRIPTION
The last parameter in step 5 under " Create a VM and connect to a Virtual Network by using the Windows PowerShell Network Controller cmdlets" is wrong and is pretty hard to spot by the reader. $vmnics is used throughout that script then it changes to $vmnic in the last command. I think I already raised this issue before and I still fell for it again.