### PR TITLE
Adding OpenOTP ADFS plugin from RCDevs Security

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/Configure-Additional-Authentication-Methods-for-AD-FS.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/Configure-Additional-Authentication-Methods-for-AD-FS.md
@@ -40,6 +40,7 @@ Mideye | Mideye Authentication Provider for AD FS | [Mideye two-factor authentic
 |One Identity| Starling 2FA AD FS|[Starling 2FA AD FS Adapter](https://www.oneidentity.com/products/starling-two-factor-authentication/)|
 |One Identity| Defender AD FS|[Defender AD FS Adapter](https://www.oneidentity.com/products/defender/)|
 |Ping Identity|PingID MFA Adapter for AD FS|[PingID MFA Adapter for AD FS](https://documentation.pingidentity.com/pingid/pingidAdminGuide/index.shtml#pid_c_PingIDforADFSSSO.html)|
+|RCDevs Security|OpenOTP ADFS plugin|[ADFS & OpenOTP](https://www.rcdevs.com/docs/howtos/openotp_adfs/adfs_openotp/)|
 |RSA, The Security Division of EMC|RSA SecurID Authentication Agent for Microsoft Active Directory Federation Services|[RSA SecurID Authentication Agent for Microsoft Active Directory Federation Services](http://www.emc.com/security/rsa-securid/rsa-authentication-agents/microsoft-ad-fs.htm)|
 |SafeNet, Inc.|SafeNet Authentication Service (SAS) Agent for AD FS|[SafeNet Authentication Service: AD FS Agent Configuration Guide](http://www.safenet-inc.com/resources/integration-guide/data-protection/Safenet_Authentication_Service/SafeNet_Authentication_Service__AD_FS_Agent_Configuration_Guide/?langtype=1033)|
 |SecureMFA|SecureMFA OTP Provider| [AD FS Multi Factor Authentication Providers](https://www.securemfa.com/)|


### PR DESCRIPTION
The modification adds the OpenOTP ADFS plugin we provide in order to integrate RCDevs OpenOTP to ADFS.