### PR TITLE
Update index.md

### DIFF
--- a/WindowsServerDocs/administration/performance-tuning/role/file-server/index.md
+++ b/WindowsServerDocs/administration/performance-tuning/role/file-server/index.md
@@ -151,7 +151,7 @@ The following REG\_DWORD registry settings can affect the performance of client 
     HKLM\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\DisableLargeMtu
     ```
 
-    Applies to Windows 10, Windows 8.1, Windows 8, Windows 7, Windows Vista, Windows Server 2022, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows Server 2008 R2, and Windows Server 2008
+    Applies to Windows 11, Windows 10, Windows 8.1, Windows 8, Windows 7, Windows Server 2022, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, and Windows Server 2008 R2
 
     The default is 0 for Windows 8 only. In Windows 8, the SMB redirector transfers payloads as large as 1 MB per request, which can improve file transfer speed. Setting this registry value to 1 limits the request size to 64 KB. You should evaluate the impact of this setting before applying it.
 


### PR DESCRIPTION
AFAIK DisableLargeMTU has been introduced with the SMB feature "Large MTU", which, according to my knowledge, has been made available with SMB 2.1. As SMB 2.1 has seen life with Windows 7 & WS08R2, I wouldn't expect the aforementioned named value on Vista or WS08. On the other hand, Windows 11 is still aware of this named value.