### PR TITLE
Update default SA lifetime in the sample

### DIFF
--- a/WindowsServerDocs/networking/sdn/gateway-performance.md
+++ b/WindowsServerDocs/networking/sdn/gateway-performance.md
@@ -56,14 +56,14 @@ $nwConnectionProperties.IpSecConfiguration.QuickMode.AuthenticationTransformatio
 $nwConnectionProperties.IpSecConfiguration.QuickMode.CipherTransformationConstant = "GCMAES256"
 $nwConnectionProperties.IpSecConfiguration.QuickMode.SALifeTimeSeconds = 3600
 $nwConnectionProperties.IpSecConfiguration.QuickMode.IdleDisconnectSeconds = 500
-$nwConnectionProperties.IpSecConfiguration.QuickMode.SALifeTimeKiloBytes = 2000
+$nwConnectionProperties.IpSecConfiguration.QuickMode.SALifeTimeKiloBytes = 2000000
 
 $nwConnectionProperties.IpSecConfiguration.MainMode = New-Object Microsoft.Windows.NetworkController.MainMode
 $nwConnectionProperties.IpSecConfiguration.MainMode.DiffieHellmanGroup = "Group2"
 $nwConnectionProperties.IpSecConfiguration.MainMode.IntegrityAlgorithm = "SHA256"
 $nwConnectionProperties.IpSecConfiguration.MainMode.EncryptionAlgorithm = "AES256"
 $nwConnectionProperties.IpSecConfiguration.MainMode.SALifeTimeSeconds = 28800
-$nwConnectionProperties.IpSecConfiguration.MainMode.SALifeTimeKiloBytes = 2000
+$nwConnectionProperties.IpSecConfiguration.MainMode.SALifeTimeKiloBytes = 2000000
 
 # L3 specific configuration (leave blank for IPSec)
 $nwConnectionProperties.IPAddresses = @()


### PR DESCRIPTION
Bump up the default SA lifetime from 2MB to 2GB. Customers can unwittingly copy this into production causing massive number of SA re-negotiations as perf starts to climb.