### PR TITLE
[mountvol] listing "mounts by volume" vs. "volumes by mount"

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/mountvol.md
+++ b/WindowsServerDocs/administration/windows-commands/mountvol.md
@@ -42,6 +42,8 @@ mountvol <drive>: /s
 
 ## Remarks
 
+- Typing `mountvol` with no parameters lists the available volumes, along with the current mount points for each. This is the only way to show the inverse of the grouping shown by the **/l** parameter.
+
 - If you dismount your volume while using the **/p** parameter, the volume list will show the volume as not mounted until a volume mount point is created.
 
 - If your volume has more than one mount point, use **/d** to remove the additional mount points before using **/p**. You can make the basic volume mountable again by assigning a volume mount point.


### PR DESCRIPTION
The `/l` switch lists the **_volumes by mount point_**, but apparently there is no switch to do the opposite, list **_mount points by volume_**. The information is, however, provided by typing `mountvol` without any parameters. As far as I can tell, this is the only way to get mount points by volume using `mountvol`.

Unfortunately, doing it this way also displays the help info as a header, and there is no way to narrow the request down to only the mount for a particular specified volume.

<pre>C:\&gt; <b>mountvol</b>
Creates, deletes, or lists a volume mount point.

MOUNTVOL [drive:]path VolumeName
MOUNTVOL [drive:]path /D
MOUNTVOL [drive:]path /L
MOUNTVOL [drive:]path /P
MOUNTVOL /R
MOUNTVOL /N
MOUNTVOL /E

    path        Specifies the existing NTFS directory where the mount
                point will reside.
    VolumeName  Specifies the volume name that is the target of the mount
                point.
    /D          Removes the volume mount point from the specified directory.
    /L          Lists the mounted volume name for the specified directory.
    /P          Removes the volume mount point from the specified directory,
                dismounts the volume, and makes the volume not mountable.
                You can make the volume mountable again by creating a volume
                mount point.
    /R          Removes volume mount point directories and registry settings
                for volumes that are no longer in the system.
    /N          Disables automatic mounting of new volumes.
    /E          Re-enables automatic mounting of new volumes.

Possible values for VolumeName along with current mount points are:

<b>    \\?\Volume{650fa92e-96e5-4f91-8d1a-2102a05ec50f}\
        E:\

    \\?\Volume{fa86ef6d-0000-0000-0000-402400000000}\
        C:\

    \\?\Volume{eafac607-2463-46ff-9772-d1d0f169fc41}\
        X:\
        E:\test-mount\</b>
C:\&gt;
</pre>
