### PR TITLE
Added paranthesis

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/performance-history-scripting.md
+++ b/WindowsServerDocs/storage/storage-spaces/performance-history-scripting.md
@@ -371,7 +371,7 @@ Function Format-Trend {
             $Sign = "-"
         }
         # Return
-        $Sign + $(Format-Bytes [Math]::Abs($RawValue)) + "/day"
+        $Sign + $(Format-Bytes ([Math]::Abs($RawValue))) + "/day"
     }
 }
 


### PR DESCRIPTION
Added parenthesis around the format-trend output. Without it, only +/day is returned, not the value.

![image](https://user-images.githubusercontent.com/2729151/145843738-5b79a7bf-2406-41f1-a630-23bbe65a11b3.png)
