### PR TITLE
Fix Azure Extended Network extension's name

### DIFF
--- a/WindowsServerDocs/manage/windows-admin-center/azure/azure-extended-network.md
+++ b/WindowsServerDocs/manage/windows-admin-center/azure/azure-extended-network.md
@@ -95,7 +95,7 @@ Deployment is driven through Windows Admin Center.
 
     ![Screenshot showing the available extensions tab of Settings](../media/azure-extended-network/installed-extensions.png)
 
-3. On the **Available extensions** tab, select **Extended network**, and then select **Install**.
+3. On the **Available extensions** tab, select **Azure Extended Network**, and then select **Install**.
 
     After a few seconds you should see a message indicating a successful installation.
 


### PR DESCRIPTION
Fix Azure Extended Network extension's name in Windows Admin Center.

![image](https://user-images.githubusercontent.com/1618784/145948515-5257e63e-b3a8-40ea-b392-72548a6eecb7.png)
