### PR TITLE
Remove 2016 from the title

### DIFF
--- a/WindowsServerDocs/security/windows-services/security-guidelines-for-disabling-system-services-in-windows-server.md
+++ b/WindowsServerDocs/security/windows-services/security-guidelines-for-disabling-system-services-in-windows-server.md
@@ -1,6 +1,6 @@
 ---
-title: Security guidelines for system services in Windows Server 2016
-description: Security guidelines for disabling services in Windows Server 2016 with Desktop Experience
+title: Security guidelines for system services in Windows Server
+description: Security guidelines for disabling services in Windows Server with Desktop Experience
 ms.topic: article
 ms.date: 11/26/2018
 ms.assetid: b886b2fd-3567-4f0a-8aa3-4ba7923d2d21


### PR DESCRIPTION
2016 can be removed from the title as this applies to all supported versions of Windows Server with Desktop experience. It also reduces the likelihood that a reader encountering the article will assume that the advice is not valid for WS 2019 and WS 2022