### PR TITLE
In my actual operation on the windows server 2012 R2 server, I found …

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/nfsadmin.md
+++ b/WindowsServerDocs/administration/windows-commands/nfsadmin.md
@@ -26,7 +26,7 @@ nfsadmin server [computername] [-u Username [-p Password]] creategroup <name>
 nfsadmin server [computername] [-u Username [-p Password]] listgroups
 nfsadmin server [computername] [-u Username [-p Password]] deletegroup <name>
 nfsadmin server [computername] [-u Username [-p Password]] renamegroup <oldname> <newname>
-nfsadmin server [computername] [-u Username [-p Password]] addmembers <hostname>[...]
+nfsadmin server [computername] [-u Username [-p Password]] addmembers <groupname>[...]
 nfsadmin server [computername] [-u Username [-p Password]] listmembers
 nfsadmin server [computername] [-u Username [-p Password]] deletemembers <hostname><groupname>[...]
 nfsadmin client [computername] [-u Username [-p Password]] {start | stop}


### PR DESCRIPTION
…that the document describes the parameters of adding users to groups incorrectly

In my actual operation on the windows server 2012 R2 server, I found that the document describes the parameters of adding users to groups incorrectly, so that the developer cannot apply this command correctly. I hope you can correct it after the local verification.
Sorry, my English is not good, the spelling may not be very smooth, thanks for the translation software