### PR TITLE
params need quotes

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/auditpol-list.md
+++ b/WindowsServerDocs/administration/windows-commands/auditpol-list.md
@@ -58,7 +58,7 @@ auditpol /list /subcategory:* /r
 To list the subcategories of the detailed Tracking and DS Access categories, type:
 
 ```
-auditpol /list /subcategory:detailed Tracking,DS Access
+auditpol /list /subcategory:"detailed Tracking","DS Access"
 ```
 
 ## Additional References


### PR DESCRIPTION
"auditpol /list /subcategory:" cannot run with spaces in params, quotes are needed. 
Adding quotes, tested OK on Win10.