### PR TITLE
Fix typo in DHCP Troubleshooting description

### DIFF
--- a/WindowsServerDocs/troubleshoot/troubleshoot-dhcp-issue.md
+++ b/WindowsServerDocs/troubleshoot/troubleshoot-dhcp-issue.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting guide for Dynamic Host Configuration Protocol (DHCP)
-description: This artilce introduces troubleshooting guide for DHCP issues.
+description: This article introduces a troubleshooting guide for DHCP issues.
 manager: dcscontentpm
 ms.date: 5/26/2020
 ms.topic: troubleshooting


### PR DESCRIPTION
Just noticed a small typo/grammar issue in the article description while browsing the docs.