### PR TITLE
Add 8.6 to supported distros for Hyper-V

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/Supported-CentOS-and-Red-Hat-Enterprise-Linux-virtual-machines-on-Hyper-V.md
+++ b/WindowsServerDocs/virtualization/hyper-v/Supported-CentOS-and-Red-Hat-Enterprise-Linux-virtual-machines-on-Hyper-V.md
@@ -61,7 +61,7 @@ In this section:
 
 ## RHEL/CentOS 8.x Series
 
-| **Feature** | **Host OS** | **8.1-8.5** |  **8.0** |
+| **Feature** | **Host OS** | **8.1-8.6** |  **8.0** |
 |-------------|----------------------------|-------------|----------|
 | LIS Availability|                        |  Built in   | Built in  |
 | [Core](Feature-Descriptions-for-Linux-and-FreeBSD-virtual-machines-on-Hyper-V.md#core)| Windows Server 2022, 2019, 2016, 2012 R2<br />Azure Stack HCI | ✔ | ✔|


### PR DESCRIPTION
RHEL 8,6 is officially supported for Hyper-V, add it to docs