### PR TITLE
Update format-trend

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/performance-history-scripting.md
+++ b/WindowsServerDocs/storage/storage-spaces/performance-history-scripting.md
@@ -370,7 +370,7 @@ Function Format-Trend {
             $Sign = "-"
         }
         # Return
-        $Sign + $(Format-Bytes [Math]::Abs($RawValue)) + "/day"
+        $Sign + $(Format-Bytes ([Math]::Abs($RawValue))) + "/day"
     }
 }
 


### PR DESCRIPTION
This function errors out since the [Math] method is not fully contained inside of a parenthesis.