### PR TITLE
Corrected syntax block

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/call.md
+++ b/WindowsServerDocs/administration/windows-commands/call.md
@@ -19,7 +19,8 @@ Calls one batch program from another without stopping the parent batch program. 
 ## Syntax
 
 ```
-call [drive:][path]<filename> [<batchparameters>] [:<label> [<arguments>]]
+call [drive:][path]<filename> [<batchparameters>]
+call :<label> [<arguments>]
 ```
 
 ### Parameters


### PR DESCRIPTION
The syntax of command **CALL** should be explained with two lines because of it is either possible to call another batch file from within a batch file or call command lines in currently processed batch file below a label in a new batch file context. It is not possible to call command lines below a label in a different a batch file as the syntax block with just the single line lets readers think. The usage help output on running `call /?` in a command prompt window explains the syntax also with two separate lines which avoids any misunderstanding on syntax for usage of command **CALL**.