### PR TITLE
Correct PowerShell Command to Start vmms Fixes #6577

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/best-practices-analyzer/The-Hyper-V-Virtual-Machine-Management-service-must-be-running.md
+++ b/WindowsServerDocs/virtualization/hyper-v/best-practices-analyzer/The-Hyper-V-Virtual-Machine-Management-service-must-be-running.md
@@ -64,13 +64,13 @@ To install the Hyper-V Management tools:
 3.  To reconfigure the service, type:
 
     ```
-    sc config vmms start=auto
+    sc.exe config vmms start=auto
     ```
 
 4.  To start the service, type:
 
     ```
-    sc start vmms
+    sc.exe start vmms
     ```
 
 If the service is already configured to start automatically and you just need to restart the service, you can do that from Hyper-V Manager, or from the sc start vmms command shown above.


### PR DESCRIPTION
The PowerShell command to configure and start the vmms service does not work. In PowerShell sc is an alias for the set-content command so just "sc start vmms" will not start the vmms service. To start the service you should use "sc.exe start vmms"