### PR TITLE
Split up Source Code Box into two

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/ad-fs-single-sign-on-settings.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/ad-fs-single-sign-on-settings.md
@@ -128,7 +128,11 @@ Set-AdfsProperties -PersistentSsoCutoffTime <DateTime>
 @RuleName = "Pass through claim - InsideCorporateNetwork"
 c:[Type == "https://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork"]
 => issue(claim = c);
+```
+
 A custom Issuance Transform rule to pass through the persistent SSO claim
+
+```
 @RuleName = "Pass Through Claim - Psso"
 c:[Type == "https://schemas.microsoft.com/2014/03/psso"]
 => issue(claim = c);


### PR DESCRIPTION
The source code box detailing how to create the custom Issuance Transform rules to allow SSO with AAD and SPO should have been two boxes imho, as there was another line of comment/explanation between the two code blocks.