### PR TITLE
Update negotiate-session-setup-tree-connect-fails.md

### DIFF
--- a/WindowsServerDocs/storage/file-server/Troubleshoot/negotiate-session-setup-tree-connect-fails.md
+++ b/WindowsServerDocs/storage/file-server/Troubleshoot/negotiate-session-setup-tree-connect-fails.md
@@ -14,7 +14,7 @@ This article describes how to troubleshoot the failures that occur during an SMB
 
 ## Negotiate fails
 
-The SMB server receives an SMB NEGOTIATE request from an SMB client. The connection times out and is reset after 60 seconds. There may be an ACK message after about 200 microseconds.
+The SMB server receives an SMB NEGOTIATE request from an SMB client. The connection times out and is reset after 60 seconds. There may be an ACK message after about 200 milliseconds.
 
 This problem is most often caused by antivirus program.
 


### PR DESCRIPTION
The default delay for delayed ACKs is 200 milliseconds, or in other words, one fifth of a second. 200 microseconds would be one *five-thousandth* of a second, which would make no sense in any real-life networking scenario.