### PR TITLE
updated gpo configuration

### DIFF
--- a/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
+++ b/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
@@ -351,6 +351,9 @@ In order to enable W32Time logging, add the following registry entries:
 
 Group Policy settings are contained in the **Global Configuration Settings** and the **Windows NTP Client Settings** GPOs.
 
+> [!NOTE]
+> If you configure a GPO for set the NTP server to your DC the value of NTPServer in Registry key will not be overwritten. The default Value Type is set to NT5DS. This means the NTP server performs synchronization according to the domain hierarchy (used by default on domain-joined computers). To view your NTP configuration run on CMD "w32tm /query /configuration"
+
 ### Global Configuration Settings
 
 These are the global Group Policy settings and default values for the Windows Time service. These settings are contained in the **Global Configuration Settings** GPO in Local Policy Editor.

--- a/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
+++ b/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
@@ -352,7 +352,7 @@ In order to enable W32Time logging, add the following registry entries:
 Group Policy settings are contained in the **Global Configuration Settings** and the **Windows NTP Client Settings** GPOs.
 
 > [!NOTE]
-> If you configure a GPO to set the NTP server to your domain controller, the policy does not overwrite the Registry value of NTPServer. The policy sets the default Value Type to NT5DS. This value means that the NTP server synchronizes according to the domain hierarchy. This is the default configuration for domain-joined computers. To view your NTP configuration, open a Command Prompt window and run w32tm /query /configuration.
+> If you configure a GPO to set the NTP server to your domain controller, the policy does not overwrite the Registry value of NTPServer. The policy sets the default Value Type to NT5DS. This value means that the NTP server synchronizes according to the domain hierarchy. This is the default configuration for domain-joined computers. To view your NTP configuration, open a Command Prompt window and run `w32tm /query /configuration`.
 
 ### Global Configuration Settings
 

--- a/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
+++ b/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
@@ -352,7 +352,7 @@ In order to enable W32Time logging, add the following registry entries:
 Group Policy settings are contained in the **Global Configuration Settings** and the **Windows NTP Client Settings** GPOs.
 
 > [!NOTE]
-> If you configure a GPO for set the NTP server to your DC the value of NTPServer in Registry key will not be overwritten. The default Value Type is set to NT5DS. This means the NTP server performs synchronization according to the domain hierarchy (used by default on domain-joined computers). To view your NTP configuration run on CMD "w32tm /query /configuration"
+> If you configure a GPO to set the NTP server to your domain controller, the policy does not overwrite the Registry value of NTPServer. The policy sets the default Value Type to NT5DS. This value means that the NTP server synchronizes according to the domain hierarchy. This is the default configuration for domain-joined computers. To view your NTP configuration, open a Command Prompt window and run w32tm /query /configuration.
 
 ### Global Configuration Settings
 

--- a/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
+++ b/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
@@ -352,7 +352,7 @@ In order to enable W32Time logging, add the following registry entries:
 Group Policy settings are contained in the **Global Configuration Settings** and the **Windows NTP Client Settings** GPOs.
 
 > [!NOTE]
-> If you configure a GPO to set the NTP server to your domain controller, the policy does not overwrite the Registry value of NTPServer. The policy sets the default Value Type to NT5DS. This value means that the NTP server synchronizes according to the domain hierarchy. This is the default configuration for domain-joined computers. To view your NTP configuration, open a Command Prompt window and run `w32tm /query /configuration`.
+> If you configure a GPO to set the NTP server to your domain controller, the policy does not overwrite the Registry value of **NTPServer**. The policy sets the default **Value Type** to **NT5DS**. This value means that the NTP server synchronizes according to the domain hierarchy. This is the default configuration for domain-joined computers. To view your NTP configuration, open a Command Prompt window and run `w32tm /query /configuration`.
 
 ### Global Configuration Settings
 


### PR DESCRIPTION
Hello all,

worked on NTP Server configuration on Customer Active Directory. After the configuration the customer has looking for the value on Registry Key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\W32Time\Parameters -> NtpServer.

According with the documentation, with the type value set to NT5DS the syncronization will be performed with DC hierarchy, so the NTPServer value will not be considerated.

Thank you