### PR TITLE
Fix Parameter-Hyphen in registry commands for the DHCP server setup

### DIFF
--- a/WindowsServerDocs/networking/technologies/dhcp/dhcp-deploy-wps.md
+++ b/WindowsServerDocs/networking/technologies/dhcp/dhcp-deploy-wps.md
@@ -425,7 +425,7 @@ After you have completed post\-installation tasks, such as creating security gro
 You can prevent this now\-unnecessary and inaccurate message from appearing in Server Manager by configuring the following registry key using this Windows PowerShell command.
 
 ```
-Set-ItemProperty –Path registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ServerManager\Roles\12 –Name ConfigurationState –Value 2
+Set-ItemProperty -Path registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ServerManager\Roles\12 -Name ConfigurationState -Value 2
 ```
 
 For more information about this command, see the following topic.
@@ -531,7 +531,7 @@ Restart-Service dhcpserver
 Add-DhcpServerInDC -DnsName DHCP1.corp.contoso.com -IPAddress 10.0.0.3
 Get-DhcpServerInDC
 
-Set-ItemProperty –Path registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ServerManager\Roles\12 –Name ConfigurationState –Value 2
+Set-ItemProperty -Path registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ServerManager\Roles\12 -Name ConfigurationState -Value 2
 
 Set-DhcpServerv4DnsSetting -ComputerName "DHCP1.corp.contoso.com" -DynamicUpdates "Always" -DeleteDnsRRonLeaseExpiry $True
 


### PR DESCRIPTION
Copy-Paste of commands did not work, because of '–' instead of '-'

'–' = U+2013 : EN DASH
'-' = U+002D : HYPHEN-MINUS
