### PR TITLE
Better wording on mode command

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/mode.md
+++ b/WindowsServerDocs/administration/windows-commands/mode.md
@@ -28,7 +28,7 @@ mode com<m>[:] [baud=<b>] [parity=<p>] [data=<d>] [stop=<s>] [to={on|off}] [xon=
 | Parameter  | Description |
 | ---------- | ----------- |
 | `com<m>[:]` | Specifies the number of the async Prncnfg.vbshronous communications port. |
-| `baud=<b>`  | Specifies the transmission rate in bits per second. The valid values include:<ul><li>**11** - 110 baud</li><li>**15** - 150 baud</li><li>**30** - 300 baud</li><li>**60** - 600 baud</li><li>**12** - 1200 baud</li><li>**24** - 2400 baud</li><li>**48** - 4800 baud</li><li>**96** - 9600 baud</li><li>**19** - 19,200 baud</li></ul> |
+| `baud=<b>`  | Specifies the transmission rate in bits per second. Mnemonic values for standard rates are:<ul><li>**11** - 110 baud</li><li>**15** - 150 baud</li><li>**30** - 300 baud</li><li>**60** - 600 baud</li><li>**12** - 1200 baud</li><li>**24** - 2400 baud</li><li>**48** - 4800 baud</li><li>**96** - 9600 baud</li><li>**19** - 19,200 baud</li></ul> |
 | `parity=<p>` | Specifies how the system uses the parity bit to check for transmission errors. The valid values include:<ul><li>**n** - none</li><li>**e** - even (default value)</li><li>**o** - odd</li><li>**m** - mark</li><li>**s** - space</li></ul>Not all devices support using the **m** or **s** parameters. |
 | `data=<d>` | Specifies the number of data bits in a character. Valid values range from **5** through **8**. The default value is **7**. Not all devices support the values **5** and **6**. |
 | `stop=<s>` | Specifies the number of stop bits that define the end of a character: **1**, **1.5**, or **2**. If the baud rate is **110**, the default value is **2**. Otherwise, the default value is **1**. Not all devices support the value **1.5**. |


### PR DESCRIPTION
Change the wording a bit to make it more clear that these values are abbrevations and do not exclude arbitrary baud rates.