### PR TITLE
Remove AD CS service restart

### DIFF
--- a/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-server-infrastructure.md
+++ b/WindowsServerDocs/remote/remote-access/vpn/always-on-vpn/deploy/vpn-deploy-server-infrastructure.md
@@ -326,12 +326,6 @@ Domain-joined VPN servers
 
 14. Close the Certification Authority snap-in.
 
-* **You can stop/start the CA service by running the following command in CMD:**
-
-```
-net stop "certsvc"
-net start "certsvc"
-```
 
 ## Create the NPS Server Authentication template
 


### PR DESCRIPTION
There is no need to restart AD CS service after creating and publishing a new Certificate Template.