### PR TITLE
Update smb-known-issues.md

### DIFF
--- a/WindowsServerDocs/storage/file-server/Troubleshoot/smb-known-issues.md
+++ b/WindowsServerDocs/storage/file-server/Troubleshoot/smb-known-issues.md
@@ -1,6 +1,6 @@
 ---
-title: SMB known issues
-description: List of the SMB known issues.
+title: SMB Common Issues
+description: Common SMB related issues with guidance on troubleshooting and resolving them.
 author: Deland-Han
 manager: dcscontentpm
 ms.topic: article
@@ -10,7 +10,7 @@ ms.date: 12/25/2019
 
 # SMB known issues
 
-The following topics describe some common troubleshooting issues that can occur when you use Server Message Block (SMB). These topics also provide possible solutions to those issues.
+The following topics describe how to truobleshoot some of the common issues related to SMB (Server Message Block). These topics also provide possible solutions to those issues.
 
 - [TCP three-way handshake failure](tcp-three-way-handshake-fails.md)
 


### PR DESCRIPTION
Title changed from "SMB known issues" to "SMB Common Issues," plus some clarifying text around the article's purpose.

The existing title makes it sound like all known SMB issues are or should be maintained here. Which is not the purpose of this article. The updates add clarity to the purpose of this article.