### PR TITLE
fix EAP server validation documentation and sync sections

### DIFF
--- a/WindowsServerDocs/networking/technologies/extensible-authentication-protocol/network-access.md
+++ b/WindowsServerDocs/networking/technologies/extensible-authentication-protocol/network-access.md
@@ -75,7 +75,7 @@ This item specifies that the client verifies that server certificates presented 
 
 ### Connect to these servers
 
-This item allows you to specify the name for Remote Authentication Dial-In User Service (RADIUS) servers that provide network authentication and authorization. Note that you must type the name **exactly** as it appears in the **Subject** field of each RADIUS server certificate, or use regular expressions to specify the server name. The complete syntax of the regular expression can be used to specify the server name, but to differentiate a regular expression with the literal string, you must use at least one "" in the string specified. For example, you can specify nps.example.com to specify the RADIUS server nps1.example.com or nps2.example.com.
+This item allows you to specify the name for Remote Authentication Dial-In User Service (RADIUS) servers that provide network authentication and authorization. Note that you must type the name **exactly** as it appears in the **Subject** field of each RADIUS server certificate, or use regular expressions to specify the server name. The complete syntax of the regular expression can be used to specify the server name, but to differentiate a regular expression with the literal string, you must use at least one `*` in the string specified. For example, you can specify `nps.*\.example\.com` to match the RADIUS servers `nps1.example.com`, `nps2.example.com` or `npsabc.example.com`.
 
 Even if no RADIUS servers are specified, the client will verify that the RADIUS server certificate was issued by a trusted root CA.
 
@@ -228,7 +228,7 @@ Default = enabled
 
 ### Connect to these servers
 
-This item allows you to specify the name for RADIUS servers that provide network authentication and authorization. Note that you must type the name **exactly** as it appears in the Subject field of each RADIUS server certificate, or use regular expressions to specify the server name. The complete syntax of the regular expression can be used to specify the server name, but to differentiate a regular expression with the literal string, you must use at least one "" in the string that is specified. For example, you can specify nps.example.com to specify the RADIUS server nps1.example.com or nps2.example.com.
+This item allows you to specify the name for Remote Authentication Dial-In User Service (RADIUS) servers that provide network authentication and authorization. Note that you must type the name **exactly** as it appears in the **Subject** field of each RADIUS server certificate, or use regular expressions to specify the server name. The complete syntax of the regular expression can be used to specify the server name, but to differentiate a regular expression with the literal string, you must use at least one `*` in the string specified. For example, you can specify `nps.*\.example\.com` to match the RADIUS servers `nps1.example.com`, `nps2.example.com` or `npsabc.example.com`.
 
 Even if no RADIUS servers are specified, the client will verify that the RADIUS server certificate was issued by a trusted root CA.
 
@@ -366,7 +366,9 @@ Default = not enabled
 
 ### Connect to these servers
 
-This item enables you to specify the name for RADIUS servers that provide network authentication and authorization. Note that you must type the name **exactly** as it appears in the Subject field of each RADIUS server certificate, or use regular expressions to specify the server name. The complete syntax of the regular expression can be used to specify the server name. But to differentiate a regular expression with the literal string, you must use at least one * in the string specified. For example, you can specify nps*.example.com to specify the RADIUS server nps1.example.com or nps2.example.com. Even if no RADIUS servers are specified, the client will verify that the RADIUS server certificate was issued by a trusted root CA.
+This item allows you to specify the name for Remote Authentication Dial-In User Service (RADIUS) servers that provide network authentication and authorization. Note that you must type the name **exactly** as it appears in the **Subject** field of each RADIUS server certificate, or use regular expressions to specify the server name. The complete syntax of the regular expression can be used to specify the server name, but to differentiate a regular expression with the literal string, you must use at least one `*` in the string specified. For example, you can specify `nps.*\.example\.com` to match the RADIUS servers `nps1.example.com`, `nps2.example.com` or `npsabc.example.com`.
+
+Even if no RADIUS servers are specified, the client will verify that the RADIUS server certificate was issued by a trusted root CA.
 
 Default = none
 


### PR DESCRIPTION
This fixes and syncs up the sections for `Connect to these servers` in EAP configuration.

The first two sections didn't make any sense at all without a `*` being mentioned there.

Unfortunately, even with the documentation derived from the third section, the original content is still not plausible.
As I don't know the internals, I don't know if a `*` is the only possible wildcard, as it's technically not a wildcard in regex.

The configuration in the GPO provides the following example for server names: `srv1;srv2;.*\.srv3\.com`

`nps*.example.com` does not make much sense in this context, as this regex would match e.g. `npssssaexample.com` but not `nps1.example.com`.
Dots are single character wildcards in regex they must be escaped when a literal dot is intended to avoid unexpected behavior, asterisks allow zero or more of the preceding character.

To match `nps1.example.com` and `nps2.example.com` one option would be `nps.\.example\.com`, but this wouldn't contain an asterisk.
Using an asterisk as the only possible regex "flag" doesn't make much sense, that doesn't mean it's not implemented that way though.