### PR TITLE
Update prnqctl.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/prnqctl.md
+++ b/WindowsServerDocs/administration/windows-commands/prnqctl.md
@@ -13,7 +13,7 @@ ms.date: 07/11/2018
 
 >Applies to: Windows Server 2022, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012
 
-Prints a test page, pauses or resumes a printer, and clears a printer queue. This command is a Visual Basic script located in the `%WINdir%\System32\printing_Admin_Scripts\<language>` directory. To use this command at a command prompt, type **cscript** followed by the full path to the prnqctl file, or change directories to the appropriate folder. For example: `cscript %WINdir%\System32\printing_Admin_Scripts\en-US\prnqctl`.
+Prints a test page, pauses or resumes a printer, and clears a printer queue. This command is a Visual Basic script located in the `%WINdir%\System32\printing_Admin_Scripts\<language>` directory. To use this command at a command prompt, type **cscript** followed by the full path to the prnqctl file, or change directories to the appropriate folder. For example: `cscript %WINdir%\System32\printing_Admin_Scripts\en-US\prnqctl.vbs`.
 
 ## Syntax
 


### PR DESCRIPTION
Changed
`cscript %WINdir%\System32\printing_Admin_Scripts\en-US\prnqctl`
to
`cscript %WINdir%\System32\printing_Admin_Scripts\en-US\prnqctl.vbs`

The file extension is needed on Windows 11 Enterprise. I assume it's the same for windows server, but I don't have a machine to validate that on. Feel free to close this PR if you know otherwise