### PR TITLE
/lp Edit

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/msiexec.md
+++ b/WindowsServerDocs/administration/windows-commands/msiexec.md
@@ -134,9 +134,7 @@ msiexec.exe [/i][/x] <path_to_package> [/L{i|w|e|a|r|u|c|m|o|p|v|x+|!|*}] <path_
 | /lm | Turns on logging and includes out-of-memory or fatal exit information in the output log file. |
 | /lo | Turns on logging and includes out-of-disk-space messages in the output log file. |
 | /lp | Turns on logging and includes terminal properties in the output log file. |
-| /lp | Turns on logging and includes terminal properties in the output log file. |
 | /lv | Turns on logging and includes verbose output in the output log file. |
-| /lp | Turns on logging and includes terminal properties in the output log file. |
 | /lx | Turns on logging and includes extra debugging information in the output log file. |
 | /l+ | Turns on logging and appends the information to an existing log file. |
 | /l! | Turns on logging and flushes each line to the log file. |


### PR DESCRIPTION
Unless my eyes deceive me, | /lp | Turns on logging and includes terminal properties in the output log file. | was written three different times.