### PR TITLE
Update delegate-ad-fs-pshell-access.md

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/operations/delegate-ad-fs-pshell-access.md
+++ b/WindowsServerDocs/identity/ad-fs/operations/delegate-ad-fs-pshell-access.md
@@ -38,7 +38,7 @@ Add-KdsRootKey -EffectiveTime ((get-date).addhours(-10)) 
 $adfsServer = Get-ADComputer server01.contoso.com
 
 # Run targeted at domain controller
-$serviceaccount = New-ADServiceAccount gMSAcontoso -DNSHostName <FQDN of the domain containing the KDS key> - PrincipalsAllowedToRetrieveManagedPassword $adfsServer –passthru
+$serviceaccount = New-ADServiceAccount gMSAcontoso -DNSHostName <FQDN of the domain containing the KDS key> -PrincipalsAllowedToRetrieveManagedPassword $adfsServer –passthru
 
 # Run this on every node
 Add-ADComputerServiceAccount -Identity server01.contoso.com -ServiceAccount $ServiceAccount


### PR DESCRIPTION
removing extra space before PrincipalsAllowedToRetrieveManagedPassword in "$serviceaccount = New-ADServiceAccount gMSAcontoso -DNSHostName <FQDN of the domain containing the KDS key> - PrincipalsAllowedToRetrieveManagedPassword $adfsServer –passthru"