### PR TITLE
Replace the EN DASH with HYPHEN-MINUS

### DIFF
--- a/WindowsServerDocs/storage/storage-spaces/deploy-standalone-storage-spaces.md
+++ b/WindowsServerDocs/storage/storage-spaces/deploy-standalone-storage-spaces.md
@@ -43,7 +43,7 @@ To use Storage Spaces on a stand-alone Windows Server 2012−based server, make 
 |Disk bus types|- Serial Attached SCSI (SAS)<br>- Serial Advanced Technology Attachment (SATA)<br>- iSCSI and Fibre Channel Controllers. |You can also use USB drives. However, it's not optimal to use USB drives in a server environment.<br>Storage Spaces is supported on iSCSI and Fibre Channel (FC) controllers as long as the virtual disks created on top of them are non-resilient (Simple with any number of columns).<br>|
 |Disk configuration|- Physical disks must be at least 4 GB<br>- Disks must be blank and not formatted. Do not create volumes.||
 |HBA considerations|- Simple host bus adapters (HBAs) that do not support RAID functionality are recommended<br>- If RAID-capable, HBAs must be in non-RAID mode with all RAID functionality disabled<br>- Adapters must not abstract the physical disks, cache data, or obscure any attached devices. This includes enclosure services that are provided by attached just-a-bunch-of-disks (JBOD) devices. |Storage Spaces is compatible only with HBAs where you can completely disable all RAID functionality.|
-|JBOD enclosures|- JBOD enclosures are optional<br>- Recommended to use Storage Spaces certified enclosures listed on the Windows Server Catalog<br>- If you're using a JBOD enclosure, verify with your storage vendor that the enclosure supports Storage Spaces to ensure full functionality<br>- To determine whether the JBOD enclosure supports enclosure and slot identification, run the following Windows PowerShell cmdlet:<br><br> Get-PhysicalDisk \| ? {$_.BusType –eq "SAS"} \| fc <br> | If the **EnclosureNumber** and **SlotNumber** fields contain values, then the enclosure supports these features.|
+|JBOD enclosures|- JBOD enclosures are optional<br>- Recommended to use Storage Spaces certified enclosures listed on the Windows Server Catalog<br>- If you're using a JBOD enclosure, verify with your storage vendor that the enclosure supports Storage Spaces to ensure full functionality<br>- To determine whether the JBOD enclosure supports enclosure and slot identification, run the following Windows PowerShell cmdlet:<br><br> Get-PhysicalDisk \| ? {$_.BusType -eq "SAS"} \| fc <br> | If the **EnclosureNumber** and **SlotNumber** fields contain values, then the enclosure supports these features.|
 
 To plan for the number of physical disks and the desired resiliency type for a stand-alone server deployment, use the following guidelines.
 
@@ -100,20 +100,20 @@ Get-StoragePool -IsPrimordial $true | Get-PhysicalDisk -CanPool $True
 The following example creates a new storage pool named *StoragePool1* that uses all available disks.
 
 ```PowerShell
-New-StoragePool –FriendlyName StoragePool1 –StorageSubsystemFriendlyName "Windows Storage*" –PhysicalDisks (Get-PhysicalDisk –CanPool $True)
+New-StoragePool -FriendlyName StoragePool1 -StorageSubsystemFriendlyName "Windows Storage*" -PhysicalDisks (Get-PhysicalDisk -CanPool $True)
 ```
 
 The following example creates a new storage pool, *StoragePool1*, that uses four of the available disks.
 
 ```PowerShell
-New-StoragePool –FriendlyName StoragePool1 –StorageSubsystemFriendlyName "Windows Storage*" –PhysicalDisks (Get-PhysicalDisk PhysicalDisk1, PhysicalDisk2, PhysicalDisk3, PhysicalDisk4)
+New-StoragePool -FriendlyName StoragePool1 -StorageSubsystemFriendlyName "Windows Storage*" -PhysicalDisks (Get-PhysicalDisk PhysicalDisk1, PhysicalDisk2, PhysicalDisk3, PhysicalDisk4)
 ```
 
 The following example sequence of cmdlets shows how to add an available physical disk *PhysicalDisk5* as a hot spare to the storage pool *StoragePool1*.
 
 ```PowerShell
-$PDToAdd = Get-PhysicalDisk –FriendlyName PhysicalDisk5
-Add-PhysicalDisk –StoragePoolFriendlyName StoragePool1 –PhysicalDisks $PDToAdd –Usage HotSpare
+$PDToAdd = Get-PhysicalDisk -FriendlyName PhysicalDisk5
+Add-PhysicalDisk -StoragePoolFriendlyName StoragePool1 -PhysicalDisks $PDToAdd -Usage HotSpare
 ```
 
 ## Step 2: Create a virtual disk
@@ -183,19 +183,19 @@ The following Windows PowerShell cmdlet or cmdlets perform the same function as 
 The following example creates a 50 GB virtual disk named *VirtualDisk1* on a storage pool named *StoragePool1*.
 
 ```PowerShell
-New-VirtualDisk –StoragePoolFriendlyName StoragePool1 –FriendlyName VirtualDisk1 –Size (50GB)
+New-VirtualDisk -StoragePoolFriendlyName StoragePool1 -FriendlyName VirtualDisk1 -Size (50GB)
 ```
 
 The following example creates a mirrored virtual disk named *VirtualDisk1* on a storage pool named *StoragePool1*. The disk uses the storage pool's  maximum storage capacity.
 
 ```PowerShell
-New-VirtualDisk –StoragePoolFriendlyName StoragePool1 –FriendlyName VirtualDisk1 –ResiliencySettingName Mirror –UseMaximumSize
+New-VirtualDisk -StoragePoolFriendlyName StoragePool1 -FriendlyName VirtualDisk1 -ResiliencySettingName Mirror -UseMaximumSize
 ```
 
 The following example creates a 50 GB virtual disk named *VirtualDisk1* on a storage pool that is named *StoragePool1*. The disk uses the thin provisioning type.
 
 ```PowerShell
-New-VirtualDisk –StoragePoolFriendlyName StoragePool1 –FriendlyName VirtualDisk1 –Size (50GB) –ProvisioningType Thin
+New-VirtualDisk -StoragePoolFriendlyName StoragePool1 -FriendlyName VirtualDisk1 -Size (50GB) -ProvisioningType Thin
 ```
 
 The following example creates a virtual disk named *VirtualDisk1* on a storage pool named *StoragePool1*. The virtual disk uses three-way mirroring and is a fixed size of 20 GB.
@@ -252,7 +252,7 @@ The following Windows PowerShell cmdlet performs the same function as the previo
 The following example initializes the disks for virtual disk *VirtualDisk1*, creates a partition with an assigned drive letter, and then formats the volume with the default NTFS file system.
 
 ```PowerShell
-Get-VirtualDisk –FriendlyName VirtualDisk1 | Get-Disk | Initialize-Disk –Passthru | New-Partition –AssignDriveLetter –UseMaximumSize | Format-Volume
+Get-VirtualDisk -FriendlyName VirtualDisk1 | Get-Disk | Initialize-Disk -Passthru | New-Partition -AssignDriveLetter -UseMaximumSize | Format-Volume
 ```
 
 ## Additional information


### PR DESCRIPTION
Some of "-" (U+002D HYPHEN-MINUS) are written in "–" (U+2013 EN DASH). It will cause the terminal can not excuse the command.