### PR TITLE
Replaced device.localcredential instances with devicelocalcredential

### DIFF
--- a/WindowsServerDocs/identity/laps/laps-scenarios-azure-active-directory.md
+++ b/WindowsServerDocs/identity/laps/laps-scenarios-azure-active-directory.md
@@ -88,22 +88,22 @@ You might need to configure the repository as Trusted for the command to succeed
 
 The next step is to create an Azure Active Directory application that's configured with the necessary permissions. To review the basic instructions for creating an Azure Active Directory application, see [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
 
-The app needs to be configured with two permissions: `Device.Read.All` and either `Device.LocalCredentials.Read` or `Device.LocalCredentials.ReadAll`.
+The app needs to be configured with two permissions: `Device.Read.All` and either `DeviceLocalCredentials.Read` or `DeviceLocalCredentials.ReadAll`.
 
 > [!IMPORTANT]
 >
-> - Use `Device.LocalCredentials.Read` to grant permissions for reading non-sensitive metadata about persisted Windows LAPS passwords. Examples include the time the password was backed up to Azure and the expected expiration time of a password. This permissions level is appropriate for reporting and compliance applications.
-> - Use `Device.LocalCredentials.ReadAll` to grant full permissions for reading everything about persisted Windows LAPS passwords, including the clear-text passwords themselves. This permissions level is sensitive and should be used carefully.
+> - Use `DeviceLocalCredentials.Read` to grant permissions for reading non-sensitive metadata about persisted Windows LAPS passwords. Examples include the time the password was backed up to Azure and the expected expiration time of a password. This permissions level is appropriate for reporting and compliance applications.
+> - Use `DeviceLocalCredentials.ReadAll` to grant full permissions for reading everything about persisted Windows LAPS passwords, including the clear-text passwords themselves. This permissions level is sensitive and should be used carefully.
 
-#### Manual consent to Device.LocalCredentials.\* permissions
+#### Manual consent to DeviceLocalCredentials.\* permissions
 
-Currently, a manual step is required to consent to either `Device.LocalCredentials.Read` or the `Device.LocalCredentials.ReadAll` permissions.
+Currently, a manual step is required to consent to either `DeviceLocalCredentials.Read` or the `DeviceLocalCredentials.ReadAll` permissions.
 
-After you decide which `Device.LocalCredentials` permission to configure, manually construct a URL for your scenario. In the following examples, `DeviceLocalCredential.Read.All` is the permission. Replace the permission with `DeviceLocalCredential.Read.Basic` if necessary.
+After you decide which `DeviceLocalCredentials` permission to configure, manually construct a URL for your scenario. In the following examples, `DeviceLocalCredential.Read.All` is the permission. Replace the permission with `DeviceLocalCredential.Read.Basic` if necessary.
 
 For multi-tenant apps:
 
-`https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=<YourClientAppID>=response_type=code&scope=https://graph.microsoft.com/DeviceLocalCredential.Read.All`
+`https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=<YourClientAppID>&response_type=code&scope=https://graph.microsoft.com/DeviceLocalCredential.Read.All`
 
 For single-tenant apps:
 


### PR DESCRIPTION
Based on feedback from Muchen Ji (MMD team) replaced device.localcredential instances with devicelocalcredential Also fixed a typo on the manual consent URL for multi-tenant: <YourClientAppID>= should be <YourClientAppID>& (same as single tenant ID essentially)