### PR TITLE
Update ksetup-setenctypeattr.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/ksetup-setenctypeattr.md
+++ b/WindowsServerDocs/administration/windows-commands/ksetup-setenctypeattr.md
@@ -46,10 +46,10 @@ To set the domain to corp.contoso.com, type:
 ksetup /domain corp.contoso.com
 ```
 
-To set the encryption type attribute to AES-256-CTS-HMAC-SHA1-96 for the domain corp.contoso.com, type:
+To set the encryption type attribute to AES256-CTS-HMAC-SHA1-96 for the domain corp.contoso.com, type:
 
 ```
-ksetup /setenctypeattr corp.contoso.com AES-256-CTS-HMAC-SHA1-96
+ksetup /setenctypeattr corp.contoso.com AES256-CTS-HMAC-SHA1-96
 ```
 
 To verify that the encryption type attribute was set as intended for the domain, type:


### PR DESCRIPTION
The "-" delimiter in AES-256-CTS-HMAC-SHA1-96 should be removed in the command line example so that it and the intro text above reads 

ksetup /setenctypeattr corp.contoso.com AES256-CTS-HMAC-SHA1-96

Text change approved by Windows Authentication Product Group via shared screen on March 31, 2023. 