### PR TITLE
Update ksetup-addenctypeattr.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/ksetup-addenctypeattr.md
+++ b/WindowsServerDocs/administration/windows-commands/ksetup-addenctypeattr.md
@@ -44,16 +44,16 @@ To set the domain to corp.contoso.com, type:
 ksetup /domain corp.contoso.com
 ```
 
-To add the encryption type *AES-256-CTS-HMAC-SHA1-96* to the list of possible types for the domain *corp.contoso.com*, type:
+To add the encryption type *AES256-CTS-HMAC-SHA1-96* to the list of possible types for the domain *corp.contoso.com*, type:
 
 ```
-ksetup /addenctypeattr corp.contoso.com AES-256-CTS-HMAC-SHA1-96
+ksetup /addenctypeattr corp.contoso.com AES256-CTS-HMAC-SHA1-96
 ```
 
-To set the encryption type attribute to *AES-256-CTS-HMAC-SHA1-96* for the domain *corp.contoso.com*, type:
+To set the encryption type attribute to *AES256-CTS-HMAC-SHA1-96* for the domain *corp.contoso.com*, type:
 
 ```
-ksetup /setenctypeattr corp.contoso.com AES-256-CTS-HMAC-SHA1-96
+ksetup /setenctypeattr corp.contoso.com AES256-CTS-HMAC-SHA1-96
 ```
 
 To verify that the encryption type attribute was set as intended for the domain, type:


### PR DESCRIPTION
Per feedback from Windows Authentication dev, there should NOT be a "-" delimiter between AES and 256 in the AES256-CTS-HMAC-SHA1-96