### PR TITLE
Updating Windows client OS supported OS

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/rds-supported-config.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/rds-supported-config.md
@@ -98,9 +98,8 @@ Remote Desktop Services supports Physical GPUs presented with Discrete Device As
 
 Windows Server 2016 or later RD Virtualization Host servers support the following guest OSes:
 
+- Windows 11 Enterprise
 - Windows 10 Enterprise
-- Windows 8.1 Enterprise
-- Windows 7 SP1 Enterprise
 
 > [!NOTE]
 > - Remote Desktop Services doesn't support heterogeneous session collections. The OSes of all VMs in a collection must be the same version.


### PR DESCRIPTION
Adding Windows 11 VDI OS support and removing unsupported client OSes (windows 7 and 8.1 reached end of life).