### PR TITLE
Update Audit-Policy-Recommendations.md

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/plan/security-best-practices/Audit-Policy-Recommendations.md
+++ b/WindowsServerDocs/identity/ad-ds/plan/security-best-practices/Audit-Policy-Recommendations.md
@@ -89,7 +89,7 @@ These tables contain the Windows default setting, the baseline recommendations, 
 | Audit Policy Category or Subcategory | Windows Default<p>`Success \ | Failure` | Baseline Recommendation<p>`Success \ | Failure` | Stronger Recommendation<p>`Success \ | Failure` |
 | --- | --- | --- | --- |
 | **Logon and Logoff** |  |  |  |
-| Audit Account Lockout | `Yes  \|  No` |  | `Yes  \|  No` |
+| Audit Account Lockout | `No  \|  Yes` |  | `No  \|  Yes` |
 | Audit User/Device Claims |  |  |  |
 | Audit IPsec Extended Mode |  |  |  |
 | Audit IPsec Main Mode |  |  | `IF  \|  IF` |


### PR DESCRIPTION
According to this article - https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/audit-account-lockout

This subcategory doesn’t have Success events, so there is no recommendation to enable Success auditing for this subcategory.

So this recommendation:  Audit Account Lockout 	success - Yes  failure - No is a mistake.