### PR TITLE
Update cluster-to-cluster-storage-replication.md

### DIFF
--- a/WindowsServerDocs/storage/storage-replica/cluster-to-cluster-storage-replication.md
+++ b/WindowsServerDocs/storage/storage-replica/cluster-to-cluster-storage-replication.md
@@ -73,7 +73,7 @@ Many of these requirements can be determined by using the `Test-SRTopology` cmdl
 
         1.  Run **ServerManager.exe** and create a server group, adding all server nodes.
 
-        2.  Install the **File Server** and **Storage Replica** roles and features on each of the nodes and restart them.
+        2.  Install the **File Server** Role and **Storage Replica**, and **Failover Clustering** features on each of the nodes and restart them.
 
     -   **Windows PowerShell method**
 


### PR DESCRIPTION
Under Step 1.7 the instructions say to install the File Server and storage replica role and feature, but it's not clear if those are both roles or where in each list they are

I defined that File Server was a Role and Storage Replica is a Feature

I also added the missing Failover Clustering Feature that is shown in the PowerShell method of deploying that was not called out in the Graphical instructions