### PR TITLE
Update laps-technical-reference.md

### DIFF
--- a/WindowsServerDocs/identity/laps/laps-technical-reference.md
+++ b/WindowsServerDocs/identity/laps/laps-technical-reference.md
@@ -16,7 +16,7 @@ Use detailed information about schema extensions and extended rights to help you
 
 ## Schema extensions
 
-Windows LAPS offers specific schema elements for Windows Server Active Directory. To use any of the following Windows LAPS Windows Server Active Directory-based features, you must add these new schema elements to the forest by running the `Update-LapsADSchema PowerShell` cmdlet.
+Windows LAPS offers specific schema elements for Windows Server Active Directory. To use any of the following Windows LAPS Windows Server Active Directory-based features, you must add these new schema elements to the forest by running the `Update-LapsADSchema` PowerShell cmdlet.
 
 ## Schema attributes
 


### PR DESCRIPTION
Fixed cmdlet to not include the word 'PowerShell'.
The previous command was wrong:

```powershell
PS C:\> Update-LapsADSchema PowerShell
Update-LapsADSchema : A positional parameter cannot be found that accepts argument 'PowerShell'.
At line:1 char:1
+ Update-LapsADSchema PowerShell
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Update-LapsADSchema], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.Windows.LAPS.UpdateLapsADSchema
```

With the fixed command it works:
```powershell
PS C:\> Update-LapsADSchema

The 'ms-LAPS-Password' schema attribute needs to be added to the AD schema.
Do you want to proceed?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
```