### PR TITLE
Update perform-in-place-upgrade.md

### DIFF
--- a/WindowsServerDocs/get-started/perform-in-place-upgrade.md
+++ b/WindowsServerDocs/get-started/perform-in-place-upgrade.md
@@ -17,6 +17,7 @@ version of Windows Server by using an in-place upgrade.
 
 > [!IMPORTANT]
 > This article covers the in-place Windows Server upgrade process for non-Azure servers and virtual machines (VMs) only. To do an in-place upgrade of Windows Server running in an Azure virtual machine (VM), see [In-place upgrade for VMs running Windows Server in Azure](/azure/virtual-machines/windows-in-place-upgrade).
+> If Azure Entra/AD Connect is set up on the server, do not do an in-place Server OS upgrade.
 
 ## Prerequisites
 

--- a/WindowsServerDocs/get-started/perform-in-place-upgrade.md
+++ b/WindowsServerDocs/get-started/perform-in-place-upgrade.md
@@ -16,8 +16,9 @@ your settings, server roles, and data intact. This article teaches you how to mo
 version of Windows Server by using an in-place upgrade.
 
 > [!IMPORTANT]
-> This article covers the in-place Windows Server upgrade process for non-Azure servers and virtual machines (VMs) only. To do an in-place upgrade of Windows Server running in an Azure virtual machine (VM), see [In-place upgrade for VMs running Windows Server in Azure](/azure/virtual-machines/windows-in-place-upgrade).
-> If Azure Entra/AD Connect is set up on the server, do not do an in-place Server OS upgrade.
+> This article covers the in-place Windows Server upgrade process for non-Azure servers and virtual machines (VMs) only. To do an in-place upgrade of Windows Server running in an Azure VM       , see [In-place upgrade for VMs running Windows Server in Azure](/azure/virtual-machines/windows-in-place-upgrade).
+>
+> For users using Microsoft Entra Connect who're looking to upgrade, see [Microsoft Entra Connect: Upgrade from a previous version to the latest](/entra/identity/hybrid/connect/how-to-upgrade-previous-version).
 
 ## Prerequisites
 


### PR DESCRIPTION
I was looking into an in-place server OS upgrade as well as an Azure Entra/AD Connect upgrade for a client and noticed, to my knowledge, the Perform an in-place upgrade of Windows Server doc or its link to Windows Server 2022 and Microsoft server applications compatibility doc does not state that, 

"If you need to upgrade the operating system of your Microsoft Entra Connect server, do not use an in-place upgrade of the OS (Operating System). Instead, prepare a new server with the desired operating system and perform a swing migration." 

I placed the note where I thought it should be and look forward to hearing back!

https://learn.microsoft.com/en-us/azure/active-directory/hybrid/connect/how-to-upgrade-previous-version#upgrading-the-server-operating-system

https://learn.microsoft.com/en-us/windows-server/get-started/perform-in-place-upgrade

https://learn.microsoft.com/en-us/windows-server/get-started/application-compatibility-windows-server-2022