### PR TITLE
remove  - http\://wustat.windows.com

### DIFF
--- a/WindowsServerDocs/administration/windows-server-update-services/deploy/2-configure-wsus.md
+++ b/WindowsServerDocs/administration/windows-server-update-services/deploy/2-configure-wsus.md
@@ -74,8 +74,6 @@ Your first WSUS server must have outbound access to ports 80 and 443 on the foll
 
 - http\://\*.download.windowsupdate.com
 
-- http\://wustat.windows.com
-
 - http\://ntservicepack.microsoft.com
 
 - http\://go.microsoft.com


### PR DESCRIPTION
wustat.windows.com may not be in use at this time due to name resolution failure in the DNS.