### PR TITLE
close unused 3389 ports

### DIFF
--- a/WindowsServerDocs/remote/remote-desktop-services/clients/change-listening-port.md
+++ b/WindowsServerDocs/remote/remote-desktop-services/clients/change-listening-port.md
@@ -52,4 +52,10 @@ Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\W
 
 New-NetFirewallRule -DisplayName 'RDPPORTLatest-TCP-In' -Profile 'Public' -Direction Inbound -Action Allow -Protocol TCP -LocalPort $portvalue 
 New-NetFirewallRule -DisplayName 'RDPPORTLatest-UDP-In' -Profile 'Public' -Direction Inbound -Action Allow -Protocol UDP -LocalPort $portvalue 
+
+# Disable the (read-only) built in firewall entries:
+Disable-NetFirewallRule -DisplayName "Remote Desktop - User Mode (TCP-In)"
+Disable-NetFirewallRule -DisplayName "Remote Desktop - User Mode (UDP-In)"
+
+
 ```


### PR DESCRIPTION
In the script on: [Change the listening port in Remote Desktop](https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/change-listening-port) new firewall ports are opened for RDP for both TCP and UDP. 

However these leave the default 3389 port open in the firewall. This is a non-privileged port number (ie: over 1024) which could potentially be used by users of a system to host a rogue application as a pseudo-RDP service and perhaps even harvest incoming data. 

Because the predefined rules cannot be modified, whilst its necessary to create two new firewall rules, it would be prudent to add these two lines to the code to close the predefined rules:

    Disable-NetFirewallRule -DisplayName "Remote Desktop - User Mode (TCP-In)"
    Disable-NetFirewallRule -DisplayName "Remote Desktop - User Mode (UDP-In)"

 
