### PR TITLE
"Everyone" special identities doesn't have SeTcbPrivilege by default

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/manage/understand-special-identities-groups.md
+++ b/WindowsServerDocs/identity/ad-ds/manage/understand-special-identities-groups.md
@@ -213,7 +213,7 @@ On computers running Windows 2000 and earlier, the Everyone group included the 
 |Well-known SID/RID|S-1-1-0 |
 |Object class|Foreign Security Principal|
 |Default location in Active Directory |CN=WellKnown Security Principals, CN=Configuration, DC=\<forestRootDomain\>|
-|Default user rights| [Access this computer from the network](/windows/device-security/security-policy-settings/access-this-computer-from-the-network): SeNetworkLogonRight<p> [Act as part of the operating system](/windows/device-security/security-policy-settings/act-as-part-of-the-operating-system): SeTcbPrivilege<p> [Bypass traverse checking](/windows/device-security/security-policy-settings/bypass-traverse-checking): SeChangeNotifyPrivilege|
+|Default user rights| [Access this computer from the network](/windows/device-security/security-policy-settings/access-this-computer-from-the-network): SeNetworkLogonRight<p> [Bypass traverse checking](/windows/device-security/security-policy-settings/bypass-traverse-checking): SeChangeNotifyPrivilege|
 
 ### Fresh Public Key identity
 


### PR DESCRIPTION
The Everyone special identity doesn't have the SeTcbPrivilege by default. Here's the proof on a Windows 11 machine:
![image](https://github.com/MicrosoftDocs/windowsserverdocs/assets/550823/c5a70163-229a-484a-a1c3-1b62e542b39f)

And if it would, it would be a serious security issue as reported by @EricaZelic on Twitter: https://twitter.com/EricaZelic/status/1722097286015054181
