### PR TITLE
Fix missing RIDs in special identities SIDs

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/manage/understand-special-identities-groups.md
+++ b/WindowsServerDocs/identity/ad-ds/manage/understand-special-identities-groups.md
@@ -197,10 +197,13 @@ This group includes all domain controllers in an Active Directory forest. Domain
 
 |Attribute|Value|
 | --- | --- |
-|Well-known SID/RID|S-1-5-21-\<RootDomain>|
+|Well-known SID/RID|S-1-5-21-\<RootDomain>-498|
 |Object class|Foreign Security Principal|
 |Default location in Active Directory |CN=WellKnown Security Principals, CN=Configuration, DC=\<forestRootDomain\>|
 |Default user rights|None|
+
+> [!NOTE]
+> The `<RootDomain>` identifier in the SID represents the three sub-authority values associated with the root domain.
 
 ### Everyone
 
@@ -373,12 +376,14 @@ This group includes all RODCs in the forest with read-only rights to the Active 
 
 |Attribute|Value|
 | --- | --- |
-|Well-known SID/RID|S-1-5-21-\<domain>|
+|Well-known SID/RID|S-1-5-21-\<domain>-521|
 |Object class|Foreign Security Principal|
 |Default location in Active Directory |CN=WellKnown Security Principals, CN=Configuration, DC=\<forestRootDomain\>|
 |Default user rights|None|
 
 > [!NOTE]
+> The `<domain>` identifier in the SID represents the three sub-authority values associated with the domain.
+> 
 > The [Denied RODC Password Replication group](understand-security-groups.md#denied-rodc-password-replication) is created automatically when an RODC account is created in the forest. Passwords can't be replicated in the Denied RODC Password Replication group.
 
 ### Remote Interactive Logon


### PR DESCRIPTION
In the SIDs that reference root domain/domain subauthorities, the RID was missing.

The RIDs were taken from https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/81d92bba-d22b-4a8c-908a-554ab29148ab