### PR TITLE
Update echo.md

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/echo.md
+++ b/WindowsServerDocs/administration/windows-commands/echo.md
@@ -43,6 +43,8 @@ echo [on | off]
 
 - To display a pipe (`|`), ampersand (`&`) or redirection character (`<` or `>`) when you're using **echo**, use a caret (`^`) immediately before that character. For example, `^|`, `^&`, `^>`, or `^<`. To display a caret, type two carets in succession (`^^`).
 
+- When inside a block terminated by parentheses (`()`), both opening and closing parentheses must also be escaped using the caret (`^`) immediately before each. For example, `This is ^(now^) correct` will correctly display `This is (now) correct`.
+
 ### Examples
 
 To display the current **echo** setting, type:
@@ -88,7 +90,7 @@ The following batch file searches the current directory for files with the .txt 
 if not exist *.txt (
 echo This directory contains no text files.
 ) else (
-   echo This directory contains the following text files:
+   echo This directory contains the following text file^(s^):
    echo.
    dir /b *.txt
    )
@@ -103,7 +105,8 @@ This directory contains no text files.
 If .txt files are found when the batch file is run the following output displays (for this example, assume the files File1.txt, File2.txt, and File3.txt exist):
 
 ```
-This directory contains the following text files:
+This directory contains the following text file(s):
+
 File1.txt
 File2.txt
 File3.txt

--- a/WindowsServerDocs/administration/windows-commands/echo.md
+++ b/WindowsServerDocs/administration/windows-commands/echo.md
@@ -43,7 +43,7 @@ echo [on | off]
 
 - To display a pipe (`|`), ampersand (`&`) or redirection character (`<` or `>`) when you're using **echo**, use a caret (`^`) immediately before that character. For example, `^|`, `^&`, `^>`, or `^<`. To display a caret, type two carets in succession (`^^`).
 
-- When inside a block terminated by parentheses (`()`), both opening and closing parentheses must also be escaped using the caret (`^`) immediately before each. For example, `This is ^(now^) correct` will correctly display `This is (now) correct`.
+- When inside a block terminated by parentheses (`()`), both opening and closing parentheses must also be escaped using the caret (`^`) immediately before each one. For example, `This is ^(now^) correct` will correctly display `This is (now) correct`.
 
 ### Examples
 


### PR DESCRIPTION
- Added reference to an edge case where using parentheses in an echo statement in a block denoted by parentheses causes the block to incorrectly assume those parentheses are syntax, causing the statement to fail without escaping the parentheses.

- Updated an example to illustrate this in action.

- Updated an example to show the previously missing empty line in the output.