### PR TITLE
Correct `platformss` to `platforms`

### DIFF
--- a/WindowsServerDocs/identity/laps/laps-overview.md
+++ b/WindowsServerDocs/identity/laps/laps-overview.md
@@ -11,7 +11,7 @@ ms.topic: overview
 
 Windows Local Administrator Password Solution (Windows LAPS) is a Windows feature that automatically manages and backs up the password of a local administrator account on your Microsoft Entra joined or Windows Server Active Directory-joined devices. You also can use Windows LAPS to automatically manage and back up the Directory Services Restore Mode (DSRM) account password on your Windows Server Active Directory domain controllers. An authorized administrator can retrieve the DSRM password and use it.
 
-## Windows LAPS supported platformss
+## Windows LAPS supported platforms
 
 Windows LAPS is now available on the following OS platforms with the specified update or later installed:
 


### PR DESCRIPTION
Given that Parseltongue is not an officially-supported localisation for Microsoft Docs I will assume that the inclusion of the word `platformss` is therefore a typo.