### PR TITLE
fix - Fixed note rendering for redirect printing

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/mode.md
+++ b/WindowsServerDocs/administration/windows-commands/mode.md
@@ -64,7 +64,7 @@ mode [<device>] [/status]
 Redirects printer output. You must be a member of the Administrators group to redirect printing.
 
 > [!NOTE]
-To set up your system so that it sends parallel printer output to a serial printer, you must use the **mode** command twice. The first time, you must use **mode** to configure the serial port. The second time, you must use **mode** to redirect parallel printer output to the serial port you specified in the first **mode** command.
+> To set up your system so that it sends parallel printer output to a serial printer, you must use the **mode** command twice. The first time, you must use **mode** to configure the serial port. The second time, you must use **mode** to redirect parallel printer output to the serial port you specified in the first **mode** command.
 
 ### Syntax
 


### PR DESCRIPTION
We've fixed incorrect note rendering for the "Redirect printing" section. This makes reading the note easier than before.

Without the changes, this is what happens:

![Screenshot_20240421_225207_Chrome](https://github.com/MicrosoftDocs/windowsserverdocs/assets/15963131/381cb0bd-0337-43b7-8db4-e6c9babc2414)
