### PR TITLE
fix - Fixed iSCSI TSP broken link

### DIFF
--- a/WindowsServerDocs/storage/iscsi/iscsi-target-server-limits.md
+++ b/WindowsServerDocs/storage/iscsi/iscsi-target-server-limits.md
@@ -426,7 +426,7 @@ This topic provides the supported and tested Microsoft iSCSI Target Server limit
 
 If you want to create volume shadow copies (VSS open-file snapshots) of data on iSCSI virtual disks from an application server, or you want to manage iSCSI virtual disks with an older app (such as the Diskraid command) that requires a Virtual Disk Service (VDS) hardware provider, install the iSCSI Target Storage Provider on the server from which you want to take a snapshot or use a VDS management app.
 
-The iSCSI Target Storage Provider is a role service in Windows Server 2016, Windows Server 2012 R2, and Windows Server 2012; you can also download and install [iSCSI Target Storage Providers (VDS/VSS) for down-level application servers](hhttps://techcommunity.microsoft.com/t5/storage-at-microsoft/iscsi-target-storage-vds-vss-provider/ba-p/424576) on the following operating systems as long as the iSCSI Target Server is running on Windows Server 2012:
+The iSCSI Target Storage Provider is a role service in Windows Server 2016, Windows Server 2012 R2, and Windows Server 2012; you can also download and install [iSCSI Target Storage Providers (VDS/VSS) for down-level application servers](https://techcommunity.microsoft.com/t5/storage-at-microsoft/iscsi-target-storage-vds-vss-provider/ba-p/424576) on the following operating systems as long as the iSCSI Target Server is running on Windows Server 2012:
 
   - Windows Storage Server 2008 R2
 


### PR DESCRIPTION
We've fixed the iSCSI Target Storage Providers (VDS/VSS) download link starting with `hhttps` when it's supposed to be `https`.

Currently, the link that we've fixed in this PR redirects to the same page.

![Screenshot_20240421_230424_Chrome](https://github.com/MicrosoftDocs/windowsserverdocs/assets/15963131/3841a5d4-2c16-4684-a050-6f6036d5875d)
