### PR TITLE
Update upgrading-to-ad-fs-in-windows-server.md

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/deployment/upgrading-to-ad-fs-in-windows-server.md
+++ b/WindowsServerDocs/identity/ad-fs/deployment/upgrading-to-ad-fs-in-windows-server.md
@@ -150,7 +150,7 @@ Now that you've updated your FBL, you need to upgrade Web Application Proxy (WAP
 1. Remove old Web Application Proxy servers, keeping only the new servers configured in the previous steps by running the following PowerShell cmdlet:
 
    ```powershell
-   Set-WebApplicationProxyConfiguration -ConnectedServersName "WAPServerName1, WAPServerName2"
+   Set-WebApplicationProxyConfiguration -ConnectedServersName "WAPServerName1", "WAPServerName2"
    ```
 
 1. To upgrade the ConfigurationVersion of the WAP servers, run the following PowerShell command:


### PR DESCRIPTION
The Upgrade Web Application Proxy section step 5 it shows an example of updating the ConnectedServerNames property however this syntax does not work. Each server needs to be in double quotes or none at all. 


Old value:
Set-WebApplicationProxyConfiguration -ConnectedServersName "WAPServerName1, WAPServerName2"

Correct value: Either one of these examples should work.  Set-WebApplicationProxyConfiguration -ConnectedServersName "WAPServerName1", "WAPServerName2"