### PR TITLE
Fix multiple typos in claim types and values in whats-new-active-directory-federation-services-windows-server.md

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/overview/whats-new-active-directory-federation-services-windows-server.md
+++ b/WindowsServerDocs/identity/ad-fs/overview/whats-new-active-directory-federation-services-windows-server.md
@@ -127,7 +127,7 @@ AD FS already supports triggering extra authentication based on a claim rule pol
 For example, 2012 R2 onwards admin can already write the following rule to prompt extra authentication if the request comes from extranet.
 
 ```powershell
-Set-AdfsAdditionalAuthenticationRule -AdditionalAuthenticationRules 'c:[type == "https://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork", value == "false"] => issue(type = "https://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod", value = "https://schemas.microsoft.com/claims/multipleauthn" );' 
+Set-AdfsAdditionalAuthenticationRule -AdditionalAuthenticationRules 'c:[type == "http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork", value == "false"] => issue(type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod", value = "http://schemas.microsoft.com/claims/multipleauthn" );' 
 ```
 
 In 2019, customers can now use claims rules to decide which other authentication provider to invoke for extra authentication. This feature is useful for two scenarios:
@@ -136,7 +136,7 @@ Customers are transitioning from one other authentication provider to another. T
 
 Customers have a need for a specific extra authentication provider (for example, certificate) for certain applications but different method (Azure AD Multi-Factor Authentication) for other applications.
 
-This configuration could be achieved by issuing the claim `https://schemas.microsoft.com/claims/authnmethodsproviders` from other authentication policies. The value of this claim should be the Name of the authentication provider.
+This configuration could be achieved by issuing the claim `http://schemas.microsoft.com/claims/authnmethodsproviders` from other authentication policies. The value of this claim should be the Name of the authentication provider.
 
 Now in 2019 they can modify the previous claim rule to choose auth providers based on their scenarios.  
 
@@ -144,11 +144,11 @@ Transitioning from one other authentication provider to another:
 You can modify the previously mentioned rule to choose Azure AD Multi-Factor Authentication for users that are in group SID S-1-5-21-608905689-872870963-3921916988-12345. For example you could use this modification for a group you manage by enterprise, which tracks the users that have registered for Azure AD Multi-Factor Authentication. This modification also works for the rest of the users that an admin wants to use certificate auth.
 
 ```powershell
-'c:[type == "https://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork", Value == "false"] => issue(type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod", Value = "https://schemas.microsoft.com/claims/multipleauthn" ); 
+'c:[type == "http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork", Value == "false"] => issue(type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod", Value = "http://schemas.microsoft.com/claims/multipleauthn" ); 
 
- c:[Type == "https://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", Value == "S-1-5-21-608905689-872870963-3921916988-12345"] => issue(Type = "`https://schemas.microsoft.com/claims/authnmethodsproviders`", Value = "AzureMfaAuthentication"); 
+ c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", Value == "S-1-5-21-608905689-872870963-3921916988-12345"] => issue(Type = "http://schemas.microsoft.com/claims/authnmethodsproviders", Value = "AzureMfaAuthentication"); 
 
-not exists([Type == "https://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", Value=="S-1-5-21-608905689-872870963-3921916988-12345"]) => issue(Type = "`https://schemas.microsoft.com/claims/authnmethodsproviders`", Value = "CertificateAuthentication");’ 
+not exists([Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", Value=="S-1-5-21-608905689-872870963-3921916988-12345"]) => issue(Type = "http://schemas.microsoft.com/claims/authnmethodsproviders", Value = "CertificateAuthentication");’ 
 ```
 
 This example shows how to set two different auth providers for two different applications:
@@ -156,7 +156,7 @@ This example shows how to set two different auth providers for two different app
 Set Application A to use Azure AD Multi-Factor Authentication as an extra auth provider:
 
 ```powershell
-Set-AdfsRelyingPartyTrust -TargetName AppA -AdditionalAuthenticationRules 'c:[type == "https://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork", Value == "false"] => issue(type = "https://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod", Value = "https://schemas.microsoft.com/claims/multipleauthn" ); 
+Set-AdfsRelyingPartyTrust -TargetName AppA -AdditionalAuthenticationRules 'c:[type == "http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork", Value == "false"] => issue(type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod", Value = "http://schemas.microsoft.com/claims/multipleauthn" ); 
 
 c:[] => issue(Type = "http://schemas.microsoft.com/claims/authnmethodsproviders", Value = "AzureMfaAuthentication");' 
 ```
@@ -169,11 +169,11 @@ Set-AdfsRelyingPartyTrust -TargetName AppB -AdditionalAuthenticationRules 'c:[ty
 c:[] => issue(Type = "http://schemas.microsoft.com/claims/authnmethodsproviders", Value = "CertificateAuthentication");' 
  ```
 
-Admins can also make rules to allow more than one extra authentication provider. In this case AD FS shows the issued auth methods providers, and a user can choose any of them. To allow multiple extra authentication providers, they should issue multiple claims `https://schemas.microsoft.com/claims/authnmethodsproviders`.
+Admins can also make rules to allow more than one extra authentication provider. In this case AD FS shows the issued auth methods providers, and a user can choose any of them. To allow multiple extra authentication providers, they should issue multiple claims `http://schemas.microsoft.com/claims/authnmethodsproviders`.
 
 If the claim evaluation returns none of the auth providers, AD FS falls back to show all the extra auth providers configured by the admin on AD FS. The user needs to then select the appropriate auth provider.
 
-To get all the other authentication providers allowed, admin can use the cmdlet (Get-AdfsGlobalAuthenticationPolicy).AdditionalAuthenticationProvider. The value of the `https://schemas.microsoft.com/claims/authnmethodsproviders` claim should be one of the provider names returned by previously mentioned cmdlet.
+To get all the other authentication providers allowed, admin can use the cmdlet (Get-AdfsGlobalAuthenticationPolicy).AdditionalAuthenticationProvider. The value of the `http://schemas.microsoft.com/claims/authnmethodsproviders` claim should be one of the provider names returned by previously mentioned cmdlet.
 
 There's no support to trigger a particular extra auth provider if the RP is using [Access Control Policies in AD FS Windows Server 2016 | Microsoft Docs](../operations/access-control-policies-in-ad-fs.md). When you move an application away from Access control policy, AD FS copies the corresponding policy from Access Control Policy to AdditionalAuthenticationRules and IssuanceAuthorizationRules. So if an admin wants to use a particular auth provider, they can move away from not using access control policy and then modify AdditionalAuthenticationRules to trigger a specific auth provider.
 


### PR DESCRIPTION
All claim types and values within "How to choose extra auth providers in 2019" must start with "http://" instead of "https://".

This was requested before at https://github.com/MicrosoftDocs/windowsserverdocs/pull/6920 (closed due to possibility of being out of date - it's still an issue, though).