### PR TITLE
Update detect-enable-and-disable-smbv1-v2-v3.md

### DIFF
--- a/WindowsServerDocs/storage/file-server/Troubleshoot/detect-enable-and-disable-smbv1-v2-v3.md
+++ b/WindowsServerDocs/storage/file-server/Troubleshoot/detect-enable-and-disable-smbv1-v2-v3.md
@@ -249,7 +249,7 @@ Here is how to detect status, enable, and disable SMB protocols on the SMB Clien
 - Detect
 
   ```cmd
-  sc.exe qc lanmanworkstation
+  sc.exe qc mrxsmb10
   ```
 
 - Disable:
@@ -273,7 +273,7 @@ For more information, see [Server storage at Microsoft](https://techcommunity.mi
 - Detect:
 
   ```cmd
-  sc.exe qc lanmanworkstation
+  sc.exe qc mrxsmb20
   ```
 
 - Disable:


### PR DESCRIPTION
Article incorrectly stated that both SMBv1 and SMBv2 status could be determined by reading LanmanWorkstation service entry.  It will show one of the dependencies for LanmanWorkstation service being mrxsmb20 however that does not tell you if that is enabled or not.