### PR TITLE
Include missing default GPO setting values in Windows-Time-Service-Tools-and-Settings.md

### DIFF
--- a/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
+++ b/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
@@ -264,6 +264,7 @@ Below you'll find the default values for the **Global Configuration Settings** o
 |ChainDisable|0|
 |ChainEntryTimeout|16|
 |ChainLoggingRate|30|
+|ChainMaxEntries|128|
 |ChainMaxHostEntries|4|
 |ClockAdjustmentAuditLimit|800|
 |ClockHoldoverPeriod|7800|

--- a/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
+++ b/WindowsServerDocs/networking/windows-time-service/Windows-Time-Service-Tools-and-Settings.md
@@ -261,6 +261,12 @@ Below you'll find the default values for the **Global Configuration Settings** o
 |Group Policy setting|Default value|
 | --- | --- |
 |AnnounceFlags|10|
+|ChainDisable|0|
+|ChainEntryTimeout|16|
+|ChainLoggingRate|30|
+|ChainMaxHostEntries|4|
+|ClockAdjustmentAuditLimit|800|
+|ClockHoldoverPeriod|7800|
 |EventLogFlags|2|
 |FrequencyCorrectRate|4|
 |HoldPeriod|5|
@@ -271,10 +277,12 @@ Below you'll find the default values for the **Global Configuration Settings** o
 |MaxPollInterval|10|
 |MaxPosPhaseCorrection|172,800 (48 hours)|
 |MinPollInterval|6|
-|PhaseCorrectRate|7|
+|PhaseCorrectRate|1|
 |PollAdjustFactor|5|
+|RequireSecureTimeSyncRequests|0|
 |SpikeWatchPeriod|900|
 |UpdateInterval|100 (1 second)|
+|UtilizeSslTimeData|1|
 
 ### GPO settings for NTP Client
 


### PR DESCRIPTION
Expand the GPO setting list on this doc page to include missing entries. 

For the full list, open "Local Group Policy Editor" on your machine locally, navigate to "Computer Configuration" -> "Administrative Templates" -> "System" -> "Windows Time Service" and click on "Global Configuration Settings" in the right-side pane. This opens a list of GPO settings in a new page. Select "Enabled" to have the default values for each setting to be populated on this page. 

***Important*** - Click "Cancel" once you are done looking through the settings, else you may end up applying them on your machine locally.