### PR TITLE
Adding Win11 24H2 as a client OS

### DIFF
--- a/WindowsServerDocs/identity/laps/laps-management-policy-settings.md
+++ b/WindowsServerDocs/identity/laps/laps-management-policy-settings.md
@@ -270,7 +270,7 @@ If not specified, this setting defaults to *3*.
 > From a security perspective, a malicious user who acquires administrative privileges on a device using a valid Windows LAPS password does have the ultimate ability to prevent or circumvent these mechanisms.
 
 > [!IMPORTANT]
-> `PostAuthenticationActions` value 11 is supported in Windows Server 2025 and later.
+> `PostAuthenticationActions` value 11 is only supported in Windows 11 24H2, Windows Server 2025 and later releases.
 
 ### AutomaticAccountManagementEnabled
 


### PR DESCRIPTION
Added Win1124H2 as a client OS release alongside Windows Server 2025