### PR TITLE
Adding Win11 24H2 alongside Sever 2025

### DIFF
--- a/WindowsServerDocs/identity/laps/laps-concepts-account-management-modes.md
+++ b/WindowsServerDocs/identity/laps/laps-concepts-account-management-modes.md
@@ -12,7 +12,7 @@ ms.topic: conceptual
 Learn about the different account management modes supported by Windows Local Administrator Password Solution (Windows LAPS).
 
 > [!IMPORTANT]
-> The Windows LAPS automatic account management feature is supported in Windows Server 2025 and later.
+> The Windows LAPS automatic account management feature is only supported in Windows 11 24H2, Windows Server 2025 and later releases.
 
 ## Overview
 


### PR DESCRIPTION
For new features, adding the client OS (Win 11 24H2) alongside Windows Server 2025