### PR TITLE
Link updates for claim rule operation documentation

### DIFF
--- a/WindowsServerDocs/identity/ad-fs/technical-reference/When-to-Use-a-Send-Group-Membership-as-a-Claim-Rule.md
+++ b/WindowsServerDocs/identity/ad-fs/technical-reference/When-to-Use-a-Send-Group-Membership-as-a-Claim-Rule.md
@@ -54,7 +54,7 @@ You create this rule using either the claim rule language or by using the Send L
 
 -   Specify an outgoing claim value
 
-For more information about how to create this rule, see [Create a Rule to Send Group Membership as a Claim](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/ee913569(v=ws.11)).
+For more information about how to create this rule, see [Create a Rule to Send Group Membership as a Claim](../operations/Create-a-Rule-to-Send-Group-Membership-as-a-Claim.md).
 
 ## Using the claim rule language
 If you want to issue claims based on an incoming SID other than a group SID, use the Transform an Incoming Claim rule template. If the administrator wants to retrieve the names for all the groups that the user is a member of, use the Send LDAP Attributes as Claims rule template instead with the **tokenGroups** attribute.
@@ -68,5 +68,5 @@ c:[Type == "https://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
 ```
 
 ## Additional references
-[Create a Rule to Send LDAP Attributes as Claims](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dd807115(v=ws.11))
+[Create a Rule to Send LDAP Attributes as Claims](../operations/Create-a-Rule-to-Send-LDAP-Attributes-as-Claims.md)
 


### PR DESCRIPTION
Two links currently point to documentation no longer supported.
Updates point to current documentation repo.