### PR TITLE
Fix Audit-Policy-Recommendations.md for workstations

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/plan/security-best-practices/Audit-Policy-Recommendations.md
+++ b/WindowsServerDocs/identity/ad-ds/plan/security-best-practices/Audit-Policy-Recommendations.md
@@ -58,15 +58,15 @@ These tables contain the Windows default setting, the baseline recommendations, 
 | --- | --- | --- | --- |
 | **Account Logon** |  |  |  |
 | Audit Credential Validation | `No | No` | `Yes | No` | `Yes | Yes` |
-| Audit Kerberos Authentication Service |  |  | `Yes | Yes` |
-| Audit Kerberos Service Ticket Operations |  |  | `Yes | Yes` |
-| Audit Other Account Logon Events |  |  | `Yes | Yes` |
+| Audit Kerberos Authentication Service |  |  |  |
+| Audit Kerberos Service Ticket Operations |  |  |  |
+| Audit Other Account Logon Events |  |  |  |
 
 | Audit Policy Category or Subcategory | Windows Default<p>`Success | Failure` | Baseline Recommendation<p>`Success | Failure` | Stronger Recommendation<p>`Success | Failure` |
 | --- | --- | --- | --- |
 | **Account Management** |  |  |  |
 | Audit Application Group Management |  |  |  |
-| Audit Computer Account Management |  | `Yes | No` | `Yes | Yes` |
+| Audit Computer Account Management |  |  |  |
 | Audit Distribution Group Management |  |  |  |
 | Audit Other Account Management Events |  | `Yes | No` | `Yes | Yes` |
 | Audit Security Group Management |  | `Yes | No` | `Yes | Yes` |


### PR DESCRIPTION
Some recommendations for win7/8/10 are invalid:

- [Audit Kerberos Authentication Service](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/audit-kerberos-authentication-service), [Audit Kerberos Service Ticket Operations](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/audit-kerberos-service-ticket-operations), [Audit Computer Account Management](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/audit-computer-account-management) make sense only on DC
- [Audit Other Account Logon Events](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/audit-other-account-logon-events) have no events in official docs as of 2021 therefore is no arguments to enable this audit policy right now.