### PR TITLE
Changes for RSA default to ED25512

### DIFF
--- a/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
+++ b/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
@@ -57,7 +57,7 @@ Since there's no user associated with the sshd service, the host keys are stored
 
 ## User key generation
 
-To use key-based authentication, you first need to generate public/private key pairs for your client. ssh-keygen.exe is used to generate key files and the algorithms DSA, RSA, ECDSA, or Ed25519 can be specified. If no algorithm is specified, RSA is used. A strong algorithm and key length should be used, such as ECDSA in this example.
+To use key-based authentication, you first need to generate public/private key pairs for your client. ssh-keygen.exe is used to generate key files and the algorithms DSA, RSA, ECDSA, or Ed25519 can be specified. If no algorithm is specified, Ed25519 is used. A strong algorithm and key length should be used, such as ECDSA in this example.
 
 To generate key files using the ECDSA algorithm, run the following command from a PowerShell or cmd prompt on your client:
 

--- a/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
+++ b/WindowsServerDocs/administration/OpenSSH/OpenSSH_KeyManagement.md
@@ -59,6 +59,9 @@ Since there's no user associated with the sshd service, the host keys are stored
 
 To use key-based authentication, you first need to generate public/private key pairs for your client. ssh-keygen.exe is used to generate key files and the algorithms DSA, RSA, ECDSA, or Ed25519 can be specified. If no algorithm is specified, Ed25519 is used. A strong algorithm and key length should be used, such as ECDSA in this example.
 
+> [!NOTE]
+> RSA is still supported in versions 9.5+ but is not recommended to use. 
+
 To generate key files using the ECDSA algorithm, run the following command from a PowerShell or cmd prompt on your client:
 
 ```powershell


### PR DESCRIPTION
Changing docs to ED25519 as default if no keygen is specified and mentioning that RSA is still supported but not recommended