### PR TITLE
Update active-directory-functional-levels.md

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/active-directory-functional-levels.md
+++ b/WindowsServerDocs/identity/ad-ds/active-directory-functional-levels.md
@@ -61,11 +61,14 @@ All default Active Directory features in earlier domain functional levels plus t
 
 You can use the following operating systems as domain controllers (DCs) with the Windows Server 2012 R2 forest and domain function level.
 
-- Windows Server 2025
 - Windows Server 2022
 - Windows Server 2019
 - Windows Server 2016
 - Windows Server 2012 R2
+
+> [!NOTE]
+> Windows Server 2025 DCs can only be introduced to forest of functional level Windows 2016 or higher. 
+  
 
 ### Windows Server 2012 R2 forest and domain functional level features
 


### PR DESCRIPTION

![ADDS2025](https://github.com/user-attachments/assets/4ea397ca-2997-4dc0-9f94-b404f6f0f7b8)
I have tested this, and Windows Server 2025 DCs cannot be introduced to a domain/forest of functional level 2012 R2, an error will arise stating that they can only be introduced to forest of functional level Windows 2016 or higher. 

So current guidance around 2025 supported FFL/DFL is incorrect and I have modified the statement and called it out with a note.