### PR TITLE
Update upgrade-overview.md

### DIFF
--- a/WindowsServerDocs/get-started/upgrade-overview.md
+++ b/WindowsServerDocs/get-started/upgrade-overview.md
@@ -66,7 +66,6 @@ In this table you can see the supported upgrade paths, based on the version you'
 | Windows   Server 2016 | - | - | Yes | Yes | Yes |
 | Windows   Server 2019 | - | - | - | Yes | Yes |
 | Windows   Server 2022 | - | - | - | - | Yes |
-| Windows   Server 2025 | - | - | - | - | Yes |
 
 You can also upgrade from an evaluation version of the operating system to a retail version, from an
 older retail version to a newer version, or, in some cases, from a volume-licensed edition of the


### PR DESCRIPTION
Removed Windows Server 2025 from the "upgrade from" row in the supported "upgrade from and to" table.

It is misleading to state that an in-place upgrade path from Windows Server 2025 to Windows Server 2025 is supported.
Regarding upgrades from Windows Server 2025, it is necessary to indicate whether future versions will be supported, and I think it is not necessary to list Windows Server 2025, which is the latest version at this time, as the upgrade from.