### PR TITLE
Update windows-server-pay-as-you-go.md

### DIFF
--- a/WindowsServerDocs/get-started/windows-server-pay-as-you-go.md
+++ b/WindowsServerDocs/get-started/windows-server-pay-as-you-go.md
@@ -156,12 +156,12 @@ To disable Windows Server Pay-as-you-go, follow these steps:
    $licenseProfile   = Set-AzResource -ResourceId $licenseProfileId -Properties $property -ApiVersion $apiVersion
    ```
 
+---
+
 > [!NOTE]
 > You have the ability to disable Windows Server Pay-as-you-go whenever you desire. It's important to remember to disable it when you're no longer using Pay-as-you-go, as failing to do so could result in continued charges for the Windows Server license even if the device is shut down, disconnected, or unavailable.
 >
 > After disabling Windows Server Pay-as-you-go, you'll need a different type of license if you want to continue using your device. You can install a traditional perpetual license by entering a product key.
-
----
 
 ## See also
 


### PR DESCRIPTION
Move the "---" delimiter above the NOTE.

In the current version, the NOTE about disabling PAYG is displayed inside the "Azure PowerShell" tab and is not visible if selected the "Azure Portal" tab.

This NOTE should always be displayed outside of the tab (Portal or PowerShell) as it is not dependent on any particular method of operation.