### PR TITLE
Replace nonbreaking spaces with normal spaces

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/bitsadmin-setproxysettings.md
+++ b/WindowsServerDocs/administration/windows-commands/bitsadmin-setproxysettings.md
@@ -37,14 +37,14 @@ bitsadmin /setproxysettings myDownloadJob PRECONFIG
 ```
 
 ```
-bitsadmin /setproxysettings myDownloadJob NO_PROXY
+bitsadmin /setproxysettings myDownloadJob NO_PROXY
 ```
 ```
-bitsadmin /setproxysettings myDownloadJob OVERRIDE proxy1:80
+bitsadmin /setproxysettings myDownloadJob OVERRIDE proxy1:80
 ```
 
 ```
-bitsadmin /setproxysettings myDownloadJob OVERRIDE proxy1,proxy2,proxy3 NULL
+bitsadmin /setproxysettings myDownloadJob OVERRIDE proxy1,proxy2,proxy3 NULL
 ```
 
 ## Related links


### PR DESCRIPTION
Using a command with nonbreaking spaces leads to an error