### PR TITLE
Update ad-forest-recovery-perform-initial-recovery.md

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/manage/forest-recovery-guide/ad-forest-recovery-perform-initial-recovery.md
+++ b/WindowsServerDocs/identity/ad-ds/manage/forest-recovery-guide/ad-forest-recovery-perform-initial-recovery.md
@@ -52,7 +52,7 @@ Then perform the following steps. Procedures for performing certain steps are in
     nonauthoritative restore of AD DS and an authoritative restore of SYSVOL.
     The restore operation must be completed by using an Active Directory-aware
     backup and restore application, such as Windows Server Backup (recommended).
-    If Hyper-Vistor Generation ID is supported on the host, then you can also do
+    If Hypervisor Generation ID is supported on the host, then you can also do
     the nonauthoritative restore using a VM snapshot.
 
     - An authoritative restore of SYSVOL is required on the first recovered


### PR DESCRIPTION
I am 99% sure that the correct term is "Hypervisor Generation ID", not "Hyper-Vistor".

Reasoning:
Hypervisor Generation ID is a well-documented feature introduced in Windows Server 2012 for virtualized domain controllers. It helps ensure safe restoration using snapshots by detecting changes in the virtual machine's generation ID. "Hyper-Vistor" does not exist in Microsoft or virtualization terminology; it is almost certainly a typo.