### PR TITLE
Update delegated-managed-service-accounts-set-up-dmsa.md

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/manage/delegated-managed-service-accounts/delegated-managed-service-accounts-set-up-dmsa.md
+++ b/WindowsServerDocs/identity/ad-ds/manage/delegated-managed-service-accounts/delegated-managed-service-accounts-set-up-dmsa.md
@@ -48,34 +48,12 @@ The following instructions allow users to create a new dMSA without migrating fr
    New-ADServiceAccount @params
    ```
 
-1. Grant permission to the specific device to retrieve the password for the service account in AD:
+2. Grant permission to the specific device to retrieve the password for the service account in AD:
 
    ```powershell
    $params = @{
     Identity = "DMSA Name"
     PrincipalsAllowedToRetrieveManagedPassword = "Machine$"
-   }
-   Set-ADServiceAccount @params
-   ```
-
-1. The **msDS-DelegatedMSAState** property value for the dMSA must be set to **3**. To view the current property value, run:
-
-   ```powershell
-   $params = @{
-    Identity = "dMSAsnmp"
-    Properties = "msDS-DelegatedMSAState"
-   }
-   Get-ADServiceAccount @params
-   ```  
-
-   To set this value to **3**, run:
-
-   ```powershell
-   $params = @{
-    Identity = "dMSAsnmp"
-    Properties = @{
-     "msDS-DelegatedMSAState" = 3
-    }
    }
    Set-ADServiceAccount @params
    ```


### PR DESCRIPTION
when the 2 commands in step 3 are done, the start of the migration fails. The state should be kept to 0 which is assigned during the creation of the dMSA. Then the start works

when set to 3 as stated the following error occurs in the Directory Service Event Log

=============================
A Delegated Managed Service Account Migration Operation Failed. 
 
Operation:
START-MIGRATION 
RequestedBy:
IAMTEC\ADM.JORGE 
ErrorCode:
5 
ErrorMessage:
00002035: SvcErr: DSID-0359073C, problem 5005 (UNABLE_TO_PROCEED), data 0
 
ServiceAccount:
CN=Service R1 Account ADLDS 1,OU=SvcAccounts,OU=Org-ITMgmt,DC=IAMTEC,DC=NET  ServiceAccountOriginalState:
0 
 
DMSAAccount:
CN=dMSA_R1_ADLDS1,OU=dMSA,OU=Org-ITMgmt,DC=IAMTEC,DC=NET  DMSAAccountOriginalState:
3 
=============================