### PR TITLE
Update Defrag command with the "/#" parameter

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/defrag.md
+++ b/WindowsServerDocs/administration/windows-commands/defrag.md
@@ -102,7 +102,7 @@ To defragment all volumes with normal priority and provide verbose output, type:
 defrag /c /h /v
 ```
 
-To defragment all volumes with normal priority and provide verbose output, type:
+To optimize storage tiers (/g) on the volume, returning a Post Defragmentation Report and a Storage Tier Optimization Report. Include /h to process the job at normal priority instead of low priority (the default), type:
 
 ```
 defrag <driveletter>: /g /h /#

--- a/WindowsServerDocs/administration/windows-commands/defrag.md
+++ b/WindowsServerDocs/administration/windows-commands/defrag.md
@@ -45,6 +45,7 @@ defrag <volume> [<parameters>]
 | /u | Prints the progress of the operation on the screen. |
 | /v | Prints verbose output containing the fragmentation statistics. |
 | /x | Performs free space consolidation on the specified volumes. |
+| /# | When used in conjunction with '/g', returns a Post Defragmentation Report and a Storage Tier Optimization Report |
 | /? | Displays the help information. |
 
 #### Remarks
@@ -100,6 +101,13 @@ To defragment all volumes with normal priority and provide verbose output, type:
 ```
 defrag /c /h /v
 ```
+
+To defragment all volumes with normal priority and provide verbose output, type:
+
+```
+defrag <driveletter>: /g /h /#
+```
+Reference:  https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn789160%28v=ws.11%29#to-optimize-storage-tiers-using-defragexe
 
 ## Scheduled task
 


### PR DESCRIPTION
The "/#" is missing from this documentation.  Reference here https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn789160%28v=ws.11%29#to-optimize-storage-tiers-using-defragexe   

defrag <driveletter>: /g /h /#

This command optimizes storage tiers (/g) on the volume, returning a Post Defragmentation Report and a Storage Tier Optimization Report. Include /h to process the job at normal priority instead of low priority (the default).