### PR TITLE
Wrong image was linked

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/manage/forest-recovery-guide/ad-forest-recovery-add-gc.md
+++ b/WindowsServerDocs/identity/ad-ds/manage/forest-recovery-guide/ad-forest-recovery-add-gc.md
@@ -21,7 +21,7 @@ Use the following procedure to add the global catalog to a DC.
 1. Right-click **NTDS Settings**, and then select **Properties**.
 1. Select the **Global Catalog** check box.
 
-:::image type="content" source="media/adsi1.png" alt-text="Add GC":::
+:::image type="content" source="media/removegc1.png" alt-text="Add GC":::
 
 ## Add the global catalog using repadmin
 


### PR DESCRIPTION
As the ADSI picture is not matching the procedure, I suggest using an existing picture showing the relevant dialog box.
This is sort of workaround, not the final fix.
I hope it will help other admins following the forest recovery guide in stressful scenarios.