### PR TITLE
Update configure-virtual-local-area-networks-for-hyper-v.md

### DIFF
--- a/WindowsServerDocs/virtualization/hyper-v/deploy/configure-virtual-local-area-networks-for-hyper-v.md
+++ b/WindowsServerDocs/virtualization/hyper-v/deploy/configure-virtual-local-area-networks-for-hyper-v.md
@@ -28,7 +28,7 @@ On the host, you configure the virtual switch to allow network traffic on the ph
 
 1. Select **OK**.
 
-All traffic that goes through the physical network adapter connected to the virtual switch is tagged with the VLAN ID you set.
+All traffic that goes through the physical network adapter connected to the virtual switch is tagged with the VLAN ID you set on the virtual switch and virtual machines.
 
 ## To allow a virtual machine to use a VLAN
 


### PR DESCRIPTION
Our customer pointed out that the current description makes it seem as if the VLAN ID set on the virtual switch is applied to all traffic passing through the physical NIC. In reality, when different VLAN IDs are set on the virtual switch and the virtual NIC on the virtual machine, each VLAN ID is applied accordingly. We have considered a revision to make this point clearer, so please review it.