### PR TITLE
rundll32: fix documentation and add more detail

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/rundll32.md
+++ b/WindowsServerDocs/administration/windows-commands/rundll32.md
@@ -11,26 +11,38 @@ ms.date: 10/16/2017
 
 # rundll32
 
-Loads and runs 32-bit dynamic-link libraries (DLLs). There are no configurable settings for Rundll32. Help information is provided for a specific DLL you run with the **rundll32** command.
-
-You must run the **rundll32** command from an elevated command prompt. To open an elevated command prompt, click **Start**, right-click **Command Prompt**, and then click **Run as administrator**.
+Loads and runs procedures from dynamic-link libraries (DLLs) conforming to a specific interface (see remarks).
 
 ## Syntax
 
 ```
-rundll32 <DLLname>
+rundll32 <dllName>,<procedureName> [<arguments>[ ...]]
 ```
 
 ### Parameters
 
 | Parameter | Description |
 |--|--|
-| [Rundll32 printui.dll,PrintUIEntry](rundll32-printui.md) | Displays the printer user interface. |
+| `<dllName>` | The DLL from which to run the procedure from. |
+| `<procedureName>` | The name of the procedure to run. |
+| `<arguments>` | Parameters to pass into the procedure `lpCmdLine`. |
+
+### Example
+
+```
+rundll32 devmgr,DeviceProperties_RunDLL /DeviceID root\system\0000
+```
 
 ## Remarks
 
-Rundll32 can only call functions from a DLL explicitly written to be called by Rundll32.
+Rundll32 assumes the procedure has an interface conforming with the [WinMain entry point](windows/win32/learnwin32/winmain--the-application-entry-point).
+
+The ```,``` separator between the DLL name and the procedure can alternatively be a space (" ").
+
+The ```procedureName``` can also alternatively be an ordinal, e.g. (```#2```) for ordinal 2.
 
 ## Related links
 
 - [Command-Line Syntax Key](command-line-syntax-key.md)
+- [Rundll32 printui.dll,PrintUIEntry](rundll32-printui.md)
+- [DeviceProperties_RunDLL](/windows-hardware/drivers/install/deviceproperties-rundll-function-prototype)


### PR DESCRIPTION
Problem: Current rundll32 documentation contains incorrect information and lacks information about the syntax.

Example: Currently, the doc claims that rundll32 loads only 32bit DLLs which is untrue, I have tested with a 64bit Windows 10 machine and when rundll32 is ran regularly is loads 64bit DLLs and when it is ran through SysWow64 like so for example ```C:\Windows\SysWow64\rundll32 kernel32,Beep``` it of course uses 32bit DLLs

Here is a screenshot from procexp that shows it uses the 64bit DLL:
![image](https://github.com/user-attachments/assets/475d90e4-dfab-4397-8c83-11fd17983075)

Solution:
- Remove 32bit only claim
- Remove claim that it requires admin rights (not needed necessarily)
- Add full syntax information and additional remarks