### PR TITLE
Update delegated-managed-service-accounts-set-up-dmsa.md

### DIFF
--- a/WindowsServerDocs/identity/ad-ds/manage/delegated-managed-service-accounts/delegated-managed-service-accounts-set-up-dmsa.md
+++ b/WindowsServerDocs/identity/ad-ds/manage/delegated-managed-service-accounts/delegated-managed-service-accounts-set-up-dmsa.md
@@ -73,7 +73,7 @@ The following instructions allow users to create a new dMSA without migrating fr
    ```powershell
    $params = @{
     Identity = "dMSAsnmp"
-    Properties = @{
+    Replace = @{
      "msDS-DelegatedMSAState" = 3
     }
    }


### PR DESCRIPTION
The previous snippet with the property, "Properties", cannot be run in PowerShell. 

It results in the following error: "Set-ADServiceAccount : A parameter cannot be found that matches parameter name 'Properties'."

The new change replaces "Properties" with "Replace". This allows you to run the snippet and update the "msDS-DelegatedMSAState" value from 0 to 3.

Server used: Windows Server 2025 24H2 
OS Build: 26100:1742