### PR TITLE
Typo: tasklist.md /svc

### DIFF
--- a/WindowsServerDocs/administration/windows-commands/tasklist.md
+++ b/WindowsServerDocs/administration/windows-commands/tasklist.md
@@ -30,7 +30,7 @@ tasklist [/s <computer> [/u [<domain>\]<username> [/p <password>]]] [{/m <module
 | /u `<domain>\<username>` | Runs the command with the account permissions of the user who is specified by `<username>` or by `<domain>\<username>`. The **/u** parameter can be specified only if **/s** is also specified. The default is the permissions of the user who is currently logged on to the computer that is issuing the command. |
 | /p `<password>` | Specifies the password of the user account that is specified in the **/u** parameter. |
 | /m `<module>` | Lists all tasks with DLL modules loaded that match the given pattern name. If the module name is not specified, this option displays all modules loaded by each task. |
-| svc | Lists all the service information for each process without truncation. Valid when the **/fo** parameter is set to **table**. |
+| /svc | Lists all the service information for each process without truncation. Valid when the **/fo** parameter is set to **table**. |
 | /v | Displays verbose task information in the output. For complete verbose output without truncation, use **/v** and **/svc** together. |
 | /fo `{table | list | csv}` | Specifies the format to use for the output. Valid values are **table**, **list**, and **csv**. The default format for output is **table**. |
 | /nh | Suppresses column headers in the output. Valid when the **/fo** parameter is set to **table** or **csv**. |


### PR DESCRIPTION
Typo in parameters for `/svc` parameter