### PR TITLE
Removed "Set-SmbServerConfiguration -EnableInsecureGuestLogons" command

### DIFF
--- a/WindowsServerDocs/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3.md
+++ b/WindowsServerDocs/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3.md
@@ -85,10 +85,6 @@ Run the following command through an elevated PowerShell prompt:
 Set-SmbClientConfiguration -EnableInsecureGuestLogons $true -Force
 ```
 
-```powershell
-Set-SmbServerConfiguration -EnableInsecureGuestLogons $true -Force
-```
-
 ---
 
 Both SMB signing, and SMB encryption policies must be disabled in Group Policy in order to use guest logons. Doing so can potentially compromise the security of the client and leave users open to credential theft and relay attacks.


### PR DESCRIPTION
`EnableInsecureGuestLogons` is not a parameter of `Set-SmbServerConfiguration` (only of `Set-SmbClientConfiguration`), as can  be seen [here ](https://learn.microsoft.com/en-us/powershell/module/smbshare/set-smbserverconfiguration?view=windowsserver2025-ps)