### PR TITLE
Fix error in powershell script in authority-information-access-retrieval.md

### DIFF
--- a/WindowsServerDocs/security/authority-information-access-retrieval.md
+++ b/WindowsServerDocs/security/authority-information-access-retrieval.md
@@ -103,7 +103,7 @@ $propertyName = "Options"
 try {
     $regCheck = (Get-ItemProperty -Path $registryPath -Name $propertyName -ErrorAction Stop).$propertyName
  
-    switch ($value) {
+    switch ($regCheck) {
         0 { "AIA is Enabled" }
         2 { "AIA is Disabled" }
         default { "Unexpected value: $regCheck" }


### PR DESCRIPTION
The powershell snippet in this document used the wrong variable name in the switch statement (`$value`), making it never work propertly. Fixed by changing it to `$regCheck`.

Borked version has incorrect output because, in a clean session, `$value` is just `$null`, hitting the `default` case, but outputs "0" to the console, which is further confusing. If `$value` happens to already exist from earlier in the session, any one of the three cases of the switch statement or an exception are possible, depending on what it is, which is obviously also goodn't.